### PR TITLE
[4/8] AC 에피소드 경계·행동·평가 계산 수정

### DIFF
--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -81,7 +81,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         value = jnp.vstack(value)
         targets = jnp.vstack(targets)
         adv = targets - value
-        (total_loss, (critic_loss, actor_loss, entropy_loss)), grad = jax.value_and_grad(
+        (_total_loss, (critic_loss, actor_loss, entropy_loss)), grad = jax.value_and_grad(
             self._loss, has_aux=True
         )(params, obses, actions, targets, adv, key)
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
@@ -128,9 +128,10 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
 

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -32,7 +32,7 @@ from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
-class Actor_Critic_Policy_Gradient_Family(object):
+class Actor_Critic_Policy_Gradient_Family:
     _run_name = "A2C"
 
     def __init__(
@@ -57,6 +57,11 @@ class Actor_Critic_Policy_Gradient_Family(object):
         lr_annealing=False,
         checkpoint_store: CheckpointStore | None = None,
     ):
+        if use_entropy_adv_shaping:
+            if not np.isfinite(ent_coef) or ent_coef < 0:
+                raise ValueError("entropy shaping requires finite ent_coef >= 0")
+            if not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1:
+                raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
         self.env_builder = env_builder
         self.model_builder_maker = model_builder_maker
         self.num_workers = num_workers
@@ -154,15 +159,19 @@ class Actor_Critic_Policy_Gradient_Family(object):
         mu, std = self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
         return mu, jnp.exp(std)
 
-    def action_discrete(self, obs):
+    def action_discrete(self, obs, eval=False):
         prob = np.asarray(self._get_actions(self.params, obs))
+        if eval:
+            return np.argmax(prob, axis=1, keepdims=True)
         return np.expand_dims(
             np.stack([np.random.choice(self.action_size[0], p=p) for p in prob], axis=0),
             axis=1,
         )
 
-    def action_continuous(self, obs):
+    def action_continuous(self, obs, eval=False):
         mu, std = self._get_actions(self.params, obs)
+        if eval:
+            return np.asarray(mu)
         return np.random.normal(mu, std)
 
     def get_logprob_discrete(self, prob, action, key, out_prob=False):
@@ -379,10 +388,12 @@ class Actor_Critic_Policy_Gradient_Family(object):
                 truncateds,
                 infos,
             ) = self.env.get_result()
+            action_observation = self.env.current_obs()
+
             train_due = (steps + self.worker_size) % (self.batch_size * self.worker_size) == 0
             if not train_due and next_step is not end:
                 # Keep the async overlap except when train_step changes the policy.
-                next_actions = self.actions(next_obses)
+                next_actions = self.actions(action_observation)
                 send(next_actions)
 
             done = np.logical_or(terminateds, truncateds)
@@ -427,12 +438,13 @@ class Actor_Critic_Policy_Gradient_Family(object):
                 loss = self.train_step(steps, logger_run=ctx.logger_run)
                 self.lossque.append(loss)
                 if next_step is not end:
-                    next_actions = self.actions(next_obses)
+                    next_actions = self.actions(action_observation)
                     send(next_actions)
 
             if next_step is not end:
-                # Advance the pipeline: the action just sent belongs to next_obses.
-                obs = next_obses
+                # The successor stored in replay may be a terminal observation;
+                # the action just sent belongs to the env's current observation.
+                obs = action_observation
                 actions = next_actions
 
             if steps % ctx.eval_freq == 0:
@@ -445,7 +457,7 @@ class Actor_Critic_Policy_Gradient_Family(object):
         return evaluate_policy(
             self.eval_env,
             self.eval_eps,
-            self.actions,
+            lambda obs: self.actions(obs, eval=True),
             logger_run=ctx.logger_run,
             steps=steps,
             conv_action=self.conv_action,
@@ -460,7 +472,7 @@ class Actor_Critic_Policy_Gradient_Family(object):
         return record_test_fn(
             self.env_builder,
             logger_run,
-            self.actions,
+            lambda obs: self.actions(obs, eval=True),
             episode,
             conv_action=self.conv_action,
         )

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -132,7 +132,7 @@ class IMPALA(IMPALA_Family):
             terminateds,
             truncateds,
         )
