### PR TITLE
[3/8] 관측 키와 actor·critic 입력 역할을 통일

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Literal
 
 import gymnasium as gym
 import numpy as np
@@ -32,7 +33,7 @@ __all__ = [
 ]
 
 
-def _action_meta(action_space) -> tuple[list[int], str]:
+def _action_meta(action_space) -> tuple[list[int], Literal["discrete", "continuous"]]:
     if hasattr(action_space, "n"):
         return [int(action_space.n)], "discrete"
     if hasattr(action_space, "shape") and action_space.shape:
@@ -69,8 +70,13 @@ def _single_env_info(env, env_id: str) -> EnvInfo:
     if not isinstance(env, SingleEnv):
         raise ValueError("Single env must satisfy the SingleEnv protocol")
     action_size, action_type = _action_meta(env.action_space)
+    observation_space = env.observation_space
+    if isinstance(observation_space, spaces.Dict):
+        observation_space = {
+            key: list(leaf.shape) for key, leaf in observation_space.spaces.items()
+        }
     return {
-        "observation_space": normalize_observation_space(env.observation_space),
+        "observation_space": observation_space,
         "action_size": action_size,
         "action_type": action_type,
         "env_type": "single",

--- a/env_builder/observations.py
+++ b/env_builder/observations.py
@@ -6,12 +6,25 @@ import numpy as np
 
 
 def _to_numpy(value):
+    detach = getattr(value, "detach", None)
+    if callable(detach):
+        value = detach()
+        cpu = getattr(value, "cpu", None)
+        if callable(cpu):
+            value = cpu()
+        numpy = getattr(value, "numpy", None)
+        if callable(numpy):
+            value = numpy()
     try:
-        array = np.asarray(value)
+        return np.asarray(value)
     except (TypeError, ValueError) as exc:
-        raise ValueError("Observation must be one numeric array") from exc
+        raise ValueError("Selected observation must be one numeric array") from exc
+
+
+def _numeric_array(value):
+    array = _to_numpy(value)
     if array.dtype == object or not np.issubdtype(array.dtype, np.number):
-        raise ValueError("Observation must be one numeric array")
+        raise ValueError("Selected observation must be one numeric array")
     return array
 
 
@@ -22,6 +35,20 @@ def _children(value):
     if isinstance(children, tuple):
         return {str(index): child for index, child in enumerate(children)}
     return None
+
+
+def _select_path(value, path, kind="Observation"):
+    for part in path.split("."):
+        children = _children(value)
+        if children is None:
+            raise ValueError(f"{kind} path {path!r} crosses a non-mapping at {part!r}")
+        if part not in children:
+            keys = ", ".join(children) or "<none>"
+            raise KeyError(
+                f"{kind} key {part!r} not found while selecting {path!r}; available keys: {keys}"
+            )
+        value = children[part]
+    return value
 
 
 def _flatten(value, leaf=None, kind="Observation", prefix=""):
@@ -41,25 +68,37 @@ def _flatten(value, leaf=None, kind="Observation", prefix=""):
     return leaves
 
 
-def normalize_observation(observation):
-    """Return a deterministic ``dict[str, ndarray]`` for every backend."""
-    normalized = _flatten(observation, _to_numpy)
+def normalize_observation(observation, observation_key=None):
+    """Flatten raw shared observations and mark every leaf with ``unified_``."""
+    if observation_key:
+        observation = _select_path(observation, observation_key)
+    normalized = _flatten(observation, _numeric_array, prefix=observation_key or "")
     if not normalized:
         raise ValueError("Observation must contain at least one array leaf")
-    return dict(sorted(normalized.items()))
+    return {f"unified_{key}": value for key, value in sorted(normalized.items())}
 
 
-def normalize_observation_space(space):
+def normalize_observation_space(space, observation_key=None):
     """Return flattened observation shapes with the same keys as observations."""
     return {
         key: list(getattr(leaf, "shape", leaf))
-        for key, leaf in flatten_observation_space(space).items()
+        for key, leaf in flatten_observation_space(space, observation_key).items()
     }
 
 
-def flatten_observation_space(space):
+def flatten_observation_space(space, observation_key=None):
     """Return flattened leaf spaces keyed like :func:`normalize_observation`."""
-    normalized = dict(sorted(_flatten(space, kind="Observation-space").items()))
+    if observation_key:
+        space = _select_path(space, observation_key, "Observation-space")
+    normalized = dict(
+        sorted(
+            _flatten(
+                space,
+                kind="Observation-space",
+                prefix=observation_key or "",
+            ).items()
+        )
+    )
     if not normalized:
         raise ValueError("Observation space must contain at least one leaf")
-    return normalized
+    return {f"unified_{key}": value for key, value in normalized.items()}

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -353,7 +353,9 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             nxtobses,
         )
         concated_preproc = self.preproc(policy_params, key, concated_obses)
-        next_preproc = jnp.split(concated_preproc, 2, axis=0)[1]
+        next_preproc = jax.tree_util.tree_map(
+            lambda feature: jnp.split(feature, 2, axis=0)[1], concated_preproc
+        )
         next_policy, log_prob = self._get_pi_log_prob(policy_params, next_preproc, key)
         concated_actions = jnp.concatenate([actions, next_policy])
         (q1, q2), variable_updates = self.critic(

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -459,7 +459,9 @@ class XQC(Deteministic_Policy_Gradient_Family):
             name: jnp.concatenate([obs, nxtobses[name]]) for name, obs in obses.items()
         }
         concated_preproc = self.preproc(policy_params, key, concated_obses)
