### PR TITLE
[1/8] 관측 정규화 변환 함수의 이름을 명확히 변경

### DIFF
--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.returns import discount_with_terminated
 
 
@@ -61,8 +61,8 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(
             params,
             key,

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -28,7 +28,7 @@ from jax_baselines.core.eval import (
 from jax_baselines.core.rollout_stats import EpisodeTracker
 from jax_baselines.core.seeding import key_gen, set_global_seeds
 from jax_baselines.core.training_session import TrainingSession
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
@@ -145,13 +145,13 @@ class Actor_Critic_Policy_Gradient_Family(object):
 
     def _get_actions_discrete(self, params, obses, key=None) -> jnp.ndarray:
         prob = jax.nn.softmax(
-            self.actor(params, key, self.preproc(params, key, convert_jax(obses))),
+            self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses))),
             axis=1,
         )
         return prob
 
     def _get_actions_continuous(self, params, obses, key=None) -> jnp.ndarray:
-        mu, std = self.actor(params, key, self.preproc(params, key, convert_jax(obses)))
+        mu, std = self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
         return mu, jnp.exp(std)
 
     def action_discrete(self, obs):

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.IMPALA.base_class import IMPALA_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 
 
 class IMPALA(IMPALA_Family):
@@ -84,8 +84,8 @@ class IMPALA(IMPALA_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
         next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -4,7 +4,7 @@ import numpy as np
 import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.returns import (
     get_gaes,
     normalize_advantage,
@@ -90,8 +90,8 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
         next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/APE_X/dpg_base_class.py
+++ b/jax_baselines/APE_X/dpg_base_class.py
@@ -20,7 +20,7 @@ from jax_baselines.core.replay_protocol import (
 )
 from jax_baselines.core.runtime_adapters import make_progress
 from jax_baselines.core.seeding import key_gen, set_global_seeds
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
@@ -152,7 +152,7 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
         pass
 
     def _get_actions(self, params, obses, key=None):
-        return self.actor(params, key, self.preproc(params, key, convert_jax(obses)))
+        return self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
 
     def description(self):
         return "buffer len : {} loss : {:.3f} |".format(

--- a/jax_baselines/BBF/bbf.py
+++ b/jax_baselines/BBF/bbf.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 import optax
 
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
@@ -124,7 +124,7 @@ class BBF(SPR):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
+        obses = convert_normalized_obs(obses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         obses = jax.tree.map(

--- a/jax_baselines/BBF/hl_gauss_bbf.py
+++ b/jax_baselines/BBF/hl_gauss_bbf.py
@@ -9,7 +9,7 @@ from jax_baselines.math.distributional import (
     MunchausenSpec,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
@@ -87,7 +87,7 @@ class HL_GAUSS_BBF(BBF):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.argmax(
-            self.hl_gauss.to_scalar(self.get_q(params, convert_jax(obses), key)),
+            self.hl_gauss.to_scalar(self.get_q(params, convert_normalized_obs(obses), key)),
             axis=1,
             keepdims=True,
         )
@@ -114,7 +114,7 @@ class HL_GAUSS_BBF(BBF):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
+        obses = convert_normalized_obs(obses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         obses = jax.tree.map(

--- a/jax_baselines/C51/apex_c51.py
+++ b/jax_baselines/C51/apex_c51.py
@@ -14,7 +14,7 @@ from jax_baselines.math.distributional import (
     categorical_projection,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import hard_update
 
 
@@ -153,14 +153,14 @@ class APE_X_C51(Ape_X_Family):
                         model(
                             params,
                             key,
-                            preproc(params, key, convert_jax(obses)),
+                            preproc(params, key, convert_normalized_obs(obses)),
                         ),
                         jnp.expand_dims(actions.astype(jnp.int32), axis=2),
                         axis=1,
                     )
                 )
 
-                next_q = model(params, key, preproc(params, key, convert_jax(nxtobses)))
+                next_q = model(params, key, preproc(params, key, convert_normalized_obs(nxtobses)))
                 next_actions = jnp.expand_dims(
                     jnp.argmax(jnp.sum(next_q * categorial_bar, axis=2), axis=1),
                     axis=(1, 2),
@@ -183,7 +183,7 @@ class APE_X_C51(Ape_X_Family):
 
             def actor(model, preproc, params, obses, key):
                 q_values = jnp.sum(
-                    model(params, key, preproc(params, key, convert_jax(obses))) * categorial_bar,
+                    model(params, key, preproc(params, key, convert_normalized_obs(obses))) * categorial_bar,
                     axis=2,
                 )
                 return jnp.argmax(q_values, axis=1)
@@ -229,8 +229,8 @@ class APE_X_C51(Ape_X_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         batch_idxes = jnp.arange(self.batch_size).reshape(-1, self.mini_batch_size)

--- a/jax_baselines/C51/c51.py
+++ b/jax_baselines/C51/c51.py
@@ -10,7 +10,7 @@ from jax_baselines.math.distributional import (
     MunchausenSpec,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import hard_update
 
 
@@ -73,7 +73,7 @@ class C51(Q_Network_Family):
         return jnp.expand_dims(
             jnp.argmax(
                 jnp.sum(
-                    self.get_q(params, convert_jax(obses), key) * self._categorial_bar,
+                    self.get_q(params, convert_normalized_obs(obses), key) * self._categorial_bar,
                     axis=2,
                 ),
                 axis=1,
@@ -96,8 +96,8 @@ class C51(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         target_distribution = self._target(

--- a/jax_baselines/C51/hl_gauss_c51.py
+++ b/jax_baselines/C51/hl_gauss_c51.py
@@ -11,7 +11,7 @@ from jax_baselines.math.distributional import (
     MunchausenSpec,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import hard_update
 
 
@@ -65,7 +65,7 @@ class HL_GAUSS_C51(Q_Network_Family):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.argmax(
-            self.hl_gauss.to_scalar(self.get_q(params, convert_jax(obses), key)),
+            self.hl_gauss.to_scalar(self.get_q(params, convert_normalized_obs(obses), key)),
             axis=1,
             keepdims=True,
         )
@@ -85,8 +85,8 @@ class HL_GAUSS_C51(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         target_distribution = self._target(

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -8,7 +8,7 @@ from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset
 from jax_baselines.math.policy_math import entropy_target_from_sigma
 
@@ -99,13 +99,13 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_jax(obses)))
+        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
         std = jnp.exp(log_std)
         pi = jax.nn.tanh(mu + std * jax.random.normal(key, std.shape))
         return pi
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        mu, _ = self.actor(params, None, self.preproc(params, None, convert_jax(obses)))
+        mu, _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
         return jax.nn.tanh(mu)
 
     def _train_on_batch(self, data, context):
@@ -225,8 +225,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         ent_coef = jnp.exp(log_ent_coef)
         key1, key2 = jax.random.split(key, 2)

--- a/jax_baselines/DDPG/apex_ddpg.py
+++ b/jax_baselines/DDPG/apex_ddpg.py
@@ -8,7 +8,7 @@ import optax
 
 from jax_baselines.APE_X.dpg_base_class import Ape_X_Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.ou_noise import OUNoise
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import soft_update
 
 
@@ -53,17 +53,17 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
                 terminateds,
                 key,
             ):
-                next_feature = preproc(params, key, convert_jax(nxtobses))
+                next_feature = preproc(params, key, convert_normalized_obs(nxtobses))
                 next_action = actor(params, key, next_feature)
                 next_q = critic(params, key, next_feature, next_action)
-                feature = preproc(params, key, convert_jax(obses))
+                feature = preproc(params, key, convert_normalized_obs(obses))
                 q_values = critic(params, key, feature, actions)
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td_error = q_values - target
                 return jnp.squeeze(jnp.abs(td_error))
 
             def actor(actor, preproc, params, obses, key):
-                return actor(params, key, preproc(params, key, convert_jax(obses)))
+                return actor(params, key, preproc(params, key, convert_normalized_obs(obses)))
 
             def get_action(actor, params, obs, noise, epsilon, key):
                 actions = np.clip(np.asarray(actor(params, obs, key)) + noise() * epsilon, -1, 1)[0]
@@ -93,8 +93,8 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         batch_idxes = jnp.arange(self.batch_size).reshape(-1, self.mini_batch_size)
         obses_batch = jax.tree.map(lambda value: value[batch_idxes], obses)

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -10,7 +10,7 @@ from flax import struct
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.ou_noise import OUNoise
 from jax_baselines.DDPG.training import DPGTrainReport
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
 
 
@@ -81,7 +81,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_jax(obses)))
+        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses)))
 
     def description(self, eval_result=None):
         description = ""
@@ -226,8 +226,8 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
 
         targets = self._target(

--- a/jax_baselines/DQN/apex_dqn.py
+++ b/jax_baselines/DQN/apex_dqn.py
@@ -8,7 +8,7 @@ import optax
 
 from jax_baselines.APE_X.base_class import Ape_X_Family
 from jax_baselines.core.seeding import key_gen
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
 
@@ -65,12 +65,12 @@ class APE_X_DQN(Ape_X_Family):
                 key,
             ):
                 q_values = jnp.take_along_axis(
-                    model(params, key, preproc(params, key, convert_jax(obses))),
+                    model(params, key, preproc(params, key, convert_normalized_obs(obses))),
                     actions.astype(jnp.int32),
                     axis=1,
                 )
                 next_q_values = jnp.max(
-                    model(params, key, preproc(params, key, convert_jax(nxtobses))),
+                    model(params, key, preproc(params, key, convert_normalized_obs(nxtobses))),
                     axis=1,
                     keepdims=True,
                 )
@@ -79,7 +79,7 @@ class APE_X_DQN(Ape_X_Family):
                 return jnp.squeeze(jnp.abs(td_error)) + prioritized_replay_eps
 
             def actor(model, preproc, params, obses, key):
-                q_values = model(params, key, preproc(params, key, convert_jax(obses)))
+                q_values = model(params, key, preproc(params, key, convert_normalized_obs(obses)))
                 return jnp.argmax(q_values, axis=1)
 
             if param_noise:
@@ -128,8 +128,8 @@ class APE_X_DQN(Ape_X_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         batch_idxes = jnp.arange(self.batch_size).reshape(-1, self.mini_batch_size)

--- a/jax_baselines/DQN/dqn.py
+++ b/jax_baselines/DQN/dqn.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.DQN.base_class import Q_Network_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
 
@@ -39,7 +39,7 @@ class DQN(Q_Network_Family):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.expand_dims(
-            jnp.argmax(self.get_q(params, convert_jax(obses), key), axis=1), axis=1
+            jnp.argmax(self.get_q(params, convert_normalized_obs(obses), key), axis=1), axis=1
         )
 
     def _train_step(
@@ -57,8 +57,8 @@ class DQN(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         targets = self._target(

--- a/jax_baselines/FQF/fqf.py
+++ b/jax_baselines/FQF/fqf.py
@@ -6,7 +6,7 @@ import optax
 
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import FQFQuantileLosses, QuantileHuberLosses
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
@@ -76,7 +76,7 @@ class FQF(Q_Network_Family):
         return self._epsilon_greedy_actions(greedy_actions, epsilon)
 
     def _get_actions(self, params, fqf_params, obses, key=None) -> jnp.ndarray:
-        feature = self.preproc(params, key, convert_jax(obses))
+        feature = self.preproc(params, key, convert_normalized_obs(obses))
         tau, tau_hat, _ = self.fpf(fqf_params, key, feature)
         return jnp.argmax(self.get_q(params, feature, tau, tau_hat, key), axis=1, keepdims=True)
 
@@ -215,8 +215,8 @@ class FQF(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         (

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -17,7 +17,7 @@ from jax_baselines.core.replay_protocol import (
 )
 from jax_baselines.core.runtime_adapters import make_progress
 from jax_baselines.core.seeding import key_gen, set_global_seeds
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.returns import get_vtrace
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
@@ -193,7 +193,7 @@ class IMPALA_Family(object):
             if action_type == "discrete":
 
                 def actor(actor_model, preproc, params, obses, key=None):
-                    prob = actor_model(params, key, preproc(params, key, convert_jax(obses)))
+                    prob = actor_model(params, key, preproc(params, key, convert_normalized_obs(obses)))
                     return jax.nn.softmax(prob)
 
                 def get_action_prob(actor, params, obses):
@@ -208,7 +208,7 @@ class IMPALA_Family(object):
 
                 def actor(actor_model, preproc, params, obses, key=None):
                     mean, log_std = actor_model(
-                        params, key, preproc(params, key, convert_jax(obses))
+                        params, key, preproc(params, key, convert_normalized_obs(obses))
                     )
                     return mean, log_std
 

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.IMPALA.base_class import IMPALA_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 
 
 class SurrogateIMPALA(IMPALA_Family):
@@ -147,8 +147,8 @@ class SurrogateIMPALA(IMPALA_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
         next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/IQN/apex_iqn.py
+++ b/jax_baselines/IQN/apex_iqn.py
@@ -8,7 +8,7 @@ import optax
 
 from jax_baselines.APE_X.base_class import Ape_X_Family
 from jax_baselines.core.seeding import key_gen
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
@@ -139,7 +139,7 @@ class APE_X_IQN(Ape_X_Family):
                 key,
             ):
                 key1, key2, key3 = jax.random.split(key, 3)
-                conv_obses = convert_jax(obses)
+                conv_obses = convert_normalized_obs(obses)
                 batch_size = next(iter(conv_obses.values())).shape[0]
                 tau = jax.random.uniform(key1, (batch_size, n_support))
                 next_tau = jax.random.uniform(key2, (batch_size, n_support))
@@ -148,7 +148,7 @@ class APE_X_IQN(Ape_X_Family):
                     jnp.expand_dims(actions.astype(jnp.int32), axis=2),
                     axis=1,
                 )
-                next_q = model(params, key3, preproc(params, key3, convert_jax(nxtobses)), next_tau)
+                next_q = model(params, key3, preproc(params, key3, convert_normalized_obs(nxtobses)), next_tau)
                 next_actions = jnp.expand_dims(
                     jnp.argmax(jnp.mean(next_q, axis=2), axis=1), axis=(1, 2)
                 )
@@ -164,7 +164,7 @@ class APE_X_IQN(Ape_X_Family):
                 # mirroring local IQN._get_actions; the priority/TD-error path
                 # (get_abs_td_error) deliberately uses plain U[0,1] like iqn.py _loss/_target.
                 tau = jax.random.uniform(key, (1, n_support)) * CVaR
-                q_values = model(params, key, preproc(params, key, convert_jax(obses)), tau)
+                q_values = model(params, key, preproc(params, key, convert_normalized_obs(obses)), tau)
                 return jnp.expand_dims(jnp.argmax(jnp.mean(q_values, axis=2), axis=1), axis=1)
 
             if param_noise:
@@ -213,8 +213,8 @@ class APE_X_IQN(Ape_X_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         key1, key2 = jax.random.split(key, 2)

--- a/jax_baselines/IQN/iqn.py
+++ b/jax_baselines/IQN/iqn.py
@@ -6,7 +6,7 @@ import optax
 
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
@@ -62,7 +62,7 @@ class IQN(Q_Network_Family):
         return self._epsilon_greedy_actions(greedy_actions, epsilon)
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        conv_obses = convert_jax(obses)
+        conv_obses = convert_normalized_obs(obses)
         batch_size = next(iter(conv_obses.values())).shape[0]
         tau = jax.random.uniform(key, (batch_size, self.n_support)) * self.CVaR
         return jnp.expand_dims(
@@ -149,8 +149,8 @@ class IQN(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         key1, key2 = jax.random.split(key, 2)

--- a/jax_baselines/QRDQN/apex_qrdqn.py
+++ b/jax_baselines/QRDQN/apex_qrdqn.py
@@ -8,7 +8,7 @@ import optax
 
 from jax_baselines.APE_X.base_class import Ape_X_Family
 from jax_baselines.core.seeding import key_gen
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
@@ -148,11 +148,11 @@ class APE_X_QRDQN(Ape_X_Family):
                 key,
             ):
                 q_values = jnp.take_along_axis(
-                    model(params, key, preproc(params, key, convert_jax(obses))),
+                    model(params, key, preproc(params, key, convert_normalized_obs(obses))),
                     jnp.expand_dims(actions.astype(jnp.int32), axis=2),
                     axis=1,
                 )
-                next_q = model(params, key, preproc(params, key, convert_jax(nxtobses)))
+                next_q = model(params, key, preproc(params, key, convert_normalized_obs(nxtobses)))
                 next_actions = jnp.expand_dims(
                     jnp.argmax(jnp.mean(next_q, axis=2), axis=1), axis=(1, 2)
                 )
@@ -166,7 +166,7 @@ class APE_X_QRDQN(Ape_X_Family):
                 return jnp.squeeze(loss)
 
             def actor(model, preproc, params, obses, key):
-                q_values = model(params, key, preproc(params, key, convert_jax(obses)))
+                q_values = model(params, key, preproc(params, key, convert_normalized_obs(obses)))
                 return jnp.expand_dims(jnp.argmax(jnp.mean(q_values, axis=2), axis=1), axis=1)
 
             if param_noise:
@@ -215,8 +215,8 @@ class APE_X_QRDQN(Ape_X_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         batch_idxes = jnp.arange(self.batch_size).reshape(-1, self.mini_batch_size)

--- a/jax_baselines/QRDQN/qrdqn.py
+++ b/jax_baselines/QRDQN/qrdqn.py
@@ -6,7 +6,7 @@ import optax
 
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
@@ -62,7 +62,7 @@ class QRDQN(Q_Network_Family):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.expand_dims(
-            jnp.argmax(jnp.mean(self.get_q(params, convert_jax(obses), key), axis=2), axis=1),
+            jnp.argmax(jnp.mean(self.get_q(params, convert_normalized_obs(obses), key), axis=2), axis=1),
             axis=1,
         )
 
@@ -147,8 +147,8 @@ class QRDQN(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
         targets = self._target(

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -9,7 +9,7 @@ from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
 from jax_baselines.math.policy_math import entropy_target_from_sigma
 
@@ -110,11 +110,11 @@ class SAC(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_jax(obses)))
+        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
         return sample_action(mu, log_std, key)
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        mu, _ = self.actor(params, None, self.preproc(params, None, convert_jax(obses)))
+        mu, _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
         return mode_action(mu)
 
     def _train_on_batch(self, data, context):
@@ -243,8 +243,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         ent_coef = jnp.exp(log_ent_coef)
         key1, key2, key3 = jax.random.split(key, 3)

--- a/jax_baselines/SPR/hl_gauss_spr.py
+++ b/jax_baselines/SPR/hl_gauss_spr.py
@@ -10,7 +10,7 @@ from jax_baselines.math.distributional import (
     MunchausenSpec,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
@@ -105,7 +105,7 @@ class HL_GAUSS_SPR(SPR):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.argmax(
-            self.hl_gauss.to_scalar(self.get_q(params, convert_jax(obses), key)),
+            self.hl_gauss.to_scalar(self.get_q(params, convert_normalized_obs(obses), key)),
             axis=1,
             keepdims=True,
         )
@@ -154,7 +154,7 @@ class HL_GAUSS_SPR(SPR):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
+        obses = convert_normalized_obs(obses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         obses = jax.tree.map(

--- a/jax_baselines/SPR/spr.py
+++ b/jax_baselines/SPR/spr.py
@@ -20,7 +20,7 @@ from jax_baselines.math.distributional import (
     MunchausenSpec,
     distributional_td_target,
 )
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
@@ -146,7 +146,7 @@ class SPR(Q_Network_Family):
         return jnp.expand_dims(
             jnp.argmax(
                 jnp.sum(
-                    self.get_q(params, convert_jax(obses), key) * self._categorial_bar,
+                    self.get_q(params, convert_normalized_obs(obses), key) * self._categorial_bar,
                     axis=2,
                 ),
                 axis=1,
@@ -297,7 +297,7 @@ class SPR(Q_Network_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
+        obses = convert_normalized_obs(obses)
         actions = actions.astype(jnp.int32)
         not_terminateds = 1.0 - terminateds
         obses = jax.tree.map(

--- a/jax_baselines/TD3/apex_td3.py
+++ b/jax_baselines/TD3/apex_td3.py
@@ -7,7 +7,7 @@ import optax
 
 from jax_baselines.APE_X.dpg_base_class import Ape_X_Deteministic_Policy_Gradient_Family
 from jax_baselines.core.seeding import key_gen
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import soft_update
 
 
@@ -136,7 +136,7 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                 key,
             ):
                 size = next(iter(obses.values())).shape[0]
-                next_feature = preproc(params, key, convert_jax(nxtobses))
+                next_feature = preproc(params, key, convert_normalized_obs(nxtobses))
                 next_action = jnp.clip(
                     actor(params, key, next_feature)
                     + jnp.clip(
@@ -149,14 +149,14 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                 )
                 q1, q2 = critic(params, key, next_feature, next_action)
                 next_q = jnp.minimum(q1, q2)
-                feature = preproc(params, key, convert_jax(obses))
+                feature = preproc(params, key, convert_normalized_obs(obses))
                 q_values1, _ = critic(params, key, feature, actions)
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td1_error = jnp.abs(q_values1 - target)
                 return jnp.squeeze(td1_error)
 
             def actor(actor, preproc, params, obses, key):
-                return actor(params, key, preproc(params, key, convert_jax(obses)))
+                return actor(params, key, preproc(params, key, convert_normalized_obs(obses)))
 
             def get_action(actor, params, obs, noise, epsilon, key):
                 actions = np.clip(np.asarray(actor(params, obs, key)) + noise() * epsilon, -1, 1)[0]
@@ -189,8 +189,8 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         batch_idxes = jnp.arange(self.batch_size).reshape(-1, self.mini_batch_size)
         obses_batch = jax.tree.map(lambda value: value[batch_idxes], obses)

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -9,7 +9,7 @@ from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
 
 
@@ -79,7 +79,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_jax(obses)))
+        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses)))
 
     def _policy_action_from_state(self, state, obs, eval, steps):
         return np.asarray(self._get_actions(state["policy"], obs, None))
@@ -206,8 +206,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         targets = self._target(
             target_policy_params,

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -9,7 +9,7 @@ from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import hubberloss
 from jax_baselines.math.param_updates import hard_update, scaled_by_reset
 
@@ -116,7 +116,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, encoder_params, policy_params, obses, key=None) -> jnp.ndarray:
-        feature = self.preproc(encoder_params, key, convert_jax(obses))
+        feature = self.preproc(encoder_params, key, convert_normalized_obs(obses))
         zs = self.encoder(encoder_params, key, feature)
         return self.actor(policy_params, key, feature, zs)
 
@@ -320,8 +320,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
 
         repr_loss, grad = jax.value_and_grad(self._encoder_loss)(
@@ -427,7 +427,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
         )
 
     def feature_and_zs(self, encoder_params, obses, key):
-        feature = self.preproc(encoder_params, key, convert_jax(obses))
+        feature = self.preproc(encoder_params, key, convert_normalized_obs(obses))
         zs = self.encoder(encoder_params, key, feature)
         return feature, zs
 

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.IMPALA.base_class import IMPALA_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.policy_math import (
     kl_divergence_continuous,
     kl_divergence_discrete,
@@ -150,8 +150,8 @@ class IMPALA_TPPO(IMPALA_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
         next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -4,7 +4,7 @@ import numpy as np
 import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.policy_math import (
     kl_divergence_continuous,
     kl_divergence_discrete,
@@ -92,8 +92,8 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         rewards = jnp.stack(rewards)
         terminateds = jnp.stack(terminateds)
         truncateds = jnp.stack(truncateds)
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
         next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -10,7 +10,7 @@ from flax import struct
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.distributional import categorical_projection
-from jax_baselines.math.jax_utils import convert_jax
+from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import (
     project_dense_kernels,
     scaled_by_reset,
@@ -133,14 +133,14 @@ class XQC(Deteministic_Policy_Gradient_Family):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         (mu, log_std), _ = self.actor(
-            params, None, self.preproc(params, None, convert_jax(obses)), False
+            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
         )
         std = jnp.exp(log_std)
         pi = jax.nn.tanh(mu + std * jax.random.normal(key, std.shape))
         return pi
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        (mu, _), _ = self.actor(params, None, self.preproc(params, None, convert_jax(obses)), False)
+        (mu, _), _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)), False)
         return jax.nn.tanh(mu)
 
     def _train_on_batch(self, data, context):
@@ -272,8 +272,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
         weights=1,
         indexes=None,
     ):
-        obses = convert_jax(obses)
-        nxtobses = convert_jax(nxtobses)
+        obses = convert_normalized_obs(obses)
+        nxtobses = convert_normalized_obs(nxtobses)
         not_terminateds = 1.0 - terminateds
         ent_coef = jnp.exp(log_ent_coef)
         key1, key2 = jax.random.split(key, 2)

--- a/jax_baselines/math/jax_utils.py
+++ b/jax_baselines/math/jax_utils.py
@@ -1,10 +1,21 @@
 import jax.numpy as jnp
 
 
-def convert_jax(obs: dict):
+def convert_normalized_obs(obs: dict):
+    """Cast observations to float32, scaling compact uint8 pixels to [0, 1]."""
     return {
         key: value.astype(jnp.float32)
         if value.dtype != jnp.uint8
         else value.astype(jnp.float32) / 255.0
         for key, value in obs.items()
     }
+
+
+if __name__ == "__main__":
+    normalized = convert_normalized_obs(
+        {"pixels": jnp.array([0, 255], dtype=jnp.uint8), "state": jnp.array([-2.0, 2.0])}
+    )
+    assert all(value.dtype == jnp.float32 for value in normalized.values())
+    assert normalized["pixels"].tolist() == [0.0, 1.0]
+    assert normalized["state"].tolist() == [-2.0, 2.0]
+    print("PASS: uint8 [0, 255] -> float32 [0, 1]; float values unchanged.")

--- a/tests/test_apex_c51_priority_projection.py
+++ b/tests/test_apex_c51_priority_projection.py
@@ -89,7 +89,7 @@ def _model_factory(cur_dist, nxt_dist):
     """A `model` mapping obs->cur_dist and nxtobs->nxt_dist.
 
     The two are distinguished by a marker scalar in the (real-array) observation
-    so the closure's `convert_jax` boundary stays exercised.
+    so the closure's `convert_normalized_obs` boundary stays exercised.
     """
 
     def preproc(params, key, obses):


### PR DESCRIPTION
압축 관측을 정규화된 float로 바꾸는 함수 이름을 `convert_jax`에서 `convert_normalized_obs`로 변경합니다. AC·DPG·DQN·분산 계열 호출부와 테스트를 함께 이관하며, 기존 이름의 별칭은 남기지 않습니다. 변환 계산은 그대로 유지합니다.

스택 1/8 · base: `main` · head: `stack/mjlab-01-normalized-obs`. 이 PR의 base 대비 diff를 리뷰하고 1→8 순서로 병합합니다.

| 순서 | PR | 상태 |
| --- | --- | --- |
| 1 | [#19 관측 정규화 변환 함수의 이름을 명확히 변경](https://github.com/tinker495/jax-baseline/pull/19) | 리뷰 가능 |
| 2 | [#20 로컬 생성물 제외와 저장소 설정 정리](https://github.com/tinker495/jax-baseline/pull/20) | 리뷰 가능 |
| 3 | [#21 관측 키와 actor·critic 입력 역할을 통일](https://github.com/tinker495/jax-baseline/pull/21) | 리뷰 가능 |
| 4 | [#22 AC 에피소드 경계·행동·평가 계산 수정](https://github.com/tinker495/jax-baseline/pull/22) | 리뷰 가능 |
| 5 | [#23 MJLab 환경 adapter와 Go1 실험 설정 추가](https://github.com/tinker495/jax-baseline/pull/23) | 리뷰 가능 |
| 6 | [#24 AC 관측 정규화와 체크포인트 상태 저장](https://github.com/tinker495/jax-baseline/pull/24) | Draft |
| 7 | [#25 AC 버퍼·정규화를 CPU 또는 GPU에 유지](https://github.com/tinker495/jax-baseline/pull/25) | Draft |
| 8 | [#26 Go1 롤아웃 성능·장치 전송 프로파일러 추가](https://github.com/tinker495/jax-baseline/pull/26) | 리뷰 가능 |

| 항목 | 내용 |
| --- | --- |
| git hash/diff | `fa147c6a8ca3ed63cdf6a016e5298e2d22d0d549`. 이 PR의 Files changed가 검증 diff이며 미커밋 소스 변경 없음. |
| logging link | N/A — 외부 로그 서비스 미사용. 로컬 기록: `runs/pr_stack/01-cli.log, 01-tests.log; runs/pr_stack/audit_01_02/`. 주요 출력은 아래 실제 결과에 보존. |
| Command | `JAX_PLATFORMS=cpu .venv/bin/python -m jax_baselines.math.jax_utils` |
| Comments | 저장소 루트, 준비된 .venv, CPU. 데이터·시드 불필요. |
| 성공 기준 | uint8 [0, 255]가 float32 [0, 1]로 변환되고 기존 float 값은 유지된다는 PASS 출력. |
| 실제 결과 | CLI 종료 0, 위 PASS 출력 확인. core import 경계 테스트 11개 통과. |

변경 Python 파일 기준 Ruff 16→16, ty 193→193. main 대비 추가 진단 0개. 함수 본문은 동일하고 문서와 모듈 실행 검증만 추가했습니다.

검증 명령은 해당 PR head를 체크아웃한 저장소 루트에서 실행합니다. 전체 스택의 최종 코드 내용은 원래 `feat/mjlab-env-adapter`의 `61dc7dd7`과 동일하게 보존했습니다.