-        (total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
+        (_total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
             self._loss, has_aux=True
         )(params, obses, actions, vs, adv, key)
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
@@ -185,7 +185,8 @@ class IMPALA(IMPALA_Family):
         )
         if self.use_entropy_adv_shaping:
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -22,7 +22,7 @@ from jax_baselines.math.returns import get_vtrace
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
-class IMPALA_Family(object):
+class IMPALA_Family:
     _run_name = "IMPALA"
     _learn_log_interval = 1000
 
@@ -52,6 +52,11 @@ class IMPALA_Family(object):
         worker_replay_factory: WorkerReplayBufferFactory | None = None,
         checkpoint_store: CheckpointStore | None = None,
     ):
+        if use_entropy_adv_shaping:
+            if not np.isfinite(ent_coef) or ent_coef < 0:
+                raise ValueError("entropy shaping requires finite ent_coef >= 0")
+            if not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1:
+                raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
         self.workers = workers
         self.model_builder_maker = model_builder_maker
         self.worker_replay_factory = worker_replay_factory
@@ -162,7 +167,8 @@ class IMPALA_Family(object):
             ),
             in_axes=(0, 0, 0),
         )(vs, next_value, truncateds)
-        adv = rewards + self.gamma * (1.0 - terminateds) * vs_t_plus_1 - value
+        bootstrap = jnp.where(terminateds.astype(bool), 0.0, vs_t_plus_1)
+        adv = rewards + self.gamma * bootstrap - value
         adv = rho * adv
         return vs, rho, adv
 
@@ -228,14 +234,14 @@ class IMPALA_Family(object):
                     )
 
                 def convert_action(action):
-                    return np.clip(action[0], -3.0, 3.0) / 3.0
+                    return action[0]
 
             return actor, get_action_prob, convert_action
 
         return builder
 
     def description(self):
-        return "loss : {:.3f} |".format(np.mean(self.lossque))
+        return f"loss : {np.mean(self.lossque):.3f} |"
 
     def run_name_update(self, run_name):
         return run_name
@@ -323,7 +329,7 @@ class IMPALA_Family(object):
             for steps in pbar:
                 if stop.is_set():
                     raise RuntimeError("distributed worker stopped during training")
-                loss, rho = self.train_step(steps)
+                loss, _rho = self.train_step(steps)
                 self.lossque.append(loss)
                 if steps % log_interval == 0:
                     pbar.set_description(self.description())

--- a/jax_baselines/PPO/impala_ppo.py
+++ b/jax_baselines/PPO/impala_ppo.py
@@ -53,9 +53,10 @@ class IMPALA_PPO(SurrogateIMPALA):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -57,9 +57,10 @@ class PPO(SurrogatePolicyGradient):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/SPO/impala_spo.py
+++ b/jax_baselines/SPO/impala_spo.py
@@ -54,9 +54,10 @@ class IMPALA_SPO(SurrogateIMPALA):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -84,9 +84,10 @@ class SPO(SurrogatePolicyGradient):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -229,7 +229,7 @@ class IMPALA_TPPO(IMPALA_Family):
                 params, opt_state, key = updates
                 obs, act, vs, old_prob, old_act_prob, adv = input
                 use_key, key = jax.random.split(key)