-        next_preproc = jnp.split(concated_preproc, 2, axis=0)[1]
+        next_preproc = jax.tree_util.tree_map(
+            lambda feature: jnp.split(feature, 2, axis=0)[1], concated_preproc
+        )
         next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, next_preproc, key, False)
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), _ = self.critic(

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -12,6 +12,8 @@ from typing import Any, Literal, Protocol, TypeAlias, TypedDict, runtime_checkab
 
 import numpy as np
 
+# Keys retain their role from the environment boundary through replay and model input:
+# unified_* is shared, actor_* is policy-only, and critic_* is value-only.
 Observation: TypeAlias = dict[str, Any]
 ObservationSpace: TypeAlias = dict[str, list[int]]
 

--- a/jax_baselines/math/statistics.py
+++ b/jax_baselines/math/statistics.py
@@ -48,7 +48,7 @@ class RunningMeanStd:
     def __init__(self, epsilon=1e-4, shapes: dict | None = None, dtype=np.float64):
         """Tracks the mean, variance and count of values."""
         if shapes is None:
-            shapes = {"obs": ()}
+            shapes = {"unified_obs": ()}
         elif not isinstance(shapes, dict):
             raise TypeError("shapes must be a dict")
         self.dtype = np.dtype(dtype)

--- a/model_builder/flax/Module.py
+++ b/model_builder/flax/Module.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional, Tuple
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import flax
 import flax.linen as nn
@@ -11,6 +12,8 @@ from flax.linen.module import (  # pylint: disable=g-multiple-import
 from flax.linen.normalization import _canonicalize_axes, _compute_stats, _normalize
 from jax import lax
 from jax.nn import initializers
+
+from model_builder.utils import ActorCriticFeatures, observation_role_keys
 
 
 class ResBlock(nn.Module):
@@ -61,7 +64,7 @@ def flatten_fn(x: jnp.ndarray) -> jnp.ndarray:
     return x.reshape((x.shape[0], -1))
 
 
-def pop_embedding_mode(policy_kwargs: Optional[dict], default: str = "normal") -> Tuple[dict, str]:
+def pop_embedding_mode(policy_kwargs: dict | None, default: str = "normal") -> tuple[dict, str]:
     """Normalize policy_kwargs and split out the embedding_mode entry.
 
     Returns the (mutated) policy_kwargs dict with ``embedding_mode`` removed and
@@ -122,13 +125,16 @@ def visual_embedding(
 
 
 class PreProcess(nn.Module):
-    states_size: dict[str, Tuple[int, ...]]
+    states_size: Mapping[str, Sequence[int]]
     embedding_mode: str = "normal"
     flatten: bool = True
     pre_postprocess: Callable = lambda x: x  # Identity function
     multiple: int = 1
+    paired: bool = False
 
     def setup(self):
+        self.role_keys = observation_role_keys(self.states_size, self.paired)
+        selected = {key for keys in self.role_keys.values() for key in keys}
         self.embedding = {
             key: (
                 visual_embedding(self.embedding_mode, self.flatten, multiple=self.multiple)
@@ -136,28 +142,39 @@ class PreProcess(nn.Module):
                 else lambda x: x
             )
             for key, st in self.states_size.items()
+            if key in selected
         }
 
     @nn.compact
     def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
         return self.pre_postprocess(
             jnp.concatenate(
-                [pre(obses[key]) for key, pre in self.embedding.items()],
-                axis=1,
+                [self.embedding[key](obses[key]) for key in self.role_keys["actor"]], axis=1
             )
+        )
+
+    def actor_critic(self, obses: dict[str, jnp.ndarray]) -> ActorCriticFeatures:
+        embedded = {key: pre(obses[key]) for key, pre in self.embedding.items()}
+        return ActorCriticFeatures(
+            actor=self.pre_postprocess(
+                jnp.concatenate([embedded[key] for key in self.role_keys["actor"]], axis=1)
+            ),
+            critic=self.pre_postprocess(
+                jnp.concatenate([embedded[key] for key in self.role_keys["critic"]], axis=1)
+            ),
         )
 
     @property
     def output_size(self):
         return sum(
-            pre(jnp.zeros((1,) + self.states_size[key])).shape[1]
+            pre(jnp.zeros((1, *self.states_size[key]))).shape[1]
             for key, pre in self.embedding.items()
         )
 
 
 PRNGKey = Any
 Array = Any
-Shape = Tuple[int, ...]
+Shape = tuple[int, ...]
 Dtype = Any  # this could be a real type?
 
 
@@ -194,24 +211,24 @@ class BatchReNorm(Module):
         calculation for the variance.
     """
 
-    use_running_average: Optional[bool] = None
+    use_running_average: bool | None = None
     axis: int = -1
     momentum: float = 0.999
     epsilon: float = 0.001
-    dtype: Optional[Dtype] = None
+    dtype: Dtype | None = None
     param_dtype: Dtype = jnp.float32
     use_bias: bool = True
     use_scale: bool = True
     bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.zeros
     scale_init: Callable[[PRNGKey, Shape, Dtype], Array] = initializers.ones
-    axis_name: Optional[str] = None
+    axis_name: str | None = None
     axis_index_groups: Any = None
     r_max: float = 3.0
     d_max: float = 5.0
     use_fast_variance: bool = True
 
     @compact
-    def __call__(self, x, use_running_average: Optional[bool] = None):
+    def __call__(self, x, use_running_average: bool | None = None):
         """
         Args:
           x: the input to be normalized.

--- a/model_builder/flax/ac/ac_builder.py
+++ b/model_builder/flax/ac/ac_builder.py
@@ -6,7 +6,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -17,10 +21,10 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         mlp = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(feature)
+        )(features["actor"])
         if self.action_type == "discrete":
             action_probs = self.layer(
                 self.action_size[0], kernel_init=clip_factorized_uniform(0.01)
@@ -38,11 +42,11 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(0.01))]
-        )(feature)
+        )(features["critic"])
         return net
 
 
@@ -52,16 +56,18 @@ def model_builder_maker(observation_space, action_size, action_type, policy_kwar
     def _model_builder(key=None, print_model=False):
         class Merged(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, action_type, **policy_kwargs)
                 self.cri = Critic(**policy_kwargs)
 
             def __call__(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return self.act(x), self.cri(x)
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def actor(self, x):
                 return self.act(x)

--- a/model_builder/flax/dpg/crossq_builder.py
+++ b/model_builder/flax/dpg/crossq_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -17,7 +21,8 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        feature = features["actor"]
         for _ in range(self.hidden_n):
             feature = self.layer(self.node)(feature)
             feature = jax.nn.relu(feature)
@@ -39,8 +44,9 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, actions: jnp.ndarray, training: bool = True
+        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
+        feature = features["critic"]
         concat = jnp.concatenate([feature, actions], axis=1)
         feature = BatchReNorm(use_running_average=not training)(concat)
         for _ in range(self.hidden_n):
@@ -57,7 +63,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -66,7 +74,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/ddpg_builder.py
+++ b/model_builder/flax/dpg/ddpg_builder.py
@@ -21,14 +21,16 @@ def _make_model_builder(
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = actor_cls(action_size, **policy_kwargs)
 
             def __call__(self, x):
                 return self.actor(self.preprocess(x))
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def actor(self, x):
                 return self.act(x)

--- a/model_builder/flax/dpg/ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/ddpg_td3_blocks.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
+from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -21,14 +22,14 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         action = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
                 self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3)),
                 jax.nn.tanh,
             ]
-        )(feature)
+        )(features["actor"])
         return action
 
 
@@ -38,8 +39,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(3))]

--- a/model_builder/flax/dpg/gaussian_blocks.py
+++ b/model_builder/flax/dpg/gaussian_blocks.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
+from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -20,10 +21,10 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         linear = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(feature)
+        )(features["actor"])
         mu = self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))(linear)
         log_std = self.layer(
             self.action_size[0],
@@ -41,8 +42,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(3))]

--- a/model_builder/flax/dpg/sac_builder.py
+++ b/model_builder/flax/dpg/sac_builder.py
@@ -13,7 +13,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -22,7 +24,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/simba_crossq_builder.py
+++ b/model_builder/flax/dpg/simba_crossq_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -16,7 +20,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        feature = features["actor"]
         for _ in range(self.hidden_n):
             feature = Dense(self.node)(feature)
             feature = jax.nn.relu(feature)
@@ -40,8 +45,9 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, actions: jnp.ndarray, training: bool = True
+        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
+        feature = features["critic"]
         actions_norm = BatchReNorm(use_running_average=not training)(actions)
         feature = jnp.concatenate([feature, actions_norm], axis=1)
         for _ in range(self.hidden_n):
@@ -58,7 +64,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -67,7 +75,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/simba_ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/simba_ddpg_td3_blocks.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, ResidualBlock
+from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -19,7 +20,7 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         action = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -28,7 +29,7 @@ class Actor(nn.Module):
                 Dense(self.action_size[0], kernel_init=clip_factorized_uniform(3)),
                 jax.nn.tanh,
             ]
-        )(feature)
+        )(features["actor"])
         return action
 
 
@@ -37,8 +38,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]

--- a/model_builder/flax/dpg/simba_sac_builder.py
+++ b/model_builder/flax/dpg/simba_sac_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, ResidualBlock
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -16,14 +20,14 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         linear = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
             + [
                 nn.LayerNorm(),
             ]
-        )(feature)
+        )(features["actor"])
         mu = Dense(
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
@@ -43,8 +47,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -59,7 +63,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -68,7 +74,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/simba_td7_builder.py
+++ b/model_builder/flax/dpg/simba_td7_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, ResidualBlock, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Encoder(nn.Module):
@@ -16,13 +20,13 @@ class Encoder(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         encoder = nn.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(feature)
+        )(features["actor"])
         return avgl1norm(encoder)
 
 
@@ -49,8 +53,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(Dense(self.node)(feature))
+    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(Dense(self.node)(features["actor"]))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         action = nn.Sequential(
             [Dense(self.node)]
@@ -70,9 +74,13 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, zs: jnp.ndarray, zsa: jnp.ndarray, actions: jnp.ndarray
+        self,
+        features: ActorCriticFeatures,
+        zs: jnp.ndarray,
+        zsa: jnp.ndarray,
+        actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(Dense(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -90,7 +98,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merge_encoder(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.enc = Encoder()
                 self.act_enc = Action_Encoder()
 
@@ -101,7 +111,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return feature, zs, zsa
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def encoder(self, feature):
                 return self.enc(feature)
@@ -124,7 +134,10 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return q
 
             def critic(self, feature, zs, zsa, a):
-                return (self.crit1(feature, zs, zsa, a), self.crit2(feature, zs, zsa, a))
+                return (
+                    self.crit1(feature, zs, zsa, a),
+                    self.crit2(feature, zs, zsa, a),
+                )
 
         encoder_model = Merge_encoder()
         preproc_fn = get_apply_fn_flax_module(encoder_model, encoder_model.preprocess)

--- a/model_builder/flax/dpg/simba_tqc_builder.py
+++ b/model_builder/flax/dpg/simba_tqc_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, ResidualBlock
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -16,14 +20,14 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         linear = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
             + [
                 nn.LayerNorm(),
             ]
-        )(feature)
+        )(features["actor"])
         mu = Dense(
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
@@ -44,8 +48,8 @@ class Critic(nn.Module):
     support_n: int = 200
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -66,7 +70,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -75,7 +81,7 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/simbav2_crossq_builder.py
+++ b/model_builder/flax/dpg/simbav2_crossq_builder.py
@@ -13,7 +13,11 @@ from model_builder.flax.layers import (
     SimbaV2Head,
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -22,8 +26,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -48,10 +52,10 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, actions: jnp.ndarray, training: bool = True
+        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
         del training
-        concat = jnp.concatenate([feature, actions], axis=1)
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -65,7 +69,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -73,7 +79,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return self.actor(feature)
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def actor(self, x):
                 return self.act(x)

--- a/model_builder/flax/dpg/simbav2_ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/simbav2_ddpg_td3_blocks.py
@@ -10,6 +10,7 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.flax.layers import SimbaV2Block, SimbaV2Embedding, SimbaV2Head
+from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -18,8 +19,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         logits = SimbaV2Head(self.node, self.action_size[0])(encoded)
@@ -31,8 +32,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)

--- a/model_builder/flax/dpg/simbav2_sac_builder.py
+++ b/model_builder/flax/dpg/simbav2_sac_builder.py
@@ -12,7 +12,11 @@ from model_builder.flax.layers import (
     SimbaV2Head,
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -21,8 +25,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -42,8 +46,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -57,7 +61,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -65,7 +71,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return self.actor(feature)
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def actor(self, x):
                 return self.act(x)

--- a/model_builder/flax/dpg/simbav2_td7_builder.py
+++ b/model_builder/flax/dpg/simbav2_td7_builder.py
@@ -6,7 +6,11 @@ import numpy as np
 from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.layers import SimbaV2Block, SimbaV2Embedding, SimbaV2Head
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Encoder(nn.Module):
@@ -14,8 +18,8 @@ class Encoder(nn.Module):
     hidden_n: int = 3
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         return encoded
@@ -40,8 +44,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
-        base = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
+        base = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             base = SimbaV2Block(self.node)(base)
         embed = jnp.concatenate([base, zs], axis=1)
@@ -58,9 +62,13 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, zs: jnp.ndarray, zsa: jnp.ndarray, actions: jnp.ndarray
+        self,
+        features: ActorCriticFeatures,
+        zs: jnp.ndarray,
+        zsa: jnp.ndarray,
+        actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         base = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             base = SimbaV2Block(self.node)(base)
@@ -78,7 +86,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merge_encoder(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.enc = Encoder(**policy_kwargs)
                 self.act_enc = ActionEncoder(**policy_kwargs)
 
@@ -89,7 +99,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return feature, zs, zsa
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def encoder(self, feature):
                 return self.enc(feature)

--- a/model_builder/flax/dpg/simbav2_tqc_builder.py
+++ b/model_builder/flax/dpg/simbav2_tqc_builder.py
@@ -12,7 +12,11 @@ from model_builder.flax.layers import (
     SimbaV2Head,
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -21,8 +25,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(feature)
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features["actor"])
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -43,8 +47,8 @@ class Critic(nn.Module):
     support_n: int = 200
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -61,7 +65,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -69,7 +75,7 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 return self.actor(feature)
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def actor(self, x):
                 return self.act(x)

--- a/model_builder/flax/dpg/td7_builder.py
+++ b/model_builder/flax/dpg/td7_builder.py
@@ -7,7 +7,11 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Encoder(nn.Module):
@@ -16,13 +20,13 @@ class Encoder(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         encoder = nn.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(feature)
+        )(features["actor"])
         return avgl1norm(encoder)
 
 
@@ -50,8 +54,8 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(self.layer(self.node)(feature))
+    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(self.layer(self.node)(features["actor"]))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         action = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
@@ -70,9 +74,13 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, zs: jnp.ndarray, zsa: jnp.ndarray, actions: jnp.ndarray
+        self,
+        features: ActorCriticFeatures,
+        zs: jnp.ndarray,
+        zsa: jnp.ndarray,
+        actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(self.layer(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -89,7 +97,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merge_encoder(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.enc = Encoder()
                 self.act_enc = Action_Encoder()
 
@@ -100,7 +110,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return feature, zs, zsa
 
             def preprocess(self, x):
-                return self.preproc(x)
+                return self.preproc.actor_critic(x)
 
             def encoder(self, feature):
                 return self.enc(feature)
@@ -123,7 +133,10 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return q
 
             def critic(self, feature, zs, zsa, a):
-                return (self.crit1(feature, zs, zsa, a), self.crit2(feature, zs, zsa, a))
+                return (
+                    self.crit1(feature, zs, zsa, a),
+                    self.crit2(feature, zs, zsa, a),
+                )
 
         encoder_model = Merge_encoder()
         preproc_fn = get_apply_fn_flax_module(encoder_model, encoder_model.preprocess)

--- a/model_builder/flax/dpg/tqc_builder.py
+++ b/model_builder/flax/dpg/tqc_builder.py
@@ -8,7 +8,11 @@ from model_builder.flax.dpg.gaussian_blocks import Actor
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Critic(nn.Module):
@@ -18,8 +22,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
@@ -38,7 +42,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x):
@@ -47,7 +53,7 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x):

--- a/model_builder/flax/dpg/xqc_builder.py
+++ b/model_builder/flax/dpg/xqc_builder.py
@@ -5,7 +5,11 @@ import numpy as np
 
 from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_flax_model_summary,
+)
 
 
 class Actor(nn.Module):
@@ -17,7 +21,8 @@ class Actor(nn.Module):
         return nn.BatchNorm(use_running_average=not training, momentum=0.99, epsilon=0.001)(feature)
 
     @nn.compact
-    def __call__(self, feature: jnp.ndarray, training: bool = True) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures, training: bool = True) -> jnp.ndarray:
+        feature = features["actor"]
         feature = self.normalize(feature, training)
         for _ in range(self.hidden_n):
             feature = nn.Dense(
@@ -48,8 +53,9 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, feature: jnp.ndarray, actions: jnp.ndarray, training: bool = True
+        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
+        feature = features["critic"]
         concat = jnp.concatenate([feature, actions], axis=1)
         feature = self.normalize(concat, training)
         for _ in range(self.hidden_n):
@@ -73,7 +79,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.preproc = PreProcess(observation_space, embedding_mode=embedding_mode)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, paired=True
+                )
                 self.act = Actor(action_size, **policy_kwargs)
 
             def __call__(self, x, training: bool = True):
@@ -82,7 +90,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 return mu, log_std
 
             def preprocess(self, x):
-                x = self.preproc(x)
+                x = self.preproc.actor_critic(x)
                 return x
 
             def actor(self, x, training: bool = True):

--- a/model_builder/haiku/Module.py
+++ b/model_builder/haiku/Module.py
@@ -1,11 +1,11 @@
-from typing import Optional, Tuple
-
 import haiku as hk
 import jax
 import jax.numpy as jnp
 
+from model_builder.utils import ActorCriticFeatures, observation_role_keys
 
-def pop_embedding_mode(policy_kwargs: Optional[dict], default: str = "normal") -> Tuple[dict, str]:
+
+def pop_embedding_mode(policy_kwargs: dict | None, default: str = "normal") -> tuple[dict, str]:
     """Normalize policy_kwargs and split out the embedding_mode entry.
 
     Returns the (mutated) policy_kwargs dict with ``embedding_mode`` removed and
@@ -56,12 +56,24 @@ def visual_embedding(mode="normal"):
 
 
 class PreProcess(hk.Module):
-    def __init__(self, state_size, embedding_mode="normal"):
+    def __init__(self, state_size, embedding_mode="normal", paired=False):
         super().__init__()
+        self.role_keys = observation_role_keys(state_size, paired)
+        selected = {key for keys in self.role_keys.values() for key in keys}
         self.embedding = {
             key: visual_embedding(embedding_mode) if len(st) == 3 else lambda x: x
             for key, st in state_size.items()
+            if key in selected
         }
 
     def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
-        return jnp.concatenate([pre(obses[key]) for key, pre in self.embedding.items()], axis=1)
+        return jnp.concatenate(
+            [self.embedding[key](obses[key]) for key in self.role_keys["actor"]], axis=1
+        )
+
+    def actor_critic(self, obses: dict[str, jnp.ndarray]) -> ActorCriticFeatures:
+        embedded = {key: pre(obses[key]) for key, pre in self.embedding.items()}
+        return ActorCriticFeatures(
+            actor=jnp.concatenate([embedded[key] for key in self.role_keys["actor"]], axis=1),
+            critic=jnp.concatenate([embedded[key] for key in self.role_keys["critic"]], axis=1),
+        )

--- a/model_builder/haiku/ac/ac_builder.py
+++ b/model_builder/haiku/ac/ac_builder.py
@@ -3,7 +3,11 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_haiku_model_summary,
+)
 
 
 class Actor(hk.Module):
@@ -15,10 +19,10 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         mlp = hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(feature)
+        )(features["actor"])
         if self.action_type == "discrete":
             return self.layer(
                 self.action_size[0], w_init=hk.initializers.RandomUniform(-0.03, 0.03)
@@ -40,11 +44,11 @@ class Critic(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]
-        )(feature)
+        )(features["critic"])
 
 
 def model_builder_maker(observation_space, action_size, action_type, policy_kwargs):
@@ -52,7 +56,9 @@ def model_builder_maker(observation_space, action_size, action_type, policy_kwar
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         actor = hk.transform(lambda x: Actor(action_size, action_type, **policy_kwargs)(x))
         critic = hk.transform(lambda x: Critic(**policy_kwargs)(x))

--- a/model_builder/haiku/dpg/ddpg_builder.py
+++ b/model_builder/haiku/dpg/ddpg_builder.py
@@ -12,7 +12,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         actor = hk.transform(lambda x: Actor(action_size, **policy_kwargs)(x))
         critic = hk.transform(lambda x, a: Critic(**policy_kwargs)(x, a))

--- a/model_builder/haiku/dpg/ddpg_td3_blocks.py
+++ b/model_builder/haiku/dpg/ddpg_td3_blocks.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.haiku.layers import LOG_STD_MEAN, LOG_STD_SCALE
+from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(hk.Module):
@@ -29,14 +30,17 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
-                self.layer(self.action_size[0], w_init=hk.initializers.RandomUniform(-0.03, 0.03)),
+                self.layer(
+                    self.action_size[0],
+                    w_init=hk.initializers.RandomUniform(-0.03, 0.03),
+                ),
                 jax.nn.tanh,
             ]
-        )(feature)
+        )(features["actor"])
 
 
 class GaussianActor(hk.Module):
@@ -47,15 +51,16 @@ class GaussianActor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         linear = hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
                 self.layer(
-                    self.action_size[0] * 2, w_init=hk.initializers.RandomUniform(-0.03, 0.03)
+                    self.action_size[0] * 2,
+                    w_init=hk.initializers.RandomUniform(-0.03, 0.03),
                 )
             ]
-        )(feature)
+        )(features["actor"])
         mu, log_std = jnp.split(linear, 2, axis=-1)
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
@@ -67,8 +72,8 @@ class Critic(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]

--- a/model_builder/haiku/dpg/sac_builder.py
+++ b/model_builder/haiku/dpg/sac_builder.py
@@ -12,7 +12,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         actor = hk.transform(lambda x: GaussianActor(action_size, **policy_kwargs)(x))
         critic = hk.transform(

--- a/model_builder/haiku/dpg/td3_builder.py
+++ b/model_builder/haiku/dpg/td3_builder.py
@@ -12,7 +12,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         actor = hk.transform(lambda x: Actor(action_size, **policy_kwargs)(x))
         critic = hk.transform(

--- a/model_builder/haiku/dpg/td7_builder.py
+++ b/model_builder/haiku/dpg/td7_builder.py
@@ -4,7 +4,11 @@ import jax.numpy as jnp
 import numpy as np
 
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_haiku_model_summary,
+)
 
 
 def avgl1norm(x, epsilon=1e-6):
@@ -18,13 +22,13 @@ class Encoder(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray) -> jnp.ndarray:
+    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
         encoder = hk.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(feature)
+        )(features["actor"])
         return avgl1norm(encoder)
 
 
@@ -53,13 +57,16 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(self.layer(self.node)(feature))
+    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(self.layer(self.node)(features["actor"]))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
-                self.layer(self.action_size[0], w_init=hk.initializers.RandomUniform(-0.03, 0.03)),
+                self.layer(
+                    self.action_size[0],
+                    w_init=hk.initializers.RandomUniform(-0.03, 0.03),
+                ),
                 jax.nn.tanh,
             ]
         )(embed_concat)
@@ -73,9 +80,13 @@ class Critic(hk.Module):
         self.layer = hk.Linear
 
     def __call__(
-        self, feature: jnp.ndarray, zs: jnp.ndarray, zsa: jnp.ndarray, actions: jnp.ndarray
+        self,
+        features: ActorCriticFeatures,
+        zs: jnp.ndarray,
+        zsa: jnp.ndarray,
+        actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(self.layer(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -90,7 +101,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         encoder = hk.transform(lambda x: Encoder()(x))
         action_encoder = hk.transform(lambda zs, a: Action_Encoder()(zs, a))

--- a/model_builder/haiku/dpg/tqc_builder.py
+++ b/model_builder/haiku/dpg/tqc_builder.py
@@ -5,7 +5,11 @@ import numpy as np
 
 from model_builder.haiku.dpg.ddpg_td3_blocks import GaussianActor
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    print_haiku_model_summary,
+)
 
 
 class Critic(hk.Module):
@@ -16,8 +20,8 @@ class Critic(hk.Module):
         self.support_n = support_n
         self.layer = hk.Linear
 
-    def __call__(self, feature: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([feature, actions], axis=1)
+    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features["critic"], actions], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(self.support_n, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]
@@ -29,7 +33,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
 
     def _model_builder(key=None, print_model=False):
         preproc = hk.transform(
-            lambda x: PreProcess(observation_space, embedding_mode=embedding_mode)(x)
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, paired=True
+            ).actor_critic(x)
         )
         actor = hk.transform(lambda x: GaussianActor(action_size, **policy_kwargs)(x))
         critic = hk.transform(

--- a/model_builder/utils.py
+++ b/model_builder/utils.py
@@ -1,3 +1,7 @@
+from collections.abc import Mapping, Sequence
+from typing import Literal, TypedDict
+
+import jax
 import numpy as np
 
 
@@ -21,3 +25,29 @@ def print_haiku_model_summary(enabled, *models):
 
     for model, *inputs in models:
         print(hk.experimental.tabulate(model)(*inputs))
+
+
+class ActorCriticFeatures(TypedDict):
+    actor: jax.Array
+    critic: jax.Array
+
+
+def observation_role_keys(
+    space: Mapping[str, Sequence[int]], actor_critic: bool = False
+) -> dict[str, tuple[str, ...]]:
+    """Resolve canonical observation roles before embedding and network construction."""
+    for key in space:
+        prefix, separator, name = key.partition("_")
+        if prefix not in ("unified", "actor", "critic") or not separator or not name:
+            raise ValueError(f"Observation key requires unified_, actor_, or critic_: {key!r}")
+    roles: tuple[Literal["actor", "critic"], ...] = (
+        ("actor", "critic") if actor_critic else ("actor",)
+    )
+    keys = {
+        role: tuple(key for key in space if key.startswith(("unified_", f"{role}_")))
+        for role in roles
+    }
+    for role, selected in keys.items():
+        if not selected:
+            raise ValueError(f"Observation space has no inputs for {role}")
+    return keys

--- a/tests/test_apex_c51_priority_projection.py
+++ b/tests/test_apex_c51_priority_projection.py
@@ -96,14 +96,14 @@ def _model_factory(cur_dist, nxt_dist):
         return obses
 
     def model(params, key, x):
-        marker = jnp.asarray(x["obs"])[0, 0]
+        marker = jnp.asarray(x["unified_obs"])[0, 0]
         return jax.lax.cond(marker > 0.5, lambda: nxt_dist, lambda: cur_dist)
 
     return model, preproc
 
 
 def _obs(marker, batch):
-    return {"obs": np.full((batch, 1), marker, dtype=np.float32)}
+    return {"unified_obs": np.full((batch, 1), marker, dtype=np.float32)}
 
 
 def test_worker_priority_matches_inlined_golden_master():

--- a/tests/test_checkpoint_state.py
+++ b/tests/test_checkpoint_state.py
@@ -186,8 +186,8 @@ def test_simba_obs_rms_round_trip():
         setattr(src, name, _field_value(name, i))
     src.simba = True
     src.reward_normalizer = None
-    src.obs_rms = RunningMeanStd(shapes={"obs": (2,)}, dtype=np.float64)
-    src.obs_rms.update({"obs": np.ones((4, 2), np.float64)})
+    src.obs_rms = RunningMeanStd(shapes={"unified_obs": (2,)}, dtype=np.float64)
+    src.obs_rms.update({"unified_obs": np.ones((4, 2), np.float64)})
     src.action_obs_rms = RunningMeanStd.from_state(src.obs_rms.to_state())
     src.checkpoint_obs_rms = None  # exercises the None branch
 

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -56,32 +56,32 @@ def test_reward_normalizer_normalize_preserves_float32_dtype():
 def test_running_mean_std_matches_batch_statistics():
     rng = np.random.default_rng(0)
     batches = [rng.normal(loc=2.0, scale=3.0, size=(50, 4)) for _ in range(5)]
-    rms = RunningMeanStd(shapes={"obs": (4,)})
+    rms = RunningMeanStd(shapes={"unified_obs": (4,)})
     for batch in batches:
-        rms.update({"obs": batch})
+        rms.update({"unified_obs": batch})
 
     allx = np.concatenate(batches, axis=0)
     # epsilon init (1e-4) makes the online estimate approach the exact moments
-    assert np.allclose(rms.means["obs"], allx.mean(axis=0), atol=1e-3)
-    assert np.allclose(rms.vars["obs"], allx.var(axis=0), atol=1e-2)
+    assert np.allclose(rms.means["unified_obs"], allx.mean(axis=0), atol=1e-3)
+    assert np.allclose(rms.vars["unified_obs"], allx.var(axis=0), atol=1e-2)
 
 
 def test_running_mean_std_normalize_centers_and_scales():
-    rms = RunningMeanStd(shapes={"obs": (3,)})
-    rms.means = {"obs": np.array([1.0, 2.0, 3.0])}
-    rms.vars = {"obs": np.array([4.0, 4.0, 4.0])}
-    out = rms.normalize({"obs": np.array([[1.0, 2.0, 3.0]])})["obs"]
+    rms = RunningMeanStd(shapes={"unified_obs": (3,)})
+    rms.means = {"unified_obs": np.array([1.0, 2.0, 3.0])}
+    rms.vars = {"unified_obs": np.array([4.0, 4.0, 4.0])}
+    out = rms.normalize({"unified_obs": np.array([[1.0, 2.0, 3.0]])})["unified_obs"]
     assert np.allclose(out, 0.0, atol=1e-3)
 
 
 def test_running_mean_std_state_round_trip():
     rng = np.random.default_rng(1)
-    rms = RunningMeanStd(shapes={"obs": (2,)})
-    rms.update({"obs": rng.normal(size=(10, 2))})
+    rms = RunningMeanStd(shapes={"unified_obs": (2,)})
+    rms.update({"unified_obs": rng.normal(size=(10, 2))})
 
     restored = RunningMeanStd.from_state(rms.to_state())
-    assert np.array_equal(restored.means["obs"], rms.means["obs"])
-    assert np.array_equal(restored.vars["obs"], rms.vars["obs"])
+    assert np.array_equal(restored.means["unified_obs"], rms.means["unified_obs"])
+    assert np.array_equal(restored.vars["unified_obs"], rms.vars["unified_obs"])
     assert restored.count == pytest.approx(rms.count)
 
 

--- a/tests/test_cpprb_compress.py
+++ b/tests/test_cpprb_compress.py
@@ -23,27 +23,29 @@ from replay_memory.replay_factory import make_replay_buffer
 H = W = 8
 S = 4  # frame-stack depth, as in Atari
 IMG = [H, W, S]
-OBS = {"obs": IMG}
+OBS = {"unified_obs": IMG}
 
 
 def test_transition_projection_has_one_plain_and_prioritized_shape():
     transitions = {
-        "obs:obs": np.zeros((2, 4), dtype=np.float32),
+        "obs:unified_obs": np.zeros((2, 4), dtype=np.float32),
         "action": np.zeros((2, 1), dtype=np.float32),
         "reward": np.zeros((2, 1), dtype=np.float32),
-        "next_obs:obs": np.ones((2, 4), dtype=np.float32),
+        "next_obs:unified_obs": np.ones((2, 4), dtype=np.float32),
         "done": np.zeros((2, 1), dtype=np.float32),
         "weights": np.ones(2, dtype=np.float32),
         "indexes": np.arange(2),
     }
 
-    plain = _project_transitions(transitions, ["obs:obs"], ["next_obs:obs"])
-    prioritized = _project_transitions(transitions, ["obs:obs"], ["next_obs:obs"], prioritized=True)
+    plain = _project_transitions(transitions, ["obs:unified_obs"], ["next_obs:unified_obs"])
+    prioritized = _project_transitions(
+        transitions, ["obs:unified_obs"], ["next_obs:unified_obs"], prioritized=True
+    )
 
     assert set(plain) == {"obses", "actions", "rewards", "nxtobses", "terminateds"}
     assert set(prioritized) == set(plain) | {"weights", "indexes"}
-    assert plain["obses"] == {"obs": transitions["obs:obs"]}
-    assert plain["nxtobses"] == {"obs": transitions["next_obs:obs"]}
+    assert plain["obses"] == {"unified_obs": transitions["obs:unified_obs"]}
+    assert plain["nxtobses"] == {"unified_obs": transitions["next_obs:unified_obs"]}
 
 
 def _frame(v):
@@ -103,14 +105,18 @@ def _feed_single(buf):
     for base, length in EPISODES:
         for step, (obs, nxt) in enumerate(_episode(base, length)):
             terminated = step == length - 1
-            buf.add({"obs": obs}, 1, 1.0, {"obs": nxt}, terminated, False)
+            buf.add({"unified_obs": obs}, 1, 1.0, {"unified_obs": nxt}, terminated, False)
 
 
 def _assert_lossless(compressed, reference):
     c = compressed.get_buffer()
     r = reference.get_buffer()
-    assert np.array_equal(c["obs:obs"], r["obs:obs"]), "obs0 reconstruction diverged"
-    assert np.array_equal(c["next_obs:obs"], r["next_obs:obs"]), "next_obs0 reconstruction diverged"
+    assert np.array_equal(
+        c["obs:unified_obs"], r["obs:unified_obs"]
+    ), "obs0 reconstruction diverged"
+    assert np.array_equal(
+        c["next_obs:unified_obs"], r["next_obs:unified_obs"]
+    ), "next_obs0 reconstruction diverged"
 
 
 def test_replay_buffer_compress_lossless():
@@ -122,8 +128,8 @@ def test_replay_buffer_compress_lossless():
     _assert_lossless(comp, ref)
     # sample returns both obs and next_obs for the image modality
     smpl = comp.sample(16)
-    assert smpl["obses"]["obs"].shape == (16, H, W, S)
-    assert smpl["nxtobses"]["obs"].shape == (16, H, W, S)
+    assert smpl["obses"]["unified_obs"].shape == (16, H, W, S)
+    assert smpl["nxtobses"]["unified_obs"].shape == (16, H, W, S)
 
 
 def test_prioritized_buffer_compress_lossless():
@@ -134,7 +140,7 @@ def test_prioritized_buffer_compress_lossless():
     assert comp._compress_active is True
     _assert_lossless(comp, ref)
     smpl = comp.sample(16, 0.4)
-    assert smpl["nxtobses"]["obs"].shape == (16, H, W, S)
+    assert smpl["nxtobses"]["unified_obs"].shape == (16, H, W, S)
     assert "weights" in smpl and "indexes" in smpl
 
 
@@ -177,31 +183,41 @@ def test_nstep_multiworker_compress_lossless():
             term = np.array([step == length - 1] * workers)
             trunc = np.array([False] * workers)
             comp.add(
-                {"obs": obs_w}, np.ones((workers, 1)), np.ones(workers), {"obs": nxt_w}, term, trunc
+                {"unified_obs": obs_w},
+                np.ones((workers, 1)),
+                np.ones(workers),
+                {"unified_obs": nxt_w},
+                term,
+                trunc,
             )
             ref.add(
-                {"obs": obs_w}, np.ones((workers, 1)), np.ones(workers), {"obs": nxt_w}, term, trunc
+                {"unified_obs": obs_w},
+                np.ones((workers, 1)),
+                np.ones(workers),
+                {"unified_obs": nxt_w},
+                term,
+                trunc,
             )
     _assert_lossless(comp, ref)
 
 
 def test_vector_obs_compress_is_noop():
     # No image modality -> compression must be inert and still round-trip.
-    vec = {"obs": [4]}
+    vec = {"unified_obs": [4]}
     buf = ReplayBuffer(100, vec, action_space=1, compress_memory=True)
     assert buf._compress_active is False
     for t in range(10):
         buf.add(
-            {"obs": np.arange(t, t + 4, dtype=np.float32)[np.newaxis, :]},
+            {"unified_obs": np.arange(t, t + 4, dtype=np.float32)[np.newaxis, :]},
             1,
             1.0,
-            {"obs": np.arange(t + 1, t + 5, dtype=np.float32)[np.newaxis, :]},
+            {"unified_obs": np.arange(t + 1, t + 5, dtype=np.float32)[np.newaxis, :]},
             t == 9,
             False,
         )
     smpl = buf.sample(5)
-    assert smpl["obses"]["obs"].shape == (5, 4)
-    assert smpl["nxtobses"]["obs"].shape == (5, 4)
+    assert smpl["obses"]["unified_obs"].shape == (5, 4)
+    assert smpl["nxtobses"]["unified_obs"].shape == (5, 4)
 
 
 @pytest.mark.parametrize("prioritized", [False, True])
@@ -255,13 +271,15 @@ def test_multiworker_single_step_image_compress_accepts_vector_done_arrays(prior
     reward = np.ones(2, dtype=np.float32)
     no_done = np.array([False, False])
 
-    buf.add({"obs": obs}, action, reward, {"obs": nxt}, no_done, no_done)
-    buf.add({"obs": obs}, action, reward, {"obs": nxt}, np.array([True, False]), no_done)
+    buf.add({"unified_obs": obs}, action, reward, {"unified_obs": nxt}, no_done, no_done)
+    buf.add(
+        {"unified_obs": obs}, action, reward, {"unified_obs": nxt}, np.array([True, False]), no_done
+    )
 
     assert len(buf) == 4
     sample = buf.sample(1, 0.4) if prioritized else buf.sample(1)
-    assert sample["obses"]["obs"].shape == (1, H, W, S)
-    assert sample["nxtobses"]["obs"].shape == (1, H, W, S)
+    assert sample["obses"]["unified_obs"].shape == (1, H, W, S)
+    assert sample["nxtobses"]["unified_obs"].shape == (1, H, W, S)
 
 
 @pytest.mark.parametrize("prioritized", [False, True])
@@ -276,12 +294,12 @@ def test_multiworker_single_step_image_compress_is_available_before_done(priorit
     reward = np.ones(2, dtype=np.float32)
     no_done = np.array([False, False])
 
-    buf.add({"obs": obs}, action, reward, {"obs": nxt}, no_done, no_done)
+    buf.add({"unified_obs": obs}, action, reward, {"unified_obs": nxt}, no_done, no_done)
 
     assert len(buf) == 2
     sample = buf.sample(1, 0.4) if prioritized else buf.sample(1)
-    assert sample["obses"]["obs"].shape == (1, H, W, S)
-    assert sample["nxtobses"]["obs"].shape == (1, H, W, S)
+    assert sample["obses"]["unified_obs"].shape == (1, H, W, S)
+    assert sample["nxtobses"]["unified_obs"].shape == (1, H, W, S)
 
 
 @pytest.mark.parametrize("prioritized", [False, True])
@@ -318,9 +336,23 @@ def test_multiworker_single_step_image_compress_store_mask_is_lossless(prioritiz
             axis=0,
         )
         comp.add(
-            {"obs": obs}, action, reward, {"obs": nxt}, no_done, no_done, store_mask=store_mask
+            {"unified_obs": obs},
+            action,
+            reward,
+            {"unified_obs": nxt},
+            no_done,
+            no_done,
+            store_mask=store_mask,
         )
-        ref.add({"obs": obs}, action, reward, {"obs": nxt}, no_done, no_done, store_mask=store_mask)
+        ref.add(
+            {"unified_obs": obs},
+            action,
+            reward,
+            {"unified_obs": nxt},
+            no_done,
+            no_done,
+            store_mask=store_mask,
+        )
 
     _assert_lossless(comp, ref)
 
@@ -346,7 +378,13 @@ def test_multiworker_single_step_image_compress_does_not_cap_long_episode(priori
     for step in range(2501):
         terminated = np.array([step == 2500, False])
         buf.add(
-            {"obs": obs}, action, reward, {"obs": nxt}, terminated, truncated, store_mask=store_mask
+            {"unified_obs": obs},
+            action,
+            reward,
+            {"unified_obs": nxt},
+            terminated,
+            truncated,
+            store_mask=store_mask,
         )
 
     assert len(buf) == 2501
@@ -389,4 +427,4 @@ def test_multiprioritized_warns_and_keeps_next_obs():
             compress_memory=True,
         )
     # central buffer must store next_obs fully (no broken deletion)
-    assert "next_obs:obs" in mp.env_dict
+    assert "next_obs:unified_obs" in mp.env_dict

--- a/tests/test_dict_observation_contract.py
+++ b/tests/test_dict_observation_contract.py
@@ -15,15 +15,21 @@ def test_observation_contract_normalizes_arrays_and_nested_mappings():
     array = np.arange(3, dtype=np.float32)
 
     normalized = normalize_observation(array)
-    assert list(normalized) == ["obs"]
-    assert normalized["obs"] is array
+    assert list(normalized) == ["unified_obs"]
+    assert normalized["unified_obs"] is array
 
     nested = normalize_observation({"z": array + 2, "a": {"b": array + 1}})
-    assert list(nested) == ["a.b", "z"]
-    np.testing.assert_array_equal(nested["a.b"], array + 1)
+    assert list(nested) == ["unified_a.b", "unified_z"]
+    np.testing.assert_array_equal(nested["unified_a.b"], array + 1)
+
+    selected = normalize_observation({"policy": {"joints": array}}, "policy.joints")
+    assert list(selected) == ["unified_policy.joints"]
+    assert selected["unified_policy.joints"] is array
+    with pytest.raises(KeyError, match="available keys: joints"):
+        normalize_observation({"policy": {"joints": array}}, "policy.velocity")
 
     tuple_observation = normalize_observation((array, {"velocity": array + 3}))
-    assert list(tuple_observation) == ["0", "1.velocity"]
+    assert list(tuple_observation) == ["unified_0", "unified_1.velocity"]
 
     tuple_space = spaces.Tuple(
         (
@@ -31,17 +37,37 @@ def test_observation_contract_normalizes_arrays_and_nested_mappings():
             spaces.Dict({"velocity": spaces.Box(-1, 1, (3,))}),
         )
     )
-    assert normalize_observation_space(tuple_space) == {"0": [3], "1.velocity": [3]}
+    assert normalize_observation_space(tuple_space) == {
+        "unified_0": [3],
+        "unified_1.velocity": [3],
+    }
+    assert normalize_observation_space(spaces.Box(-1, 1, (3,))) == {"unified_obs": [3]}
+    assert list(normalize_observation({"actor_obs": array})) == ["unified_actor_obs"]
+
+    class Tensor:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return array
+
+    np.testing.assert_array_equal(normalize_observation(Tensor())["unified_obs"], array)
 
 
 def test_core_batches_observation_dict_without_losing_keys():
-    observation = {"position": np.array([1.0, 2.0]), "velocity": np.array([3.0])}
+    observation = {
+        "unified_position": np.array([1.0, 2.0]),
+        "unified_velocity": np.array([3.0]),
+    }
 
     batched = batch_observation(observation)
 
-    assert list(batched) == ["position", "velocity"]
-    assert batched["position"].shape == (1, 2)
-    assert batched["velocity"].shape == (1, 1)
+    assert list(batched) == ["unified_position", "unified_velocity"]
+    assert batched["unified_position"].shape == (1, 2)
+    assert batched["unified_velocity"].shape == (1, 1)
 
 
 def test_core_and_storage_reject_legacy_list_observations():
@@ -54,10 +80,10 @@ def test_core_and_storage_reject_legacy_list_observations():
 
 
 def test_epoch_and_replay_buffers_keep_observation_keys():
-    space = {"position": [2], "velocity": [1]}
+    space = {"unified_position": [2], "unified_velocity": [1]}
     obs = {
-        "position": np.array([[1.0, 2.0]], dtype=np.float32),
-        "velocity": np.array([[3.0]], dtype=np.float32),
+        "unified_position": np.array([[1.0, 2.0]], dtype=np.float32),
+        "unified_velocity": np.array([[3.0]], dtype=np.float32),
     }
     next_obs = {key: value + 1 for key, value in obs.items()}
 
@@ -65,7 +91,7 @@ def test_epoch_and_replay_buffers_keep_observation_keys():
     epoch.add(obs, [[0]], [1.0], next_obs, [False], [False])
     epoch_data = epoch.get_buffer()
     assert set(epoch_data["obses"]) == set(space)
-    assert epoch_data["obses"]["position"].shape == (1, 1, 2)
+    assert epoch_data["obses"]["unified_position"].shape == (1, 1, 2)
 
     replay = ReplayBuffer(4, space)
     replay.add(obs, [0], 1.0, next_obs, False)
@@ -81,19 +107,25 @@ def test_crossq_critic_loss_concatenates_dict_observation_values():
 
     def preproc(_params, _key, observations):
         seen.update(observations)
-        return observations["obs"]
+        return {
+            "actor": observations["unified_obs"],
+            "critic": observations["unified_obs"],
+        }
 
     agent.preproc = preproc
     agent._get_pi_log_prob = lambda _params, features, _key: (
-        jnp.zeros((features.shape[0], 1)),
-        jnp.zeros((features.shape[0], 1)),
+        jnp.zeros((features["actor"].shape[0], 1)),
+        jnp.zeros((features["actor"].shape[0], 1)),
     )
     agent.critic = lambda params, _key, features, _actions, _training: (
-        (jnp.zeros((features.shape[0], 1)), jnp.zeros((features.shape[0], 1))),
+        (
+            jnp.zeros((features["actor"].shape[0], 1)),
+            jnp.zeros((features["actor"].shape[0], 1)),
+        ),
         {"batch_stats": params["batch_stats"]},
     )
-    observations = {"obs": jnp.ones((2, 3))}
-    next_observations = {"obs": jnp.full((2, 3), 2.0)}
+    observations = {"unified_obs": jnp.ones((2, 3))}
+    next_observations = {"unified_obs": jnp.full((2, 3), 2.0)}
 
     loss, _ = agent._critic_loss(
         {"batch_stats": {}},
@@ -110,6 +142,6 @@ def test_crossq_critic_loss_concatenates_dict_observation_values():
 
     assert jnp.isfinite(loss)
     np.testing.assert_array_equal(
-        seen["obs"],
-        jnp.concatenate([observations["obs"], next_observations["obs"]]),
+        seen["unified_obs"],
+        jnp.concatenate([observations["unified_obs"], next_observations["unified_obs"]]),
     )

--- a/tests/test_distributed_runtime_adapter_protocol.py
+++ b/tests/test_distributed_runtime_adapter_protocol.py
@@ -73,7 +73,7 @@ class _Runtime:
 class _Worker:
     def get_info(self):
         return {
-            "observation_space": {"obs": [4]},
+            "observation_space": {"unified_obs": [4]},
             "action_size": [2],
             "action_type": "discrete",
             "env_type": "single",
@@ -87,7 +87,7 @@ def test_distributed_runtime_core_surface_is_normal_python_calls():
     runtime = _Runtime()
 
     assert get_worker_env_info([_Worker()], runtime.worker_info) == (
-        {"obs": [4]},
+        {"unified_obs": [4]},
         [2],
         "SingleEnv",
     )

--- a/tests/test_distributed_worker_injection.py
+++ b/tests/test_distributed_worker_injection.py
@@ -59,7 +59,7 @@ def test_worker_builds_env_through_injected_adapter(worker_cls):
         return PreparedWorkerEnvSpec(
             env=env,
             env_info={
-                "observation_space": {"obs": [4]},
+                "observation_space": {"unified_obs": [4]},
                 "action_size": [2],
                 "action_type": "discrete",
                 "env_type": "single",
@@ -75,7 +75,7 @@ def test_worker_builds_env_through_injected_adapter(worker_cls):
 
     assert calls == [(1, 7)]
     info = worker.get_info()
-    assert info["observation_space"] == {"obs": [4]}
+    assert info["observation_space"] == {"unified_obs": [4]}
     assert info["action_size"] == [2]
     assert info["action_type"] == "discrete"
     # get_worker_env_info normalizes distributed envs to SingleEnv; the worker
@@ -90,11 +90,11 @@ def test_impala_worker_replay_factory_satisfies_seam():
     from replay_memory.replay_factory import make_impala_worker_buffer
 
     env_dict = {
-        "obs:obs": {"shape": (4,)},
+        "obs:unified_obs": {"shape": (4,)},
         "action": {"shape": 1},
         "log_prob": {},
         "reward": {},
-        "next_obs:obs": {"shape": (4,)},
+        "next_obs:unified_obs": {"shape": (4,)},
         "terminated": {},
         "truncted": {},
     }
@@ -103,11 +103,11 @@ def test_impala_worker_replay_factory_satisfies_seam():
 
     assert len(buffer) == 0
     buffer.add(
-        {"obs": np.zeros((4,))},
+        {"unified_obs": np.zeros((4,))},
         action=0,
         log_prob=0.0,
         reward=1.0,
-        nxtobs_t={"obs": np.ones((4,))},
+        nxtobs_t={"unified_obs": np.ones((4,))},
         terminated=False,
     )
     assert len(buffer) == 1
@@ -123,10 +123,10 @@ def test_apex_worker_replay_factory_satisfies_seam():
     from replay_memory.replay_factory import make_worker_replay_buffer
 
     env_dict = {
-        "obs:obs": {"shape": (4,)},
+        "obs:unified_obs": {"shape": (4,)},
         "action": {"shape": 1},
         "reward": {},
-        "next_obs:obs": {"shape": (4,)},
+        "next_obs:unified_obs": {"shape": (4,)},
         "done": {},
     }
 
@@ -134,10 +134,10 @@ def test_apex_worker_replay_factory_satisfies_seam():
 
     assert len(buffer) == 0
     buffer.add(
-        {"obs": np.zeros((4,))},
+        {"unified_obs": np.zeros((4,))},
         action=0,
         reward=1.0,
-        nxtobs_t={"obs": np.ones((4,))},
+        nxtobs_t={"unified_obs": np.ones((4,))},
         terminated=False,
     )
     assert len(buffer) == 1

--- a/tests/test_dpg_training.py
+++ b/tests/test_dpg_training.py
@@ -291,21 +291,21 @@ def test_bulk_helpers_recurse_into_dict_observations():
     agent = FakeBulkAgent()
     lifecycle = DPGTrainingLifecycle(agent)
     data = {
-        "obses": {"obs": np.ones((8, 3))},
+        "obses": {"unified_obs": np.ones((8, 3))},
         "actions": np.ones((8, 1)),
         "rewards": np.ones((8, 1)),
-        "nxtobses": {"obs": np.ones((8, 3))},
+        "nxtobses": {"unified_obs": np.ones((8, 3))},
         "terminateds": np.zeros((8, 1)),
     }
 
     reshaped = lifecycle._reshape_bulk_batch(data, chunk_size=2)
 
-    assert reshaped["obses"]["obs"].shape == (2, 4, 3)
-    assert reshaped["nxtobses"]["obs"].shape == (2, 4, 3)
+    assert reshaped["obses"]["unified_obs"].shape == (2, 4, 3)
+    assert reshaped["nxtobses"]["unified_obs"].shape == (2, 4, 3)
     assert reshaped["actions"].shape == (2, 4, 1)
     first = next(iter_bulk_batches(reshaped, (object(), object())))
-    assert first["obses"]["obs"].shape == (4, 3)
-    assert flatten_bulk_batch(reshaped)["obses"]["obs"].shape == (8, 3)
+    assert first["obses"]["unified_obs"].shape == (4, 3)
+    assert flatten_bulk_batch(reshaped)["obses"]["unified_obs"].shape == (8, 3)
 
 
 class FakeMissingBulkHookAgent(FakeAgent):

--- a/tests/test_env_builder_adapter.py
+++ b/tests/test_env_builder_adapter.py
@@ -36,18 +36,18 @@ class _DiscreteActionSpace:
 
 
 class _FakeSingleEnv:
-    observation_space = _ObservationSpace((4,))
     action_space = _DiscreteActionSpace(3)
 
     def __init__(self, seed=None):
+        self.observation_space = {"unified_obs": [4]}
         self.seed = seed
 
     def reset(self, *args, **kwargs):
-        return np.zeros(self.observation_space.shape, dtype=np.float32), {}
+        return {"unified_obs": np.zeros(4, dtype=np.float32)}, {}
 
     def step(self, action):
         return (
-            np.zeros(self.observation_space.shape, dtype=np.float32),
+            {"unified_obs": np.zeros(4, dtype=np.float32)},
             0.0,
             False,
             False,
@@ -62,7 +62,7 @@ class _FakeVectorizedEnv(VectorizedEnv):
     def __init__(self, worker_num=3):
         self.worker_num = worker_num
         self.env_info = {
-            "observation_space": {"obs": [5]},
+            "observation_space": {"unified_obs": [5]},
             "action_size": [2],
             "action_type": "continuous",
             "env_type": "fake_vector",
@@ -75,7 +75,7 @@ class _FakeVectorizedEnv(VectorizedEnv):
         return self.env_info
 
     def current_obs(self):
-        return np.zeros((self.worker_num, 5), dtype=np.float32)
+        return {"unified_obs": np.zeros((self.worker_num, 5), dtype=np.float32)}
 
     def step(self, action):
         pass
@@ -231,7 +231,7 @@ def test_get_local_env_info_consumes_adapter_prepared_single_envs():
                 env=env,
                 eval_env=_FakeSingleEnv(),
                 env_info={
-                    "observation_space": {"obs": [4]},
+                    "observation_space": {"unified_obs": [4]},
                     "action_size": [3],
                     "action_type": "discrete",
                     "env_type": "single",
@@ -248,7 +248,7 @@ def test_get_local_env_info_consumes_adapter_prepared_single_envs():
     )
 
     assert calls == [(1, 7)]
-    assert observation_space == {"obs": [4]}
+    assert observation_space == {"unified_obs": [4]}
     assert action_size == [3]
     assert worker_size == 1
     assert env_type == "SingleEnv"
@@ -273,7 +273,7 @@ def test_get_local_env_info_consumes_adapter_prepared_vectorized_envs():
     )
 
     assert calls == [(3, 11)]
-    assert observation_space == {"obs": [5]}
+    assert observation_space == {"unified_obs": [5]}
     assert action_size == [2]
     assert worker_size == 3
     assert env_type == "VectorizedEnv"
@@ -303,7 +303,7 @@ def test_get_local_env_info_requires_local_eval_env():
                 env=env,
                 eval_env=None,
                 env_info={
-                    "observation_space": {"obs": [4]},
+                    "observation_space": {"unified_obs": [4]},
                     "action_size": [3],
                     "action_type": "discrete",
                     "env_type": "single",
@@ -323,7 +323,7 @@ def test_prepare_worker_env_requires_single_worker_spec():
             return PreparedWorkerEnvSpec(
                 env=_FakeVectorizedEnv(worker_num=2),
                 env_info={
-                    "observation_space": {"obs": [5]},
+                    "observation_space": {"unified_obs": [5]},
                     "action_size": [2],
                     "action_type": "continuous",
                     "env_type": "fake_vector",
@@ -366,7 +366,7 @@ def test_env_builder_adapter_prepares_train_eval_pair_and_seed_policy():
             env_info=env.env_info
             if isinstance(env, VectorizedEnv)
             else {
-                "observation_space": {"obs": [4]},
+                "observation_space": {"unified_obs": [4]},
                 "action_size": [3],
                 "action_type": "discrete",
                 "env_type": "single",
@@ -421,7 +421,7 @@ def test_experiments_composition_path_uses_adapter_prepared_envs(monkeypatch):
             return PreparedWorkerEnvSpec(
                 env=env,
                 env_info={
-                    "observation_space": {"obs": [4]},
+                    "observation_space": {"unified_obs": [4]},
                     "action_size": [3],
                     "action_type": "discrete",
                     "env_type": "single",
@@ -449,7 +449,7 @@ def test_experiments_composition_path_uses_adapter_prepared_envs(monkeypatch):
 
     assert isinstance(env, _FakeVectorizedEnv)
     assert eval_env.seed == 121
-    assert observation_space == {"obs": [5]}
+    assert observation_space == {"unified_obs": [5]}
     assert action_size == [2]
     assert worker_size == 4
     assert env_type == "VectorizedEnv"

--- a/tests/test_flax_dpg_builder_param_tree.py
+++ b/tests/test_flax_dpg_builder_param_tree.py
@@ -32,7 +32,7 @@ from model_builder.flax.dpg.tqc_builder import (
 )
 
 _POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
-_OBSERVATION_SPACE = {"obs": [4]}
+_OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _SUPPORT_N = 25
 
@@ -140,10 +140,10 @@ def test_deterministic_builders_preserve_public_contract_and_param_roots(
     assert set(critic_params["params"]) == critic_roots
 
     key = jax.random.PRNGKey(1)
-    feature = preproc(policy_params, key, {"obs": jnp.zeros((1, 4), dtype=jnp.float32)})
+    feature = preproc(policy_params, key, {"unified_obs": jnp.zeros((1, 4), dtype=jnp.float32)})
     action = actor(policy_params, key, feature)
     values = critic(critic_params, key, feature, action)
-    assert feature.shape == (1, 4)
+    assert feature["actor"].shape == feature["critic"].shape == (1, 4)
     assert action.shape == (1, 2)
     if twin:
         assert tuple(value.shape for value in values) == ((1, 1), (1, 1))

--- a/tests/test_frame_buffer.py
+++ b/tests/test_frame_buffer.py
@@ -20,7 +20,7 @@ H = W = 6
 S = 4
 NSTEP = 3
 GAMMA = 0.99
-OBS = {"obs": [H, W, S]}  # Cf = 1 (Atari grayscale frame stack)
+OBS = {"unified_obs": [H, W, S]}  # Cf = 1 (Atari grayscale frame stack)
 EPISODES = [(10, 5), (40, 7), (80, 6)]
 
 
@@ -79,10 +79,10 @@ def _feed(buf):
         for t in range(length):
             nxt = fs.step(base + t + 1)
             buf.add(
-                {"obs": obs[None]},
+                {"unified_obs": obs[None]},
                 np.float32(1.0),
                 np.float32(base + t),
-                {"obs": nxt[None]},
+                {"unified_obs": nxt[None]},
                 t == length - 1,
                 False,
             )
@@ -99,17 +99,17 @@ def test_nstep_transitions_match_cpprb():
     fb = FrameStackReplayBuffer(1000, OBS, 1, NSTEP, GAMMA, n_frames=S)
     _feed(fb)
     ref = _reference()
-    total = len(ref["obs:obs"])
+    total = len(ref["obs:unified_obs"])
     g = fb._gather(np.arange(0, total, dtype=np.int64))
     # obs stack reconstruction is lossless
-    assert np.array_equal(g["obses"]["obs"], ref["obs:obs"])
+    assert np.array_equal(g["obses"]["unified_obs"], ref["obs:unified_obs"])
     # n-step discounted reward and done match for every row
     assert np.allclose(g["rewards"][:, 0], ref["reward"][:, 0], atol=1e-4)
     assert np.array_equal(g["terminateds"][:, 0].astype(bool), ref["done"][:, 0].astype(bool))
     # next_obs matches wherever it is used (done == 0; done == 1 is masked in the target)
     mask = ref["done"][:, 0] == 0
     assert mask.sum() > 0
-    assert np.array_equal(g["nxtobses"]["obs"][mask], ref["next_obs:obs"][mask])
+    assert np.array_equal(g["nxtobses"]["unified_obs"][mask], ref["next_obs:unified_obs"][mask])
 
 
 def test_single_frame_storage():
@@ -128,12 +128,14 @@ def test_prioritized_sample_consistent_with_ground_truth():
     leaves = s["indexes"]
     assert (leaves < pri._ready()).all()
     for i, leaf in enumerate(leaves):
-        assert np.array_equal(s["obses"]["obs"][i], ground["obses"]["obs"][leaf])
+        assert np.array_equal(s["obses"]["unified_obs"][i], ground["obses"]["unified_obs"][leaf])
         assert np.isclose(s["rewards"][i, 0], ground["rewards"][leaf, 0])
-        assert np.array_equal(s["nxtobses"]["obs"][i], ground["nxtobses"]["obs"][leaf])
+        assert np.array_equal(
+            s["nxtobses"]["unified_obs"][i], ground["nxtobses"]["unified_obs"][leaf]
+        )
     assert (s["weights"] > 0).all() and (s["weights"] <= 1.0 + 1e-6).all()
     pri.update_priorities(leaves, np.abs(np.random.randn(64)).astype(np.float32) + 0.1)
-    assert pri.sample(16)["obses"]["obs"].shape == (16, H, W, S)
+    assert pri.sample(16)["obses"]["unified_obs"].shape == (16, H, W, S)
 
 
 class _FrameBufferBulkAgent:
@@ -181,7 +183,7 @@ def test_qnet_bulk_priority_updates_flatten_for_prioritized_frame_buffer():
 
     assert loss == 2.0
     assert agent.train_steps_count == 2
-    assert pri.sample(4)["obses"]["obs"].shape == (4, H, W, S)
+    assert pri.sample(4)["obses"]["unified_obs"].shape == (4, H, W, S)
 
 
 def test_truncation_bootstraps_without_crash():
@@ -191,10 +193,10 @@ def test_truncation_bootstraps_without_crash():
     for t in range(6):
         nxt = fs.step(t + 1)
         fb.add(
-            {"obs": obs[None]},
+            {"unified_obs": obs[None]},
             np.float32(1),
             np.float32(1),
-            {"obs": nxt[None]},
+            {"unified_obs": nxt[None]},
             False,
             t == 5,
         )
@@ -204,17 +206,17 @@ def test_truncation_bootstraps_without_crash():
     for t in range(6):
         nxt = fs2.step(51 + t)
         fb.add(
-            {"obs": obs[None]},
+            {"unified_obs": obs[None]},
             np.float32(1),
             np.float32(1),
-            {"obs": nxt[None]},
+            {"unified_obs": nxt[None]},
             False,
             False,
         )
         obs = nxt
     g = fb._gather(np.arange(0, fb._ready(), dtype=np.int64))
     assert (g["terminateds"] == 0).all()  # truncation does not set done
-    assert g["obses"]["obs"].shape[1:] == (H, W, S)
+    assert g["obses"]["unified_obs"].shape[1:] == (H, W, S)
 
 
 @pytest.mark.parametrize("prioritized", [False, True])
@@ -238,7 +240,7 @@ def test_factory_keeps_cpprb_for_vector_or_singlestep():
     # vector obs -> not frame-compressible
     assert isinstance(
         make_replay_buffer(
-            _need(observation_space={"obs": [4]}, n_step=NSTEP, compress_memory=True)
+            _need(observation_space={"unified_obs": [4]}, n_step=NSTEP, compress_memory=True)
         ),
         Cpprb,
     )

--- a/tests/test_haiku_dpg_builder_param_tree.py
+++ b/tests/test_haiku_dpg_builder_param_tree.py
@@ -30,7 +30,7 @@ from model_builder.haiku.dpg.tqc_builder import (
 )
 
 _POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
-_OBSERVATION_SPACE = {"obs": [4]}
+_OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _TQC_SUPPORT_N = 25
 

--- a/tests/test_issue7_contracts.py
+++ b/tests/test_issue7_contracts.py
@@ -128,7 +128,7 @@ def test_apex_dpg_constructors_initialize_model_setup_dependencies(monkeypatch, 
     class _Worker:
         def get_info(self):
             return {
-                "observation_space": {"obs": [3]},
+                "observation_space": {"unified_obs": [3]},
                 "action_size": [1],
                 "action_type": "continuous",
                 "env_type": "single",
@@ -209,14 +209,14 @@ def test_flax_ac_continuous_actor_initializes_log_std_param():
     from model_builder.flax.ac.ac_builder import model_builder_maker
 
     builder = model_builder_maker(
-        {"obs": [3]},
+        {"unified_obs": [3]},
         [1],
         "continuous",
         {"node": 8, "hidden_n": 1, "embedding_mode": "normal"},
     )
     preproc, actor, critic, params = builder(jax.random.PRNGKey(0))
 
-    obs = {"obs": np.zeros((1, 3), dtype=np.float32)}
+    obs = {"unified_obs": np.zeros((1, 3), dtype=np.float32)}
     feature = preproc(params, None, obs)
     mu, log_std = actor(params, None, feature)
     value = critic(params, None, feature)

--- a/tests/test_observation_role_isolation.py
+++ b/tests/test_observation_role_isolation.py
@@ -1,0 +1,84 @@
+"""Policy outputs must not leak privileged critic-only observations."""
+
+import importlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("backend", ["flax", "haiku"])
+@pytest.mark.parametrize("family", ["ac", "dpg"])
+def test_actor_critic_observation_roles_are_isolated(backend, family):
+    module = importlib.import_module(
+        f"model_builder.{backend}.{family}.{'ac' if family == 'ac' else 'ddpg'}_builder"
+    )
+    space = {"actor_sensor": [2], "critic_privileged": [3], "unified_command": [1]}
+    kwargs = {"node": 16, "hidden_n": 1}
+    key = jax.random.PRNGKey(3)
+    if family == "ac":
+        preproc, actor, critic, params = module.model_builder_maker(
+            space, (2,), "continuous", kwargs
+        )(key)
+        critic_params = params
+    elif backend == "flax":
+        preproc, actor, critic, params, critic_params = module.model_builder_maker(
+            space, (2,), kwargs
+        )(key)
+    else:
+        preproc, actor, critic, params = module.model_builder_maker(space, (2,), kwargs)(key)
+        critic_params = params
+
+    obs = {name: jnp.ones((2, *shape)) for name, shape in space.items()}
+
+    def outputs(observations):
+        feature = preproc(params, key, observations)
+        policy = actor(params, key, feature)
+        value = (
+            critic(critic_params, key, feature)
+            if family == "ac"
+            else critic(critic_params, key, feature, jnp.zeros((2, 2)))
+        )
+        return policy[0] if family == "ac" else policy, value
+
+    features = preproc(params, key, obs)
+    assert features["actor"].shape == (2, 3)
+    assert features["critic"].shape == (2, 4)
+    for role, name in (("actor", "actor_sensor"), ("critic", "critic_privileged")):
+        changed = preproc(params, key, {**obs, name: obs[name] * 7})
+        assert not np.array_equal(changed[role], features[role])
+    shared = preproc(params, key, {**obs, "unified_command": obs["unified_command"] * 7})
+    for role in ("actor", "critic"):
+        assert not np.array_equal(shared[role], features[role])
+
+    policy, value = outputs(obs)
+    actor_changed, critic_unchanged = outputs({**obs, "actor_sensor": obs["actor_sensor"] * 7})
+    actor_unchanged, _ = outputs({**obs, "critic_privileged": obs["critic_privileged"] * 7})
+    shared_actor, _ = outputs({**obs, "unified_command": obs["unified_command"] * 7})
+    np.testing.assert_array_equal(actor_unchanged, policy)
+    np.testing.assert_array_equal(critic_unchanged, value)
+    assert not np.allclose(actor_changed, policy)
+    assert not np.allclose(shared_actor, policy)
+
+
+@pytest.mark.parametrize("backend", ["flax", "haiku"])
+def test_td7_encoder_and_actor_ignore_privileged_observations(backend):
+    module = importlib.import_module(f"model_builder.{backend}.dpg.td7_builder")
+    space = {"actor_sensor": [2], "critic_privileged": [3], "unified_command": [1]}
+    key = jax.random.PRNGKey(3)
+    built = module.model_builder_maker(space, (2,), {"node": 16, "hidden_n": 1})(key)
+    preproc, encoder, _, actor, _ = built[:5]
+    encoder_params, policy_params = built[5:7]
+    obs = {name: jnp.ones((2, *shape)) for name, shape in space.items()}
+    feature = preproc(encoder_params, key, obs)
+    privileged = preproc(
+        encoder_params, key, {**obs, "critic_privileged": obs["critic_privileged"] * 7}
+    )
+    zs = encoder(encoder_params, key, feature)
+    privileged_zs = encoder(encoder_params, key, privileged)
+    np.testing.assert_array_equal(privileged_zs, zs)
+    np.testing.assert_array_equal(
+        actor(policy_params, key, feature, zs),
+        actor(policy_params, key, privileged, privileged_zs),
+    )

--- a/tests/test_qnet_eval_mode.py
+++ b/tests/test_qnet_eval_mode.py
@@ -113,7 +113,7 @@ def test_iqn_get_actions_uses_observation_batch_for_tau_not_worker_size():
     actions = IQN._get_actions(
         stub,
         BEHAVIOR_PARAMS,
-        {"obs": np.zeros((1, 4), dtype=np.float32)},
+        {"unified_obs": np.zeros((1, 4), dtype=np.float32)},
         jax.random.PRNGKey(0),
     )
 

--- a/tests/test_replay_factory_injection.py
+++ b/tests/test_replay_factory_injection.py
@@ -56,7 +56,7 @@ def test_q_network_family_uses_injected_replay_factory():
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
     agent.buffer_size = 123
-    agent.observation_space = {"obs": [4]}
+    agent.observation_space = {"unified_obs": [4]}
     agent.worker_size = 2
     agent.n_step = 3
     agent.n_step_method = True
@@ -72,7 +72,7 @@ def test_q_network_family_uses_injected_replay_factory():
     assert factory.calls == [
         LocalReplayNeed(
             buffer_size=123,
-            observation_space={"obs": [4]},
+            observation_space={"unified_obs": [4]},
             action_shape_or_n=1,
             worker_size=2,
             n_step=3,
@@ -89,7 +89,7 @@ def test_dpg_family_uses_injected_replay_factory():
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
     agent.buffer_size = 456
-    agent.observation_space = {"obs": [8]}
+    agent.observation_space = {"unified_obs": [8]}
     agent.action_size = [2]
     agent.worker_size = 4
     agent.n_step = 2
@@ -105,7 +105,7 @@ def test_dpg_family_uses_injected_replay_factory():
     assert factory.calls == [
         LocalReplayNeed(
             buffer_size=456,
-            observation_space={"obs": [8]},
+            observation_space={"unified_obs": [8]},
             action_shape_or_n=[2],
             worker_size=4,
             n_step=2,
@@ -129,7 +129,7 @@ def test_apex_families_use_injected_replay_topology(family_cls, action_shape_or_
     replay_factory = FakeApeXReplayFactory(fake_buffer, worker_factory)
     agent.apex_replay_factory = replay_factory
     agent.buffer_size = 789
-    agent.observation_space = {"obs": [5]}
+    agent.observation_space = {"unified_obs": [5]}
     agent.action_size = [3]
     agent.prioritized_replay_alpha = 0.8
     agent.prioritized_replay_eps = 0.02
@@ -145,7 +145,7 @@ def test_apex_families_use_injected_replay_topology(family_cls, action_shape_or_
     assert replay_factory.calls == [
         SharedPrioritizedReplayNeed(
             buffer_size=789,
-            observation_space={"obs": [5]},
+            observation_space={"unified_obs": [5]},
             action_shape_or_n=action_shape_or_n,
             n_step=4,
             gamma=0.91,
@@ -171,7 +171,7 @@ def test_multi_prioritized_replay_factory_builds_from_need(monkeypatch):
 
     need = SharedPrioritizedReplayNeed(
         buffer_size=789,
-        observation_space={"obs": [5]},
+        observation_space={"unified_obs": [5]},
         action_shape_or_n=1,
         n_step=4,
         gamma=0.91,
@@ -185,7 +185,7 @@ def test_multi_prioritized_replay_factory_builds_from_need(monkeypatch):
     assert isinstance(buffer, FakeMultiPrioritizedReplayBuffer)
     assert calls == [
         (
-            (789, {"obs": [5]}, 0.8, 1, 4, 0.91, "manager", True),
+            (789, {"unified_obs": [5]}, 0.8, 1, 4, 0.91, "manager", True),
             {"eps": 0.02},
         )
     ]
@@ -198,7 +198,7 @@ def test_apex_replay_factory_composes_shared_and_worker_replay(monkeypatch):
     monkeypatch.setattr(replay_factory, "make_multi_prioritized_buffer", lambda need: shared)
     need = SharedPrioritizedReplayNeed(
         buffer_size=1,
-        observation_space={"obs": [4]},
+        observation_space={"unified_obs": [4]},
         action_shape_or_n=1,
         n_step=1,
         gamma=0.99,
@@ -227,7 +227,7 @@ def test_impala_family_uses_rollout_need_for_runtime_buffer():
     agent.runtime = runtime
     agent.buffer_size = 64
     agent.worker_num = 2
-    agent.observation_space = {"obs": [4]}
+    agent.observation_space = {"unified_obs": [4]}
     agent.action_type = "continuous"
     agent.action_size = [3]
     agent.sample_size = 5
@@ -240,7 +240,7 @@ def test_impala_family_uses_rollout_need_for_runtime_buffer():
         ImpalaRolloutNeed(
             replay_size=64,
             actor_num=2,
-            observation_space={"obs": [4]},
+            observation_space={"unified_obs": [4]},
             discrete=False,
             action_space=[3],
             sample_size=5,
@@ -266,7 +266,7 @@ def test_ray_distributed_runtime_builds_impala_buffer_from_need(monkeypatch):
     need = ImpalaRolloutNeed(
         replay_size=64,
         actor_num=2,
-        observation_space={"obs": [4]},
+        observation_space={"unified_obs": [4]},
         discrete=False,
         action_space=[3],
         sample_size=5,
@@ -278,7 +278,7 @@ def test_ray_distributed_runtime_builds_impala_buffer_from_need(monkeypatch):
     assert isinstance(buffer, FakeRayImpalaBuffer)
     assert calls == [
         (
-            (64, 2, {"obs": [4]}),
+            (64, 2, {"unified_obs": [4]}),
             {"discrete": False, "action_space": [3], "sample_size": 5, "seed": 7},
         )
     ]
@@ -292,7 +292,7 @@ def test_spr_uses_injected_transition_replay_factory():
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
     agent.buffer_size = 321
-    agent.observation_space = {"obs": [84, 84, 4]}
+    agent.observation_space = {"unified_obs": [84, 84, 4]}
     agent.worker_size = 1
     agent.n_step = 3
     agent.n_step_method = True
@@ -309,7 +309,7 @@ def test_spr_uses_injected_transition_replay_factory():
     assert factory.calls == [
         SelfPredictionReplayNeed(
             buffer_size=321,
-            observation_space={"obs": [84, 84, 4]},
+            observation_space={"unified_obs": [84, 84, 4]},
             action_shape_or_n=1,
             worker_size=1,
             n_step=3,
@@ -336,7 +336,7 @@ def test_replay_factory_builds_self_prediction_buffer_from_need():
     buf = make_replay_buffer(
         SelfPredictionReplayNeed(
             buffer_size=321,
-            observation_space={"obs": [84, 84, 4]},
+            observation_space={"unified_obs": [84, 84, 4]},
             action_shape_or_n=1,
             n_step=3,
             gamma=0.99,
@@ -355,7 +355,7 @@ def test_replay_factory_builds_self_prediction_buffer_from_need():
         (
             SelfPredictionReplayNeed(
                 buffer_size=321,
-                observation_space={"obs": [84, 84, 4]},
+                observation_space={"unified_obs": [84, 84, 4]},
                 action_shape_or_n=1,
                 compress_observations=True,
                 prediction_depth=5,
@@ -365,7 +365,7 @@ def test_replay_factory_builds_self_prediction_buffer_from_need():
         (
             SelfPredictionReplayNeed(
                 buffer_size=321,
-                observation_space={"obs": [84, 84, 4]},
+                observation_space={"unified_obs": [84, 84, 4]},
                 action_shape_or_n=1,
                 worker_size=2,
                 prediction_depth=5,

--- a/tests/test_returns_episode_boundary.py
+++ b/tests/test_returns_episode_boundary.py
@@ -187,7 +187,7 @@ class _ScriptEnv:
         self.awaiting_result = False
 
     def current_obs(self):
-        return {"obs": np.zeros((self.ws, 2), dtype=np.float32)}
+        return {"unified_obs": np.zeros((self.ws, 2), dtype=np.float32)}
 
     def step(self, actions):
         if self.awaiting_result:
@@ -205,7 +205,7 @@ class _ScriptEnv:
         # Nonzero so the dummy-step reward zeroing is observable in the buffer.
         rewards = np.ones(self.ws, dtype=np.float32)
         truncs = np.zeros(self.ws, dtype=bool)
-        return {"obs": nxt}, rewards, terms, truncs, {}
+        return {"unified_obs": nxt}, rewards, terms, truncs, {}
 
 
 class _LivesScriptEnv(_ScriptEnv):
@@ -222,7 +222,7 @@ class _LivesScriptEnv(_ScriptEnv):
         terms, truncs, lives = self._rows[self._t]
         self._t += 1
         return (
-            {"obs": np.ones((self.ws, 2), dtype=np.float32)},
+            {"unified_obs": np.ones((self.ws, 2), dtype=np.float32)},
             np.ones(self.ws, dtype=np.float32),
             np.asarray(terms, dtype=bool),
             np.asarray(truncs, dtype=bool),
@@ -437,11 +437,11 @@ class _ScriptSingleEnv:
         self.received_actions = []
 
     def reset(self):
-        return {"obs": np.zeros(2, dtype=np.float32)}, {}
+        return {"unified_obs": np.zeros(2, dtype=np.float32)}, {}
 
     def step(self, action):
         self.received_actions.append(action)
-        return {"obs": np.ones(2, dtype=np.float32)}, 1.0, False, False, {}
+        return {"unified_obs": np.ones(2, dtype=np.float32)}, 1.0, False, False, {}
 
 
 def test_a2c_single_env_action_plumbing_and_buffer_shape():

--- a/tests/test_review_replay_env_regressions.py
+++ b/tests/test_review_replay_env_regressions.py
@@ -14,15 +14,15 @@ from replay_memory.frame_buffers import FrameStackReplayBuffer
 def test_nstep_truncation_projects_zero_termination(prioritized):
     cls = PrioritizedNstepReplayBuffer if prioritized else NstepReplayBuffer
     kwargs = {"alpha": 0.6} if prioritized else {}
-    buf = cls(32, {"obs": [1]}, worker_size=1, n_step=3, gamma=0.99, **kwargs)
+    buf = cls(32, {"unified_obs": [1]}, worker_size=1, n_step=3, gamma=0.99, **kwargs)
 
     for step in range(2):
         obs = np.array([[step]], dtype=np.float32)
         buf.add(
-            {"obs": obs},
+            {"unified_obs": obs},
             np.array([0.0], dtype=np.float32),
             np.float32(1.0),
-            {"obs": obs + 1},
+            {"unified_obs": obs + 1},
             False,
             step == 1,
         )
@@ -34,7 +34,7 @@ def test_nstep_truncation_projects_zero_termination(prioritized):
 def test_vector_nstep_truncation_stores_zero_termination(prioritized):
     cls = PrioritizedNstepReplayBuffer if prioritized else NstepReplayBuffer
     kwargs = {"alpha": 0.6} if prioritized else {}
-    buf = cls(32, {"obs": [1]}, worker_size=2, n_step=3, gamma=0.99, **kwargs)
+    buf = cls(32, {"unified_obs": [1]}, worker_size=2, n_step=3, gamma=0.99, **kwargs)
     action = np.zeros((2, 1), dtype=np.float32)
     reward = np.ones(2, dtype=np.float32)
     only_first_worker = np.array([True, False])
@@ -42,10 +42,10 @@ def test_vector_nstep_truncation_stores_zero_termination(prioritized):
     for step in range(2):
         obs = np.array([[step], [0]], dtype=np.float32)
         buf.add(
-            {"obs": obs},
+            {"unified_obs": obs},
             action,
             reward,
-            {"obs": obs + 1},
+            {"unified_obs": obs + 1},
             np.zeros(2, dtype=bool),
             np.array([step == 1, False]),
             store_mask=only_first_worker,
@@ -55,7 +55,7 @@ def test_vector_nstep_truncation_stores_zero_termination(prioritized):
 
 
 def test_vector_nstep_replay_emits_during_long_episode_without_staging_cap():
-    buf = NstepReplayBuffer(3000, {"obs": [1]}, worker_size=2, n_step=3, gamma=0.99)
+    buf = NstepReplayBuffer(3000, {"unified_obs": [1]}, worker_size=2, n_step=3, gamma=0.99)
     action = np.zeros((2, 1), dtype=np.float32)
     reward = np.ones(2, dtype=np.float32)
     no_done = np.zeros(2, dtype=bool)
@@ -64,10 +64,10 @@ def test_vector_nstep_replay_emits_during_long_episode_without_staging_cap():
     for step in range(2005):
         obs = np.array([[step], [0]], dtype=np.float32)
         buf.add(
-            {"obs": obs},
+            {"unified_obs": obs},
             action,
             reward,
-            {"obs": obs + 1},
+            {"unified_obs": obs + 1},
             no_done,
             no_done,
             store_mask=only_first_worker,
@@ -77,10 +77,10 @@ def test_vector_nstep_replay_emits_during_long_episode_without_staging_cap():
 
     obs = np.array([[2005], [0]], dtype=np.float32)
     buf.add(
-        {"obs": obs},
+        {"unified_obs": obs},
         action,
         reward,
-        {"obs": obs + 1},
+        {"unified_obs": obs + 1},
         np.array([True, False]),
         no_done,
         store_mask=only_first_worker,
@@ -91,7 +91,7 @@ def test_vector_nstep_replay_emits_during_long_episode_without_staging_cap():
 def test_frame_replay_uses_supplied_next_observation_at_truncation():
     buf = FrameStackReplayBuffer(
         16,
-        observation_space={"obs": [1, 1, 4]},
+        observation_space={"unified_obs": [1, 1, 4]},
         action_space=1,
         n_step=3,
         gamma=0.99,
@@ -101,18 +101,18 @@ def test_frame_replay_uses_supplied_next_observation_at_truncation():
     mid = np.array([[[[10, 10, 10, 11]]]], dtype=np.uint8)
     boundary_next = np.array([[[[10, 10, 11, 12]]]], dtype=np.uint8)
 
-    buf.add({"obs": obs}, np.float32(0), np.float32(1), {"obs": mid}, False, False)
+    buf.add({"unified_obs": obs}, np.float32(0), np.float32(1), {"unified_obs": mid}, False, False)
     buf.add(
-        {"obs": mid},
+        {"unified_obs": mid},
         np.float32(0),
         np.float32(1),
-        {"obs": boundary_next},
+        {"unified_obs": boundary_next},
         False,
         True,
     )
 
     transition = buf._gather(np.array([0], dtype=np.int64))
-    assert np.array_equal(transition["nxtobses"]["obs"][0], boundary_next[0])
+    assert np.array_equal(transition["nxtobses"]["unified_obs"][0], boundary_next[0])
     assert transition["terminateds"][0, 0] == 0
 
 
@@ -120,7 +120,9 @@ def test_gym_vector_fast_path_honors_seed():
     first = GymVectorizedEnv("CartPole-v1", worker_num=2, seed=123)
     second = GymVectorizedEnv("CartPole-v1", worker_num=2, seed=123)
     try:
-        assert np.array_equal(first.current_obs()["obs"], second.current_obs()["obs"])
+        assert np.array_equal(
+            first.current_obs()["unified_obs"], second.current_obs()["unified_obs"]
+        )
     finally:
         first.close()
         second.close()

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -125,19 +125,19 @@ class FakeSingleEnv:
     def reset(self):
         self.rec.append(("reset",))
         self.c += 1
-        return {"obs": np.array([float(self.c)])}, {}
+        return {"unified_obs": np.array([float(self.c)])}, {}
 
     def true_reset(self):
         self.rec.append(("true_reset",))
         self.c += 1
-        return {"obs": np.array([float(self.c)])}, {}
+        return {"unified_obs": np.array([float(self.c)])}, {}
 
     def step(self, action):
         self.rec.append(("env_step", rep(action)))
         r, term, trunc = self.script[self.t]
         self.t += 1
         self.c += 1
-        return {"obs": np.array([float(self.c)])}, r, term, trunc, {}
+        return {"unified_obs": np.array([float(self.c)])}, r, term, trunc, {}
 
 
 class FakeVecEnv:
@@ -151,7 +151,7 @@ class FakeVecEnv:
 
     def current_obs(self):
         self.c += 1
-        return {"obs": np.array([float(self.c)] * self.ws)}
+        return {"unified_obs": np.array([float(self.c)] * self.ws)}
 
     def step(self, actions):
         self.rec.append(("env_step", rep(actions)))
@@ -160,7 +160,7 @@ class FakeVecEnv:
 
     def get_result(self):
         rewards, terms, truncs = self._last
-        nxt = {"obs": np.array([float(self.c) + 0.5] * self.ws)}
+        nxt = {"unified_obs": np.array([float(self.c) + 0.5] * self.ws)}
         return nxt, rewards, terms, truncs, {}
 
     def true_reset(self):
@@ -849,7 +849,7 @@ def test_qnet_single_action_double_indexes_discrete_action():
     agent.update_eps = 0.5
     agent.actions = lambda obs, eps: np.array([[7]])
 
-    sel = agent._single_action_selection(["obs"], steps=3)
+    sel = agent._single_action_selection(["unified_obs"], steps=3)
 
     assert sel.env_action == 7
     assert list(sel.store_action) == [7]
@@ -880,7 +880,7 @@ def test_dpg_single_action_single_indexes_continuous_action():
     agent = Deteministic_Policy_Gradient_Family.__new__(Deteministic_Policy_Gradient_Family)
     agent.actions = lambda obs, steps: np.array([[0.5]])
 
-    sel = agent._single_action_selection(["obs"], steps=3)
+    sel = agent._single_action_selection(["unified_obs"], steps=3)
 
     assert list(sel.env_action) == [0.5]
     assert list(sel.store_action) == [0.5]
@@ -925,7 +925,7 @@ class _ShapeCheckingEvalEnv:
         self.actions = []
 
     def reset(self):
-        return {"obs": np.zeros(3)}, {}
+        return {"unified_obs": np.zeros(3)}, {}
 
     def step(self, action):
         action = np.asarray(action)
@@ -934,7 +934,7 @@ class _ShapeCheckingEvalEnv:
                 f"Action dimension mismatch. Expected {self.action_shape}, found {action.shape}"
             )
         self.actions.append(action)
-        return {"obs": np.zeros(3)}, 0.0, True, False, {}
+        return {"unified_obs": np.zeros(3)}, 0.0, True, False, {}
 
 
 def _dpg_action_agent():
@@ -949,7 +949,7 @@ def _dpg_action_agent():
     agent.worker_size = 1
     agent.action_size = (1,)
     agent._select_action_state = lambda eval, steps: {"encoder": None, "policy": None}
-    agent._policy_action_from_state = lambda state, obs, eval, steps: np.asarray(obs["obs"])
+    agent._policy_action_from_state = lambda state, obs, eval, steps: np.asarray(obs["unified_obs"])
     agent._apply_action_noise = lambda actions, steps, eval: actions
     return agent
 
@@ -957,23 +957,23 @@ def _dpg_action_agent():
 def test_dpg_rollout_actions_use_policy_update_normalizer_and_update_live_rms():
     agent = _dpg_action_agent()
 
-    action = agent.actions({"obs": np.array([1.0])}, steps=5, eval=False)
+    action = agent.actions({"unified_obs": np.array([1.0])}, steps=5, eval=False)
 
     assert np.array_equal(action, np.array([11.0]))
-    assert agent.obs_rms.calls == [("update", {"obs": np.array([1.0])})]
-    assert agent.action_obs_rms.calls == [("normalize", {"obs": np.array([1.0])})]
+    assert agent.obs_rms.calls == [("update", {"unified_obs": np.array([1.0])})]
+    assert agent.action_obs_rms.calls == [("normalize", {"unified_obs": np.array([1.0])})]
     assert agent.checkpoint_obs_rms.calls == []
 
 
 def test_dpg_eval_actions_use_checkpoint_normalizer():
     agent = _dpg_action_agent()
 
-    action = agent.actions({"obs": np.array([1.0])}, steps=5, eval=True)
+    action = agent.actions({"unified_obs": np.array([1.0])}, steps=5, eval=True)
 
     assert np.array_equal(action, np.array([1001.0]))
     assert agent.obs_rms.calls == []
     assert agent.action_obs_rms.calls == []
-    assert agent.checkpoint_obs_rms.calls == [("normalize", {"obs": np.array([1.0])})]
+    assert agent.checkpoint_obs_rms.calls == [("normalize", {"unified_obs": np.array([1.0])})]
 
 
 def test_dpg_eval_skips_random_warmup_and_uses_policy_action():

--- a/tests/test_rollout_stats.py
+++ b/tests/test_rollout_stats.py
@@ -111,13 +111,13 @@ class _ScriptedSingleEnv:
         self.t = 0
 
     def reset(self):
-        return {"obs": np.zeros(1, dtype=np.float32)}, {}
+        return {"unified_obs": np.zeros(1, dtype=np.float32)}, {}
 
     def step(self, action):
         reward, terminated, truncated = self.script[self.t]
         info = self.infos[self.t]
         self.t += 1
-        return {"obs": np.zeros(1, dtype=np.float32)}, reward, terminated, truncated, info
+        return {"unified_obs": np.zeros(1, dtype=np.float32)}, reward, terminated, truncated, info
 
 
 class _ScriptedVecEnv:
@@ -128,7 +128,7 @@ class _ScriptedVecEnv:
         self.i = 0
 
     def current_obs(self):
-        return {"obs": np.zeros((self.ws, 1), dtype=np.float32)}
+        return {"unified_obs": np.zeros((self.ws, 1), dtype=np.float32)}
 
     def step(self, actions):
         pass
@@ -138,7 +138,7 @@ class _ScriptedVecEnv:
         infos = self.infos[self.i]
         self.i += 1
         return (
-            {"obs": np.zeros((self.ws, 1), dtype=np.float32)},
+            {"unified_obs": np.zeros((self.ws, 1), dtype=np.float32)},
             rewards,
             terminateds,
             truncateds,

--- a/tests/test_runtime_adapters.py
+++ b/tests/test_runtime_adapters.py
@@ -24,10 +24,10 @@ class _OneStepEnv:
 
     def reset(self):
         self.reset_count += 1
-        return {"obs": np.array([0.0])}, {}
+        return {"unified_obs": np.array([0.0])}, {}
 
     def step(self, action):
-        return {"obs": np.array([0.0])}, 3.0, True, False, {}
+        return {"unified_obs": np.array([0.0])}, 3.0, True, False, {}
 
     def close(self):
         self.closed = True
@@ -104,7 +104,7 @@ def test_core_record_and_test_uses_worker_env_protocol(tmp_path):
             return PreparedWorkerEnvSpec(
                 env=env,
                 env_info={
-                    "observation_space": {"obs": [1]},
+                    "observation_space": {"unified_obs": [1]},
                     "action_size": [2],
                     "action_type": "discrete",
                     "env_type": "single",

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
+import pytest
 
 from experiments.cli.dpg import DPG_RUNNER
 from jax_baselines.CrossQ.crossq import CrossQ
@@ -33,51 +34,66 @@ def test_dpg_eval_path_uses_sac_mode_without_sampling():
     agent.learning_starts = 100
     agent.use_checkpointing = False
     agent.policy_params = None
-    agent.preproc = lambda params, key, obs: obs["obs"]
-    agent.actor = lambda params, key, feature: (feature, jnp.full_like(feature, 10.0))
+    agent.preproc = lambda params, key, obs: {
+        "actor": obs["unified_obs"],
+        "critic": obs["unified_obs"],
+    }
+    agent.actor = lambda params, key, feature: (
+        feature["actor"],
+        jnp.full_like(feature["actor"], 10.0),
+    )
 
-    obs = {"obs": jnp.array([[0.25, -0.5]])}
+    obs = {"unified_obs": jnp.array([[0.25, -0.5]])}
     actions = agent.actions(obs, steps=0, eval=True)
 
-    np.testing.assert_allclose(actions, jnp.tanh(obs["obs"]))
+    np.testing.assert_allclose(actions, jnp.tanh(obs["unified_obs"]))
 
 
 def test_sac_actor_loss_uses_minimum_expected_q():
     agent = object.__new__(SAC)
     agent.preproc = lambda params, key, obs: obs
     agent._get_pi_log_prob = lambda params, feature, key: (
-        jnp.zeros((feature.shape[0], 1)),
-        jnp.zeros((feature.shape[0], 1)),
+        jnp.zeros((feature["actor"].shape[0], 1)),
+        jnp.zeros((feature["actor"].shape[0], 1)),
     )
     agent.critic = lambda params, key, feature, policy: (
         jnp.array([[0.0], [10.0]]),
         jnp.array([[4.0], [2.0]]),
     )
 
-    loss, _ = SAC._actor_loss(agent, None, None, jnp.ones((2, 1)), None, 0.01)
+    loss, _ = SAC._actor_loss(
+        agent,
+        None,
+        None,
+        {"actor": jnp.ones((2, 1)), "critic": jnp.ones((2, 1))},
+        None,
+        0.01,
+    )
 
     np.testing.assert_allclose(loss, -1.0)
 
 
-def test_other_stochastic_dpg_algorithms_also_use_mode_for_evaluation():
-    obs = {"obs": jnp.array([[0.25, -0.5]])}
+@pytest.mark.parametrize("cls", [TQC, CrossQ])
+def test_other_stochastic_dpg_algorithms_also_use_mode_for_evaluation(cls):
+    obs = {"unified_obs": jnp.array([[0.25, -0.5]])}
 
-    tqc = object.__new__(TQC)
-    tqc.preproc = lambda params, key, value: value["obs"]
-    tqc.actor = lambda params, key, feature: (feature, jnp.full_like(feature, 10.0))
+    agent = object.__new__(cls)
+    agent.preproc = lambda params, key, value: {
+        "actor": value["unified_obs"],
+        "critic": value["unified_obs"],
+    }
+    agent.actor = lambda params, key, feature: (
+        feature["actor"],
+        jnp.full_like(feature["actor"], 10.0),
+    )
 
-    crossq = object.__new__(CrossQ)
-    crossq.preproc = lambda params, key, value: value["obs"]
-    crossq.actor = lambda params, key, feature: (feature, jnp.full_like(feature, 10.0))
-
-    np.testing.assert_allclose(tqc._get_eval_actions(None, obs), jnp.tanh(obs["obs"]))
-    np.testing.assert_allclose(crossq._get_eval_actions(None, obs), jnp.tanh(obs["obs"]))
+    np.testing.assert_allclose(agent._get_eval_actions(None, obs), jnp.tanh(obs["unified_obs"]))
 
 
 def test_crossq_actors_have_no_batch_stats_but_critics_do():
     for make_builder in (crossq_model_builder_maker, simba_crossq_model_builder_maker):
         builder = make_builder(
-            {"obs": [4]},
+            {"unified_obs": [4]},
             [2],
             {"node": 16, "hidden_n": 1, "embedding_mode": "normal"},
         )
@@ -86,7 +102,7 @@ def test_crossq_actors_have_no_batch_stats_but_critics_do():
         assert "batch_stats" not in policy_params
         assert "batch_stats" in critic_params
 
-        feature = preproc(policy_params, None, {"obs": jnp.zeros((2, 4))})
+        feature = preproc(policy_params, None, {"unified_obs": jnp.zeros((2, 4))})
         mu, log_std = actor(policy_params, None, feature)
         (q1, q2), updates = critic(critic_params, None, feature, jnp.zeros((2, 2)), True)
 
@@ -109,10 +125,13 @@ def test_flashsac_entropy_target_and_defaults():
 
 def test_sac_actor_and_temperature_update_on_configured_period():
     agent = object.__new__(SAC)
-    agent.preproc = lambda params, key, obs: obs["obs"]
+    agent.preproc = lambda params, key, obs: {
+        "actor": obs["unified_obs"],
+        "critic": obs["unified_obs"],
+    }
     agent.actor = lambda params, key, feature: (
-        jnp.full((feature.shape[0], 1), params),
-        jnp.full((feature.shape[0], 1), -1.0),
+        jnp.full((feature["actor"].shape[0], 1), params),
+        jnp.full((feature["actor"].shape[0], 1), -1.0),
     )
     agent.critic = lambda params, key, feature, actions: (
         params + actions,
@@ -136,10 +155,10 @@ def test_sac_actor_and_temperature_update_on_configured_period():
     log_ent_coef = jnp.log(jnp.asarray(0.01))
     opt_ent_coef_state = agent.ent_coef_optimizer.init(log_ent_coef)
     data = {
-        "obses": {"obs": jnp.ones((2, 1))},
+        "obses": {"unified_obs": jnp.ones((2, 1))},
         "actions": jnp.zeros((2, 1)),
         "rewards": jnp.zeros((2, 1)),
-        "nxtobses": {"obs": jnp.ones((2, 1))},
+        "nxtobses": {"unified_obs": jnp.ones((2, 1))},
         "terminateds": jnp.zeros((2, 1)),
     }
 
@@ -211,10 +230,10 @@ def test_sac_actor_and_target_use_distinct_fresh_keys():
         key,
         1,
         log_ent_coef,
-        obses={"obs": jnp.zeros((1, 1))},
+        obses={"unified_obs": jnp.zeros((1, 1))},
         actions=jnp.zeros((1, 1)),
         rewards=jnp.zeros((1, 1)),
-        nxtobses={"obs": jnp.zeros((1, 1))},
+        nxtobses={"unified_obs": jnp.zeros((1, 1))},
         terminateds=jnp.zeros((1, 1)),
     )
     target_key, _, actor_key = jax.random.split(key, 3)

--- a/tests/test_scaled_by_reset.py
+++ b/tests/test_scaled_by_reset.py
@@ -34,17 +34,17 @@ from model_builder.flax.dpg.td3_builder import (
 )
 
 _POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
-_OBSERVATION_SPACE = {"obs": [4]}
+_OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _BATCH_SIZE = 8
 
 
 def _batch():
     return {
-        "obses": {"obs": np.ones((_BATCH_SIZE, 4), dtype=np.float32)},
+        "obses": {"unified_obs": np.ones((_BATCH_SIZE, 4), dtype=np.float32)},
         "actions": np.zeros((_BATCH_SIZE, _ACTION_SIZE[0]), dtype=np.float32),
         "rewards": np.ones((_BATCH_SIZE, 1), dtype=np.float32),
-        "nxtobses": {"obs": np.full((_BATCH_SIZE, 4), 2.0, dtype=np.float32)},
+        "nxtobses": {"unified_obs": np.full((_BATCH_SIZE, 4), 2.0, dtype=np.float32)},
         "terminateds": np.zeros((_BATCH_SIZE, 1), dtype=np.float32),
     }
 

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -21,10 +21,13 @@ def _continuous_agent(cls, family):
     agent.lamda = 0.95
     agent.gae_normalize = False
     agent.gae_normalize_scope = "batch"
-    agent.preproc = lambda params, key, obses: obses["obs"]
-    agent.critic = lambda params, key, feature: jnp.zeros((*feature.shape[:-1], 1))
+    agent.preproc = lambda params, key, obses: {
+        "actor": obses["unified_obs"],
+        "critic": obses["unified_obs"],
+    }
+    agent.critic = lambda params, key, feature: jnp.zeros((*feature["critic"].shape[:-1], 1))
     agent.actor = lambda params, key, feature: (
-        jnp.zeros((*feature.shape[:-1], 2)),
+        jnp.zeros((*feature["actor"].shape[:-1], 2)),
         jnp.zeros((1, 2)),
     )
     agent.get_logprob = MethodType(family.get_logprob_continuous, agent)
@@ -32,7 +35,9 @@ def _continuous_agent(cls, family):
 
 
 def _rollout(worker_count=2, timesteps=3):
-    obses = [{"obs": np.zeros((timesteps, 3), dtype=np.float32)} for _ in range(worker_count)]
+    obses = [
+        {"unified_obs": np.zeros((timesteps, 3), dtype=np.float32)} for _ in range(worker_count)
+    ]
     actions = [np.zeros((timesteps, 2), dtype=np.float32) for _ in range(worker_count)]
     scalars = [np.zeros((timesteps, 1), dtype=np.float32) for _ in range(worker_count)]
     return obses, actions, scalars
@@ -48,12 +53,11 @@ def _rollout(worker_count=2, timesteps=3):
 def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, family, kind):
     agent = _continuous_agent(cls, family)
     agent.params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
-    agent.preproc = lambda params, key, obses: obses["obs"]
     agent.critic = lambda params, key, feature: (
-        jnp.zeros((*feature.shape[:-1], 1)) + params["bias"]
+        jnp.zeros((*feature["critic"].shape[:-1], 1)) + params["bias"]
     )
     agent.actor = lambda params, key, feature: (
-        jnp.zeros((*feature.shape[:-1], 2)) + params["bias"],
+        jnp.zeros((*feature["actor"].shape[:-1], 2)) + params["bias"],
         jnp.zeros((1, 2)),
     )
     agent.optimizer = optax.sgd(1e-3)
@@ -69,7 +73,7 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
     obses, actions, scalars = _rollout(timesteps=2)
 
     if kind == "local":
-        obses = {"obs": np.stack([observation["obs"] for observation in obses])}
+        obses = {"unified_obs": np.stack([observation["unified_obs"] for observation in obses])}
         agent.gae_normalize = False
         agent.gae_normalize_scope = "batch"
         agent.value_clip = 0.3

--- a/tests/test_transition_buffers.py
+++ b/tests/test_transition_buffers.py
@@ -5,22 +5,22 @@ from replay_memory.transition_buffers import TransitionReplayBuffer
 
 def test_self_prediction_filled_mask_keeps_terminal_reward_step(monkeypatch):
     buf = TransitionReplayBuffer(
-        10, observation_space={"obs": [1]}, action_space=1, prediction_depth=3
+        10, observation_space={"unified_obs": [1]}, action_space=1, prediction_depth=3
     )
     action = np.array([0], dtype=np.float32)
 
     buf.add(
-        {"obs": np.array([0], dtype=np.float32)},
+        {"unified_obs": np.array([0], dtype=np.float32)},
         action,
         1.0,
-        {"obs": np.array([1], dtype=np.float32)},
+        {"unified_obs": np.array([1], dtype=np.float32)},
         False,
     )
     buf.add(
-        {"obs": np.array([1], dtype=np.float32)},
+        {"unified_obs": np.array([1], dtype=np.float32)},
         action,
         2.0,
-        {"obs": np.array([2], dtype=np.float32)},
+        {"unified_obs": np.array([2], dtype=np.float32)},
         True,
     )
 

--- a/tests/test_vectorized_env_fixes.py
+++ b/tests/test_vectorized_env_fixes.py
@@ -54,21 +54,21 @@ def _batch(worker_size):
 
 
 def test_replay_buffer_no_mask_adds_every_worker():
-    buf = ReplayBuffer(100, {"obs": [2]}, 1)
+    buf = ReplayBuffer(100, {"unified_obs": [2]}, 1)
     obs, act, rew, nxt, term, trunc = _batch(3)
-    buf.add({"obs": obs}, act, rew, {"obs": nxt}, term, trunc)
+    buf.add({"unified_obs": obs}, act, rew, {"unified_obs": nxt}, term, trunc)
     assert len(buf) == 3
 
 
 def test_replay_buffer_store_mask_skips_dummy_workers():
-    buf = ReplayBuffer(100, {"obs": [2]}, 1)
+    buf = ReplayBuffer(100, {"unified_obs": [2]}, 1)
     obs, act, rew, nxt, term, trunc = _batch(3)
     # worker 0 is a post-done autoreset dummy; only workers 1 and 2 are real.
     buf.add(
-        {"obs": obs},
+        {"unified_obs": obs},
         act,
         rew,
-        {"obs": nxt},
+        {"unified_obs": nxt},
         term,
         trunc,
         store_mask=np.array([False, True, True]),
@@ -77,13 +77,13 @@ def test_replay_buffer_store_mask_skips_dummy_workers():
 
 
 def test_replay_buffer_all_dummy_mask_adds_nothing():
-    buf = ReplayBuffer(100, {"obs": [2]}, 1)
+    buf = ReplayBuffer(100, {"unified_obs": [2]}, 1)
     obs, act, rew, nxt, term, trunc = _batch(2)
     buf.add(
-        {"obs": obs},
+        {"unified_obs": obs},
         act,
         rew,
-        {"obs": nxt},
+        {"unified_obs": nxt},
         term,
         trunc,
         store_mask=np.array([False, False]),
@@ -104,14 +104,14 @@ def test_active_worker_indices_rejects_mismatched_store_mask_length():
 
 
 def test_nstep_multiworker_add_store_mask_skips_dummy_worker():
-    buf = NstepReplayBuffer(100, {"obs": [2]}, 1, worker_size=2, n_step=2)
+    buf = NstepReplayBuffer(100, {"unified_obs": [2]}, 1, worker_size=2, n_step=2)
     obs, act, rew, nxt, term, trunc = _batch(2)
     for _ in range(2):
         buf.multiworker_add(
-            {"obs": obs},
+            {"unified_obs": obs},
             act,
             rew,
-            {"obs": nxt},
+            {"unified_obs": nxt},
             term,
             trunc,
             store_mask=np.array([False, True]),
@@ -119,7 +119,7 @@ def test_nstep_multiworker_add_store_mask_skips_dummy_worker():
 
     transitions = buf.get_buffer()
     assert len(buf) == 1
-    assert np.array_equal(transitions["obs:obs"][0], obs[1])
+    assert np.array_equal(transitions["obs:unified_obs"][0], obs[1])
 
 
 # --- Fix 3: explicit --env_backend selection -----------------------------
@@ -276,7 +276,7 @@ def test_envpool_get_result_resorts_recv_into_canonical_env_order():
     obs, rew, term, _, result_infos = env.get_result()
 
     # Canonical 0..N-1 order: env0, env1, env2 -- every array re-sorted in lockstep.
-    assert obs["obs"].tolist() == [[0.0], [1.0], [2.0]]
+    assert obs["unified_obs"].tolist() == [[0.0], [1.0], [2.0]]
     assert rew.tolist() == [0.0, 1.0, 2.0]
     assert term.tolist() == [False, False, True]
     assert result_infos["reward"].tolist() == [0.0, 10.0, 20.0]

--- a/tests/test_xqc_model_variant.py
+++ b/tests/test_xqc_model_variant.py
@@ -6,7 +6,7 @@ from model_builder.flax.dpg.xqc_builder import model_builder_maker
 
 def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     builder = model_builder_maker(
-        {"obs": [4]},
+        {"unified_obs": [4]},
         [2],
         {"node": 16, "hidden_n": 1, "embedding_mode": "normal"},
     )
@@ -27,7 +27,7 @@ def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     assert critic_one["Dense_3"]["kernel"].shape == (32, 32)
     assert critic_one["Dense_4"]["kernel"].shape == (32, 101)
 
-    feature = preproc(policy_params, None, {"obs": jnp.zeros((2, 4), dtype=jnp.float32)})
+    feature = preproc(policy_params, None, {"unified_obs": jnp.zeros((2, 4), dtype=jnp.float32)})
     (mu, log_std), actor_updates = actor(policy_params, None, feature, True)
     (q1, q2), critic_updates = critic(
         critic_params, None, feature, jnp.zeros((2, 2), dtype=jnp.float32), True

--- a/tests/test_xqc_training_rules.py
+++ b/tests/test_xqc_training_rules.py
@@ -57,7 +57,9 @@ def test_xqc_categorical_q_uses_fixed_support_expectation():
 
 def test_xqc_categorical_train_step_updates_online_and_target_critics():
     agent = XQC.__new__(XQC)
-    builder = model_builder_maker({"obs": [4]}, [2], {"node": 16, "embedding_mode": "normal"})
+    builder = model_builder_maker(
+        {"unified_obs": [4]}, [2], {"node": 16, "embedding_mode": "normal"}
+    )
     (
         agent.preproc,
         agent.actor,
@@ -92,10 +94,10 @@ def test_xqc_categorical_train_step_updates_online_and_target_critics():
         jax.random.PRNGKey(1),
         1,
         log_ent_coef,
-        {"obs": jnp.zeros((4, 4))},
+        {"unified_obs": jnp.zeros((4, 4))},
         jnp.zeros((4, 2)),
         jnp.ones((4, 1)),
-        {"obs": jnp.ones((4, 4))},
+        {"unified_obs": jnp.ones((4, 4))},
         jnp.zeros((4, 1)),
     )
 


### PR DESCRIPTION
환경의 공통 관측과 actor·critic 전용 관측을 `unified_`·`actor_`·`critic_` 계약으로 통일합니다. Flax와 Haiku 빌더, CrossQ·XQC의 feature 처리, 직렬화·모델 테스트를 함께 이관해 역할별 입력이 섞이지 않도록 합니다.

스택 3/8 · base: `stack/mjlab-02-repo-maintenance` · head: `stack/mjlab-03-observation-roles`. 이 PR의 base 대비 diff를 리뷰하고 1→8 순서로 병합합니다.

| 순서 | PR | 상태 |
| --- | --- | --- |
| 1 | [#19 관측 정규화 변환 함수의 이름을 명확히 변경](https://github.com/tinker495/jax-baseline/pull/19) | 리뷰 가능 |
| 2 | [#20 로컬 생성물 제외와 저장소 설정 정리](https://github.com/tinker495/jax-baseline/pull/20) | 리뷰 가능 |
| 3 | [#21 관측 키와 actor·critic 입력 역할을 통일](https://github.com/tinker495/jax-baseline/pull/21) | 리뷰 가능 |
| 4 | [#22 AC 에피소드 경계·행동·평가 계산 수정](https://github.com/tinker495/jax-baseline/pull/22) | 리뷰 가능 |
| 5 | [#23 MJLab 환경 adapter와 Go1 실험 설정 추가](https://github.com/tinker495/jax-baseline/pull/23) | 리뷰 가능 |
| 6 | [#24 AC 관측 정규화와 체크포인트 상태 저장](https://github.com/tinker495/jax-baseline/pull/24) | Draft |
| 7 | [#25 AC 버퍼·정규화를 CPU 또는 GPU에 유지](https://github.com/tinker495/jax-baseline/pull/25) | Draft |
| 8 | [#26 Go1 롤아웃 성능·장치 전송 프로파일러 추가](https://github.com/tinker495/jax-baseline/pull/26) | 리뷰 가능 |


| 항목 | 내용 |
| --- | --- |
| git hash/diff | `f5b03ea10701aa3d1efa431571a752f006af8e99`. 이 PR의 Files changed가 검증 diff이며 미커밋 소스 변경 없음. |
| logging link | N/A — 외부 로그 서비스 미사용. 로컬 기록: `runs/pr_stack/overlays/03/VERIFICATION.md, cli-audio-dummy.log, diagnostic-comparison.json`. 주요 출력은 아래 실제 결과에 보존. |
| Command | `JAX_PLATFORMS=cpu SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy .venv/bin/python -m experiments.cli.pg --algo PPO --env CartPole-v1 --steps 32 --batch 8 --mini_batch 8 --epoch_num 1 --node 16 --hidden_n 1 --eval_num 1 --seed 3` |
| Comments | 준비된 .venv, CPU, 시드 3. 측정에서는 BLAS/OMP 스레드 1, 격리 체크아웃의 PYTHONPATH와 별도 logdir 사용. 위 명령은 동일 진입점의 저장소 루트 표기. SDL dummy는 headless 녹화용. 짧은 실행으로 수렴을 판단하지 않음. |
| 성공 기준 | 정규 관측 키로 PPO 모델을 구성하고 32스텝 학습·평가·녹화를 완료. 역할 격리 테스트 통과. |
| 실제 결과 | CLI 종료 0, 최종 평가 21.7 ± 14.0146. 관련 테스트 91개 통과 후 추출 과정에서 누락한 직렬화 키 fixture 1곳을 수정하여 해당 테스트도 통과. 조립한 커밋과 검증 overlay의 63개 파일이 byte 단위로 동일함. |

동일 경로 main 대비 Ruff 37→24, ty 158→154; 추가 진단 0개. 관측 키와 모델 feature tree 계약 변경이므로 사용자 정의 환경·모델도 새 키로 이관해야 합니다.

검증 명령은 해당 PR head를 체크아웃한 저장소 루트에서 실행합니다. 전체 스택의 최종 코드 내용은 원래 `feat/mjlab-env-adapter`의 `61dc7dd7`과 동일하게 보존했습니다.