-                (total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
+                (_total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
                     self._loss, has_aux=True
                 )(params, obs, act, vs, old_prob, old_act_prob, adv, use_key)
                 updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
@@ -338,9 +338,10 @@ class IMPALA_TPPO(IMPALA_Family):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -160,7 +160,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (total_loss, (c_loss, a_loss, entropy_loss, kl),), grad = jax.value_and_grad(
+                (_total_loss, (c_loss, a_loss, entropy_loss, kl),), grad = jax.value_and_grad(
                     self._loss, has_aux=True
                 )(params, obs, act, old_value, target, old_prob, old_act_prob, adv, use_key)
                 updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
@@ -231,7 +231,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             adv * ratio
             - self.kl_coef
             * jnp.where(
-                (kl >= self.kl_range) & (ratio > 1.0),
+                (kl >= self.kl_range) & (ratio * adv >= adv),
                 kl,
                 self.kl_range,
             )
@@ -267,9 +267,10 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             1.0 + jnp.log(2.0 * jnp.pi)
         )
         if self.use_entropy_adv_shaping:
-            # Paper's shaping: psi(H) = min(alpha * H, |A| / kappa) >= 0
+            # Differential entropy can be negative; shaping must preserve the advantage sign.
             psi_h = jnp.minimum(
-                self.ent_coef * entropy_h, jnp.abs(adv) / self.entropy_adv_shaping_kappa
+                self.ent_coef * jnp.maximum(entropy_h, 0.0),
+                jnp.abs(adv) / self.entropy_adv_shaping_kappa,
             )
             adv += psi_h
         adv = jax.lax.stop_gradient(adv)
@@ -280,7 +281,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             adv * ratio
             - self.kl_coef
             * jnp.where(
-                (kl >= self.kl_range) & (ratio > 1.0),
+                (kl >= self.kl_range) & (ratio * adv >= adv),
                 kl,
                 self.kl_range,
             )

--- a/jax_baselines/core/env_info.py
+++ b/jax_baselines/core/env_info.py
@@ -25,7 +25,7 @@ def _discrete_action_conv(a):
 
 
 def _continuous_action_conv(a):
-    return np.clip(a, -3.0, 3.0) / 3.0
+    return np.clip(a, -5.0, 5.0)
 
 
 def _require_env_info(env_info: EnvInfo | None) -> EnvInfo:

--- a/jax_baselines/math/returns.py
+++ b/jax_baselines/math/returns.py
@@ -6,23 +6,23 @@ def discount_with_terminated(rewards, terminateds, truncateds, next_values, gamm
     # rewards/terminateds/truncateds arrive flat ([T]) from the scalar-per-step
     # buffer, while the critic's next_values keep a trailing unit dim ([T, 1]).
     # Reshape so the scan stays [T, 1] (otherwise truncateds[-1] is a scalar and
-    # the boundary-set below fails to broadcast), and cast the bool done-flags to
-    # float so ``done = term + trunc - term*trunc`` is valid -- JAX rejects
-    # subtraction on bool. Mirrors get_gaes' flat->[T,1] alignment.
+    # the boundary-set below fails to broadcast). Mirrors get_gaes' flat->[T,1]
+    # alignment.
     rewards = rewards.reshape(next_values.shape)
-    terminateds = terminateds.reshape(next_values.shape).astype(jnp.float32)
-    truncateds = truncateds.reshape(next_values.shape).astype(jnp.float32)
+    terminateds = terminateds.reshape(next_values.shape).astype(bool)
+    truncateds = truncateds.reshape(next_values.shape).astype(bool)
 
     def f(ret, info):
         reward, term, trunc, nextval = info
         # done marks the episode boundary (terminated OR truncated); the return
         # accumulation resets there. At a boundary the value is bootstrapped from
         # nextval only on truncation (term == 0), never on a true terminal.
-        done = term + trunc - term * trunc
-        ret = reward + gamma * (ret * (1.0 - done) + nextval * (1.0 - term) * done)
+        done = jnp.logical_or(term, trunc)
+        bootstrap = jnp.where(term, jnp.zeros_like(nextval), nextval)
+        ret = reward + gamma * jnp.where(done, bootstrap, ret)
         return ret, ret
 
-    truncateds = truncateds.at[-1].set(jnp.ones((1,), dtype=jnp.float32))
+    truncateds = truncateds.at[-1].set(jnp.ones((1,), dtype=bool))
     _, discounted = jax.lax.scan(
         f,
         jnp.zeros((1,), dtype=jnp.float32),
@@ -38,13 +38,16 @@ def get_gaes(rewards, terminateds, truncateds, values, next_values, gamma, lamda
     # ([T, 1]). Align them so deltas stays [T, 1]; otherwise [T] broadcasts
     # against [T, 1] into a [T, T] matrix and the scan carry shape blows up.
     rewards = rewards.reshape(values.shape)
-    terminateds = terminateds.reshape(values.shape)
-    truncateds = truncateds.reshape(values.shape)
-    deltas = rewards + gamma * (1.0 - terminateds) * next_values - values
+    terminateds = terminateds.reshape(values.shape).astype(bool)
+    truncateds = truncateds.reshape(values.shape).astype(bool)
+    bootstrap = jnp.where(terminateds, jnp.zeros_like(next_values), next_values)
+    deltas = rewards + gamma * bootstrap - values
 
     def f(last_gae_lam, info):
         delta, term, trunc = info
-        last_gae_lam = delta + gamma * lamda * (1.0 - term) * (1.0 - trunc) * last_gae_lam
+        boundary = jnp.logical_or(term, trunc)
+        continuation = jnp.where(boundary, jnp.zeros_like(last_gae_lam), last_gae_lam)
+        last_gae_lam = delta + gamma * lamda * continuation
         return last_gae_lam, last_gae_lam
 
     _, advs = jax.lax.scan(
@@ -79,11 +82,16 @@ def validate_advantage_normalize_scope(scope):
 
 
 def get_vtrace(rewards, rhos, c_ts, terminateds, truncateds, values, next_values, gamma):
-    deltas = rhos * (rewards + gamma * (1.0 - terminateds) * next_values - values)
+    terminateds = terminateds.astype(bool)
+    truncateds = truncateds.astype(bool)
+    bootstrap = jnp.where(terminateds, jnp.zeros_like(next_values), next_values)
+    deltas = rhos * (rewards + gamma * bootstrap - values)
 
     def f(last_v, info):
         delta, c_t, term, trunc = info
-        last_v = delta + gamma * c_t * (1.0 - term) * (1.0 - trunc) * last_v
+        boundary = jnp.logical_or(term, trunc)
+        continuation = jnp.where(boundary, jnp.zeros_like(last_v), last_v)
+        last_v = delta + gamma * c_t * continuation
         return last_v, last_v
 
     _, A = jax.lax.scan(

--- a/model_builder/flax/ac/ac_builder.py
+++ b/model_builder/flax/ac/ac_builder.py
@@ -32,7 +32,11 @@ class Actor(nn.Module):
             return action_probs
         elif self.action_type == "continuous":
             mu = self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(0.01))(mlp)
-            log_std = self.param("log_std", nn.initializers.zeros, (1, self.action_size[0]))
+            log_std = jnp.clip(
+                self.param("log_std", nn.initializers.zeros, (1, self.action_size[0])),
+                -20,
+                2,
+            )
             return mu, log_std
 
 

--- a/tests/test_env_builder_adapter.py
+++ b/tests/test_env_builder_adapter.py
@@ -344,7 +344,9 @@ def test_infer_action_meta_uses_adapter_normalized_action_type():
     assert discrete_type == "discrete"
     assert discrete_conv([2]) == 2
     assert continuous_type == "continuous"
-    np.testing.assert_allclose(continuous_conv(np.array([6.0, -6.0])), np.array([1.0, -1.0]))
+    action = np.array([6.0, -6.0])
+    np.testing.assert_array_equal(continuous_conv(action), [5.0, -5.0])
+    np.testing.assert_array_equal(action, [6.0, -6.0])
 
 
 def test_env_builder_adapter_prepares_train_eval_pair_and_seed_policy():

--- a/tests/test_returns_episode_boundary.py
+++ b/tests/test_returns_episode_boundary.py
@@ -26,8 +26,10 @@ from env_builder import env_builder as eb
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.APE_X.dpg_worker import Ape_X_Worker as ApeXDPGWorker
 from jax_baselines.APE_X.worker import Ape_X_Worker as ApeXQWorker
+from jax_baselines.core.env_info import infer_action_meta
+from jax_baselines.IMPALA.base_class import IMPALA_Family
 from jax_baselines.IMPALA.worker import Impala_Worker
-from jax_baselines.math.returns import discount_with_terminated, get_vtrace
+from jax_baselines.math.returns import discount_with_terminated, get_gaes, get_vtrace
 
 GAMMA = 0.9
 
@@ -62,6 +64,53 @@ def test_discount_bootstraps_on_truncation_not_termination():
     term_returns = _returns([1, 1, 1, 1], [0, 0, 1, 0], [0, 0, 1, 0], [10, 10, 10, 10])
     assert trunc_returns[2] == round(1 + GAMMA * 10, 3)  # 10.0
     assert term_returns[2] == 1.0
+
+
+def test_terminal_nan_next_value_is_ignored_by_return_estimators():
+    rewards = jnp.array([[1.0]], dtype=jnp.float32)
+    terminateds = jnp.array([[True]])
+    truncateds = jnp.array([[False]])
+    values = jnp.array([[0.0]], dtype=jnp.float32)
+    next_values = jnp.array([[jnp.nan]], dtype=jnp.float32)
+
+    discounted = discount_with_terminated(rewards, terminateds, truncateds, next_values, GAMMA)
+    gae = get_gaes(rewards, terminateds, truncateds, values, next_values, GAMMA, 0.95)
+    vtrace = get_vtrace(
+        rewards,
+        jnp.ones_like(rewards),
+        jnp.ones_like(rewards),
+        terminateds,
+        truncateds,
+        values,
+        next_values,
+        GAMMA,
+    )
+
+    np.testing.assert_allclose(discounted, [[1.0]])
+    np.testing.assert_allclose(gae, [[1.0]])
+    np.testing.assert_allclose(vtrace, [[1.0]])
+
+
+def test_impala_terminal_nan_next_value_is_ignored_by_advantage():
+    agent = IMPALA_Family.__new__(IMPALA_Family)
+    agent.gamma = GAMMA
+    agent.lamda = 0.95
+    agent.rho_max = 1.0
+    agent.cut_max = 1.0
+    shape = (1, 1, 1)
+
+    vs, _, advantage = agent._compute_vtrace(
+        jnp.zeros(shape),
+        jnp.zeros(shape),
+        jnp.ones(shape),
+        jnp.ones(shape),
+        jnp.zeros(shape),
+        jnp.zeros(shape),
+        jnp.full(shape, jnp.nan),
+    )
+
+    np.testing.assert_allclose(vs, [[[1.0]]])
+    np.testing.assert_allclose(advantage, [[[1.0]]])
 
 
 def test_discount_does_not_bleed_across_episode_boundary():
@@ -208,6 +257,26 @@ class _ScriptEnv:
         return {"unified_obs": nxt}, rewards, terms, truncs, {}
 
 
+class _DistinctObservationEnv(_ScriptEnv):
+    ws = 1
+
+    def __init__(self):
+        self._t = 0
+        self.sent_actions = []
+        self.awaiting_result = False
+
+    def current_obs(self):
+        return {"unified_obs": np.array([[2 * self._t]], dtype=np.float32)}
+
+    def get_result(self):
+        if not self.awaiting_result:
+            raise RuntimeError("get_result called without a pending step")
+        self.awaiting_result = False
+        successor = {"unified_obs": np.array([[2 * self._t + 1]], dtype=np.float32)}
+        self._t += 1
+        return successor, np.ones(1), np.zeros(1, dtype=bool), np.zeros(1, dtype=bool), {}
+
+
 class _LivesScriptEnv(_ScriptEnv):
     def __init__(self, rows):
         self._rows = rows
@@ -245,12 +314,16 @@ class _RecordingBuffer:
         self.rewards = []
         self.truncateds = []
         self.actions = []
+        self.obses = []
+        self.nxtobses = []
 
     def add(self, obs, action, reward, nxtobs, terminated, truncated):
         self.terminateds.append(np.asarray(terminated).copy())
         self.rewards.append(np.asarray(reward).copy())
         self.truncateds.append(np.asarray(truncated).copy())
         self.actions.append(np.asarray(action).copy())
+        self.obses.append(np.asarray(obs["unified_obs"]).copy())
+        self.nxtobses.append(np.asarray(nxtobs["unified_obs"]).copy())
 
 
 class _Pbar(list):
@@ -305,15 +378,35 @@ def test_a2c_vectorized_flags_autoreset_dummy_step_as_terminal():
     assert stored_trunc == [[False, False], [False, False], [False, False]]
 
 
-def test_a2c_vectorized_converts_continuous_actions_before_env_step():
+def test_a2c_vectorized_stores_successor_but_acts_on_current_observation():
+    agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.env = _DistinctObservationEnv()
+    agent.buffer = _RecordingBuffer()
+    agent.worker_size = 1
+    agent.batch_size = 2
+    agent.action_type = "discrete"
+    agent.lossque = deque(maxlen=10)
+    agent.actions = lambda obs: np.asarray(obs["unified_obs"])
+    agent.train_step = lambda steps, logger_run=None: 0.0
+    agent.eval = lambda ctx, steps: None
+    agent.description = lambda result: ""
+
+    Actor_Critic_Policy_Gradient_Family.learn_VectorizedEnv(agent, _Ctx([0, 1, 2]))
+
+    assert [obs.item() for obs in agent.buffer.obses] == [0.0, 2.0, 4.0]
+    assert [obs.item() for obs in agent.buffer.nxtobses] == [1.0, 3.0, 5.0]
+    assert [action.item() for action in agent.env.sent_actions] == [0.0, 2.0, 4.0]
+    assert not agent.env.awaiting_result
+
+
+def test_a2c_vectorized_preserves_continuous_actions_before_env_step():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.env = _ScriptEnv([np.array([False, False])])
     agent.buffer = _RecordingBuffer()
     agent.worker_size = 2
     agent.batch_size = 10_000
-    agent.action_type = "continuous"
-    agent.actions = lambda obs: np.full((2, 1), 6.0, dtype=np.float32)
-    agent.conv_action = lambda actions: np.clip(actions, -3.0, 3.0) / 3.0
+    agent.action_type, agent.conv_action = infer_action_meta("continuous")
+    agent.actions = lambda obs: np.array([[-6.0], [2.0]], dtype=np.float32)
     agent.train_step = lambda steps: 0.0
     agent.eval = lambda ctx, steps: None
     agent.description = lambda eval_result: "desc"
@@ -321,8 +414,8 @@ def test_a2c_vectorized_converts_continuous_actions_before_env_step():
     Actor_Critic_Policy_Gradient_Family.learn_VectorizedEnv(agent, _Ctx([0]))
 
     assert len(agent.env.sent_actions) == 1
-    assert all(np.array_equal(action, np.ones((2, 1))) for action in agent.env.sent_actions)
-    assert np.array_equal(agent.buffer.actions[0], np.full((2, 1), 6.0))
+    np.testing.assert_array_equal(agent.env.sent_actions[0], [[-5.0], [2.0]])
+    np.testing.assert_array_equal(agent.buffer.actions[0], [[-6.0], [2.0]])
 
 
 def test_a2c_vectorized_recomputes_pipelined_action_after_policy_update():
@@ -444,7 +537,15 @@ class _ScriptSingleEnv:
         return {"unified_obs": np.ones(2, dtype=np.float32)}, 1.0, False, False, {}
 
 
-def test_a2c_single_env_action_plumbing_and_buffer_shape():
+@pytest.mark.parametrize(
+    "action_type, action, expected_action",
+    [
+        ("discrete", [[1]], 1),
+        ("continuous", [[6.0]], [5.0]),
+        ("continuous", [[-6.0, 2.0]], [-5.0, 2.0]),
+    ],
+)
+def test_a2c_single_env_action_plumbing_and_buffer_shape(action_type, action, expected_action):
     # Regression for the worker=1 SingleEnv path: it used to double-collapse the
     # action (`self.actions(obs)[0]` then `conv_action(...)[0]`), so conv_action's
     # own a[0] already left a scalar and the extra [0] raised IndexError before
@@ -455,9 +556,8 @@ def test_a2c_single_env_action_plumbing_and_buffer_shape():
     agent.env = env
     agent.batch_size = 10_000  # train cadence never fires
     agent.lossque = deque(maxlen=10)
-    # action_discrete returns [worker=1, action_dim=1]; _discrete_action_conv is a[0].
-    agent.actions = lambda obs: np.array([[1]], dtype=np.int32)
-    agent.conv_action = lambda a: a[0]
+    agent.actions = lambda obs: np.asarray(action)
+    agent.action_type, agent.conv_action = infer_action_meta(action_type)
     agent.train_step = lambda steps: 0.0
     agent.eval = lambda ctx, steps: None
     agent.description = lambda eval_result: "desc"
@@ -465,13 +565,27 @@ def test_a2c_single_env_action_plumbing_and_buffer_shape():
 
     Actor_Critic_Policy_Gradient_Family.learn_SingleEnv(agent, _Ctx([0, 1, 2]))
 
-    # env.step received a bare scalar action each step (not an array, no crash).
     assert len(env.received_actions) == 3
-    assert all(np.ndim(a) == 0 for a in env.received_actions)
+    for received in env.received_actions:
+        if action_type == "discrete":
+            assert np.ndim(received) == 0
+            assert received == expected_action
+        else:
+            np.testing.assert_array_equal(received, expected_action)
     # The buffer keeps the worker dim so a real EpochBuffer's action[worker_idx]
     # stays indexable -- stored shape [worker=1, action_dim=1], matching the
     # vectorized path rather than the pre-fix collapsed scalar.
-    assert all(a.shape == (1, 1) for a in agent.buffer.actions)
+    for stored in agent.buffer.actions:
+        np.testing.assert_array_equal(stored, action)
+
+
+def test_impala_worker_preserves_continuous_actions():
+    agent = IMPALA_Family.__new__(IMPALA_Family)
+    agent.action_type = "continuous"
+    agent.action_size = [3]
+    _, _, convert_action = agent.get_actor_builder()()
+
+    np.testing.assert_array_equal(convert_action(np.array([[-6.0, 2.0, 6.0]])), [-6.0, 2.0, 6.0])
 
 
 def test_pipelined_loop_drives_real_async_envpool_end_to_end():

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -306,7 +306,8 @@ class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
         self.calls = []
         self.eval_env = "eval-env"
         self.eval_eps = 3
-        self.actions = "actions"
+        self.actions = lambda obs, eval=False: (obs, eval)
+        self.record_test_fn = lambda builder, logger, actions, episode, conv_action: actions("obs")
         self.conv_action = "conv-action"
         # Mirror the real base __init__ defaults (base_class.py:68,70) so the
         # hardened prepare_run (direct attribute access) keeps its no-op
@@ -381,7 +382,7 @@ def test_on_policy_eval_uses_run_context_logger(monkeypatch):
     rec = []
 
     def fake_evaluate_policy(eval_env, eval_eps, actions, logger_run, steps, conv_action):
-        rec.append((eval_env, eval_eps, actions, logger_run, steps, conv_action))
+        rec.append((eval_env, eval_eps, actions("obs"), logger_run, steps, conv_action))
         return {"score": 1.0}
 
     monkeypatch.setattr(
@@ -394,7 +395,14 @@ def test_on_policy_eval_uses_run_context_logger(monkeypatch):
     result = agent.eval(ctx, 42)
 
     assert result == {"score": 1.0}
-    assert rec == [("eval-env", 3, "actions", "ctx-logger", 42, "conv-action")]
+    assert rec == [("eval-env", 3, ("obs", True), "ctx-logger", 42, "conv-action")]
+
+
+def test_on_policy_recording_uses_eval_actions():
+    agent = FakeOnPolicyAgent()
+    agent.env_builder = "builder"
+
+    assert agent.test_eval_env("logger", 1) == ("obs", True)
 
 
 class _MetricLoggerRun:


### PR DESCRIPTION
종료된 에피소드의 무효 bootstrap 값이 return·GAE·V-trace로 전파되지 않도록 계산을 수정합니다. 엔트로피 shaping 검증과 TPPO rollback 조건을 정리하고, 연속 행동을 ±5로 제한하며 결정적 평가와 reset 이후 관측 갱신을 반영합니다. Flax AC의 log_std 제한도 포함합니다.

스택 4/8 · base: `stack/mjlab-03-observation-roles` · head: `stack/mjlab-04-ac-correctness`. 이 PR의 base 대비 diff를 리뷰하고 1→8 순서로 병합합니다.

| 순서 | PR | 상태 |
| --- | --- | --- |
| 1 | [#19 관측 정규화 변환 함수의 이름을 명확히 변경](https://github.com/tinker495/jax-baseline/pull/19) | 리뷰 가능 |
| 2 | [#20 로컬 생성물 제외와 저장소 설정 정리](https://github.com/tinker495/jax-baseline/pull/20) | 리뷰 가능 |
| 3 | [#21 관측 키와 actor·critic 입력 역할을 통일](https://github.com/tinker495/jax-baseline/pull/21) | 리뷰 가능 |
| 4 | [#22 AC 에피소드 경계·행동·평가 계산 수정](https://github.com/tinker495/jax-baseline/pull/22) | 리뷰 가능 |
| 5 | [#23 MJLab 환경 adapter와 Go1 실험 설정 추가](https://github.com/tinker495/jax-baseline/pull/23) | 리뷰 가능 |
| 6 | [#24 AC 관측 정규화와 체크포인트 상태 저장](https://github.com/tinker495/jax-baseline/pull/24) | Draft |
| 7 | [#25 AC 버퍼·정규화를 CPU 또는 GPU에 유지](https://github.com/tinker495/jax-baseline/pull/25) | Draft |
| 8 | [#26 Go1 롤아웃 성능·장치 전송 프로파일러 추가](https://github.com/tinker495/jax-baseline/pull/26) | 리뷰 가능 |


| 항목 | 내용 |
| --- | --- |
| git hash/diff | `f5d600cba449f55e2045a3b67bb5cf437dc5746f`. 이 PR의 Files changed가 검증 diff이며 미커밋 소스 변경 없음. |
| logging link | N/A — 외부 로그 서비스 미사용. 로컬 기록: `runs/pr_stack/overlays/04/verification.log, cli-smoke.log, cli-artifacts/, static_comparison.json`. 주요 출력은 아래 실제 결과에 보존. |
| Command | `JAX_PLATFORMS=cpu SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy .venv/bin/python -m experiments.cli.pg --algo PPO --env CartPole-v1 --steps 32 --batch 16 --mini_batch 16 --node 16 --hidden_n 1 --eval_num 1 --logdir runs/pr04-smoke` |
| Comments | 준비된 .venv, CPU, 기본 시드 0. 실제 검증은 격리 체크아웃에서 같은 .venv의 절대 경로 인터프리터로 실행. 짧은 smoke 실행이며 학습 수렴 검증은 아님. |
| 성공 기준 | 32스텝 학습·평가·녹화 완료, 저장된 파라미터 8개 leaf 모두 유한값. 에피소드 경계·TPPO 관련 회귀 테스트 통과. |
| 실제 결과 | CLI 종료 0, 32스텝 완료, 파라미터 8개 모두 유한값, 최종 10회 평가 평균 9.2. 관련 CPU 테스트 57개 통과. |

동일 경로 main 대비 Ruff 17→9, ty 60→60. 타입 메시지 1개의 Unknown→Array 변화는 기존 Actor 반환 타입 진단의 추론 정밀도 변화이며 새 진단 위치가 아닙니다.

검증 명령은 해당 PR head를 체크아웃한 저장소 루트에서 실행합니다. 전체 스택의 최종 코드 내용은 원래 `feat/mjlab-env-adapter`의 `61dc7dd7`과 동일하게 보존했습니다.
