### PR TITLE
[7/8] AC 버퍼·정규화를 CPU 또는 GPU에 유지

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -119,9 +119,12 @@ def get_env_builder(
     observation_key=None,
     episode_length=None,
     device="cuda:0",
+    jax_arrays=False,
 ):
     if env_backend not in _ENV_BACKENDS:
         raise ValueError(f"env_backend must be one of {_ENV_BACKENDS}, got {env_backend!r}")
+    if jax_arrays and env_backend != "mjlab":
+        raise ValueError("jax_arrays requires env_backend='mjlab'")
 
     def env_builder(worker=1, render_mode=None, seed=None):
         if env_backend == "mjlab":
@@ -135,6 +138,7 @@ def get_env_builder(
                 episode_length=episode_length,
                 device=device,
                 render_mode=render_mode,
+                jax_arrays=jax_arrays,
             )
         if worker > 1:
             # Vectorized backend is an explicit choice: gymnasium AsyncVectorEnv
@@ -321,7 +325,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
 
         # Set up action conversion for the normalized [-1, 1] core contract.
         if not isinstance(self.env.action_space, spaces.Box):
-            self.action_conv = lambda a: np.asarray(a).flatten().astype(np.int32)
+            self.action_conv = lambda a: a.flatten().astype(np.int32)
         elif (
             np.isfinite(self.env.action_space.low).all()
             and np.isfinite(self.env.action_space.high).all()
@@ -329,7 +333,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
             unit = np.ones(self.env.action_space.shape, dtype=self.env.action_space.dtype)
             _, _, self.action_conv = rescale_box(self.env.action_space, -unit, unit)
         else:
-            self.action_conv = lambda a: np.asarray(a)
+            self.action_conv = lambda a: a
 
         # env_id vector for send(); recv() may hand back envs in completion
         # order, so every result is re-sorted to the canonical 0..N-1 layout
@@ -365,7 +369,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
         step) while the environments advance. ``get_result()`` collects the
         outcome via ``recv()``.
         """
-        self.env.send(self.action_conv(actions), self._all_env_ids)
+        self.env.send(self.action_conv(np.asarray(actions)), self._all_env_ids)
         self._awaiting_recv = True
 
     def get_result(self):

--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypeAlias
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 from gymnasium import spaces
 
@@ -17,28 +19,19 @@ from jax_baselines.core.env_protocols import (
     VectorizedEnv,
 )
 
-
-def _snapshot(value):
-    if isinstance(value, Mapping):
-        return {key: _snapshot(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return type(value)(_snapshot(item) for item in value)
-    if hasattr(value, "shape"):
-        return _to_numpy(value).copy()
-    return value
+Array: TypeAlias = np.ndarray | jax.Array
 
 
 class MjlabVectorizedEnv(VectorizedEnv):
     env_info: EnvInfo
 
-    def __init__(self, env_id, env, torch, seed=None, observation_key=None):
+    def __init__(self, env_id, env, torch, seed=None, observation_key=None, jax_arrays=False):
         self.env = env
         self._torch = torch
+        self.jax_arrays = jax_arrays
         self.worker_num = env.num_envs
         self._observation_key = observation_key
-        self._pending: (
-            tuple[Observation, np.ndarray, np.ndarray, np.ndarray, dict[str, Any]] | None
-        ) = None
+        self._pending: tuple[Observation, Array, Array, Array, dict[str, Any]] | None = None
         self._closed = False
         self._frame = None
         self.reset(seed=seed)
@@ -57,6 +50,25 @@ class MjlabVectorizedEnv(VectorizedEnv):
             "core_env_type": "VectorizedEnv",
         }
 
+    def _array(self, value) -> Array:
+        if not self.jax_arrays:
+            return _to_numpy(value).copy()
+        if isinstance(value, self._torch.Tensor):
+            # Clone on the producer stream before mjlab mutates/reset its buffers.
+            return jax.dlpack.from_dlpack(
+                value.detach().clone(memory_format=self._torch.contiguous_format)
+            )
+        return jnp.array(value, copy=True)
+
+    def _snapshot(self, value):
+        if isinstance(value, Mapping):
+            return {key: self._snapshot(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return type(value)(self._snapshot(item) for item in value)
+        if isinstance(value, (self._torch.Tensor, np.ndarray, jax.Array)):
+            return self._array(value)
+        return value
+
     def _selected(self, observation) -> Observation:
         if (
             self._observation_key is None
@@ -66,19 +78,20 @@ class MjlabVectorizedEnv(VectorizedEnv):
             shared = {
                 key: value for key, value in observation.items() if key not in ("actor", "critic")
             }
-            selected = normalize_observation(shared) if shared else {}
+            selected = normalize_observation(shared, array_converter=self._array) if shared else {}
             for role in ("actor", "critic"):
                 selected.update(
                     {
                         f"{role}_{key.removeprefix('unified_')}": value
-                        for key, value in normalize_observation(observation[role]).items()
+                        for key, value in normalize_observation(
+                            observation[role], array_converter=self._array
+                        ).items()
                     }
                 )
-            return {key: value.copy() for key, value in sorted(selected.items())}
-        return {
-            key: value.copy()
-            for key, value in normalize_observation(observation, self._observation_key).items()
-        }
+            return dict(sorted(selected.items()))
+        return normalize_observation(
+            observation, self._observation_key, array_converter=self._array
+        )
 
     def reset(self, *, seed: int | None = None) -> tuple[Observation, dict[str, Any]]:
         if self._pending is not None:
@@ -86,7 +99,7 @@ class MjlabVectorizedEnv(VectorizedEnv):
         self._frame = None
         observation, info = self.env.reset(seed=seed)
         self._obs = self._selected(observation)
-        return self._obs, _snapshot(info)
+        return self._obs, self._snapshot(info)
 
     def current_obs(self) -> Observation:
         return self._obs
@@ -97,33 +110,43 @@ class MjlabVectorizedEnv(VectorizedEnv):
     def step(self, action: Any) -> None:
         if self._pending is not None:
             raise RuntimeError("step() called before collecting the previous result")
-        actions = np.asarray(action)
+        actions = (
+            self._torch.from_dlpack(action)
+            if isinstance(action, jax.Array)
+            else self._torch.as_tensor(action)
+        )
         expected = (self.worker_num, *self.action_space.shape)
         if actions.shape != expected:
             raise ValueError(f"Expected actions with shape {expected}, got {actions.shape}")
-        actions = self._torch.as_tensor(actions, dtype=self._torch.float32, device=self.env.device)
+        actions = actions.to(dtype=self._torch.float32, device=self.env.device)
         observation, reward, terminated, truncated, info = self.env.step(actions)
         if self.env.render_mode == "rgb_array":
             self._frame = np.array(self.env.render(), copy=True)
-        # CPU tensors can share storage with arrays; snapshot before reset mutates buffers.
+        # Snapshot terminal data before partial reset mutates simulator buffers.
         successor = self._selected(observation)
-        reward = _to_numpy(reward).copy()
-        terminated = _to_numpy(terminated).astype(bool, copy=True)
-        truncated = _to_numpy(truncated).astype(bool, copy=True)
-        info = _snapshot(info)
+        done_ids = self._torch.nonzero(terminated | truncated, as_tuple=False).flatten()
+        reward = self._array(reward)
+        terminated = self._array(terminated).astype(bool)
+        truncated = self._array(truncated).astype(bool)
+        info = self._snapshot(info)
         self._obs = successor
-        done_ids = np.flatnonzero(terminated | truncated)
-        if done_ids.size:
-            ids = self._torch.as_tensor(done_ids, dtype=self._torch.int64, device=self.env.device)
-            current, _ = self.env.reset(env_ids=ids)
+        if done_ids.numel():
+            current, _ = self.env.reset(env_ids=done_ids)
             # Only replace reset rows: a partial reset may recompute noisy observations.
             current = self._selected(current)
-            self._obs = {key: value.copy() for key, value in successor.items()}
-            for key in self._obs:
-                self._obs[key][done_ids] = current[key][done_ids]
+            array_module = jnp if self.jax_arrays else np
+            done = terminated | truncated
+            self._obs = {
+                key: array_module.where(
+                    done.reshape((self.worker_num,) + (1,) * (value.ndim - 1)),
+                    current[key],
+                    value,
+                )
+                for key, value in successor.items()
+            }
         self._pending = successor, reward, terminated, truncated, info
 
-    def get_result(self) -> tuple[Observation, np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
+    def get_result(self) -> tuple[Observation, Array, Array, Array, dict[str, Any]]:
         if self._pending is None:
             raise RuntimeError("get_result() called without a preceding step()")
         result, self._pending = self._pending, None
@@ -131,11 +154,11 @@ class MjlabVectorizedEnv(VectorizedEnv):
 
     def real_reset_mask(self, terminateds, truncateds, infos):
         del infos
-        return np.asarray(terminateds, dtype=bool) | np.asarray(truncateds, dtype=bool)
+        return terminateds | truncateds
 
     def autoreset_mask(self, terminateds, truncateds, infos):
         del truncateds, infos
-        return np.zeros_like(np.asarray(terminateds), dtype=bool)
+        return (jnp if self.jax_arrays else np).zeros_like(terminateds, dtype=bool)
 
     def close(self) -> None:
         if not self._closed:
@@ -168,7 +191,7 @@ class MjlabSingleEnv(SingleEnv):
         return self._current(), info
 
     def step(self, action: Any) -> tuple[Observation, float, bool, bool, dict[str, Any]]:
-        action = np.asarray(action)
+        action = (jnp if self._vector.jax_arrays else np).asarray(action)
         self._vector.step(action[None])
         observation, reward, terminated, truncated, info = self._vector.get_result()
         if terminated[0] or truncated[0]:
@@ -198,6 +221,7 @@ def make_mjlab_env(
     episode_length=None,
     device="cuda:0",
     render_mode=None,
+    jax_arrays=False,
 ) -> MjlabSingleEnv | MjlabVectorizedEnv:
     if render_mode not in (None, "rgb_array"):
         raise ValueError("mjlab supports only render_mode=None or 'rgb_array'")
@@ -223,7 +247,7 @@ def make_mjlab_env(
         cfg.episode_length_s = episode_length * (cfg.sim.mujoco.timestep * cfg.decimation)
     env = ManagerBasedRlEnv(cfg, device=device, render_mode=render_mode)
     try:
-        vector = MjlabVectorizedEnv(env_id, env, torch, seed, observation_key)
+        vector = MjlabVectorizedEnv(env_id, env, torch, seed, observation_key, jax_arrays)
         return MjlabSingleEnv(vector) if worker_num == 1 else vector
     except Exception:
         env.close()

--- a/env_builder/observations.py
+++ b/env_builder/observations.py
@@ -21,8 +21,8 @@ def _to_numpy(value):
         raise ValueError("Selected observation must be one numeric array") from exc
 
 
-def _numeric_array(value):
-    array = _to_numpy(value)
+def _numeric_array(value, array_converter=_to_numpy):
+    array = array_converter(value)
     if array.dtype == object or not np.issubdtype(array.dtype, np.number):
         raise ValueError("Selected observation must be one numeric array")
     return array
@@ -68,14 +68,17 @@ def _flatten(value, leaf=None, kind="Observation", prefix=""):
     return leaves
 
 
-def normalize_observation(observation, observation_key=None):
+def normalize_observation(observation, observation_key=None, *, array_converter=_to_numpy):
     """Flatten raw shared observations and mark every leaf with ``unified_``."""
     if observation_key:
         observation = _select_path(observation, observation_key)
-    normalized = _flatten(observation, _numeric_array, prefix=observation_key or "")
+    normalized = _flatten(observation, prefix=observation_key or "")
     if not normalized:
         raise ValueError("Observation must contain at least one array leaf")
-    return {f"unified_{key}": value for key, value in sorted(normalized.items())}
+    return {
+        f"unified_{key}": _numeric_array(value, array_converter)
+        for key, value in sorted(normalized.items())
+    }
 
 
 def normalize_observation_space(space, observation_key=None):

--- a/experiments/cli/_env.py
+++ b/experiments/cli/_env.py
@@ -11,6 +11,9 @@ def add_env_args(parser):
     parser.add_argument("--env_observation_key", help="dotted observation path")
     parser.add_argument("--env_episode_length", type=int, help="episode length in steps")
     parser.add_argument("--env_device", default="cuda:0", help="simulator device")
+    parser.add_argument(
+        "--env_jax_arrays", action="store_true", help="exchange mjlab tensors with JAX via DLPack"
+    )
 
 
 def env_builder_kwargs(args):
@@ -19,4 +22,5 @@ def env_builder_kwargs(args):
         "observation_key": args.env_observation_key,
         "episode_length": args.env_episode_length,
         "device": args.env_device,
+        "jax_arrays": args.env_jax_arrays,
     }

--- a/experiments/cli/pg.py
+++ b/experiments/cli/pg.py
@@ -16,6 +16,12 @@ def add_args(parser):
     parser.add_argument("--experiment_name", type=str, default="PG", help="experiment name")
     parser.add_argument("--env", type=str, default="Pendulum-v1", help="environment")
     add_env_args(parser)
+    parser.add_argument(
+        "--memory_backend",
+        choices=("auto", "cpu", "gpu"),
+        default="auto",
+        help="rollout storage; auto follows the environment observation device",
+    )
     parser.add_argument("--model_lib", type=str, default="flax", help="model lib")
     parser.add_argument("--worker", type=int, default=1, help="gym_worker_size")
     parser.add_argument("--algo", type=str, default="A2C", help="algo ID")
@@ -103,6 +109,7 @@ def _common(a):
         "val_coef": a.val_coef,
         "ent_coef": a.ent_coef,
         "obs_normalization": a.obs_normalization,
+        "memory_backend": a.memory_backend,
         "use_entropy_adv_shaping": a.use_entropy_adv_shaping,
         "log_dir": a.logdir,
         "optimizer_factory": make_optimizer_factory(

--- a/experiments/configs/pg_mjlab_go1.yaml
+++ b/experiments/configs/pg_mjlab_go1.yaml
@@ -5,6 +5,7 @@ base:
   env: Mjlab-Velocity-Flat-Unitree-Go1
   env_backend: mjlab
   env_device: cuda:0
+  env_jax_arrays: true
   worker: 4096
   steps: 491520000
   eval_num: 5

--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -57,10 +57,6 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         terminateds,
         truncateds,
     ):
-        actions = jnp.stack(actions)
-        rewards = jnp.stack(rewards)
-        terminateds = jnp.stack(terminateds)
-        truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
         value = jax.vmap(self.critic, in_axes=(None, None, 0))(

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -2,6 +2,7 @@ from collections import deque
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from itertools import chain, pairwise
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -28,7 +29,7 @@ from jax_baselines.core.eval import (
     extract_vector_original_rewards,
     record_and_test,
 )
-from jax_baselines.core.rollout_stats import EpisodeTracker
+from jax_baselines.core.rollout_stats import EpisodeTracker, device_episode_step
 from jax_baselines.core.seeding import key_gen, set_global_seeds
 from jax_baselines.core.training_session import TrainingSession
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -36,9 +37,27 @@ from jax_baselines.math.statistics import RunningMeanStd
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
+@jax.jit
+def _sample_continuous(mu, std, key):
+    return mu + std * jax.random.normal(key, mu.shape, dtype=mu.dtype)
+
+
+@jax.jit
+def _sample_discrete(prob, key):
+    return jax.random.categorical(key, jnp.log(prob), axis=-1)[:, None]
+
+
+@jax.jit
+def _normalize_observation(obs, means, variances):
+    return {
+        key: (value - means[key]) / (jnp.sqrt(variances[key]) + 0.01) for key, value in obs.items()
+    }
+
+
 class Actor_Critic_Policy_Gradient_Family:
     _run_name = "A2C"
     actor: Callable
+    _get_actions: Callable
     preproc: Callable
     logger: AbstractContextManager
 
@@ -64,7 +83,10 @@ class Actor_Critic_Policy_Gradient_Family:
         lr_annealing=False,
         checkpoint_store: CheckpointStore | None = None,
         obs_normalization=False,
+        memory_backend: Literal["auto", "cpu", "gpu"] = "auto",
     ):
+        if memory_backend not in ("auto", "cpu", "gpu"):
+            raise ValueError("memory_backend must be 'auto', 'cpu', or 'gpu'")
         if use_entropy_adv_shaping:
             if not np.isfinite(ent_coef) or ent_coef < 0:
                 raise ValueError("entropy shaping requires finite ent_coef >= 0")
@@ -97,9 +119,31 @@ class Actor_Critic_Policy_Gradient_Family:
         self.optimizer = self._make_optimizer(self.learning_rate)
 
         self.get_env_setup()
+        self._initial_reset: tuple[dict, dict] | None = None
+        self.memory_backend: Literal["cpu", "gpu"] = "cpu"
+        if memory_backend == "gpu":
+            self.memory_backend = "gpu"
+        elif memory_backend == "auto":
+            if self.env_type == "SingleEnv":
+                self._initial_reset = self.env.reset()
+                initial_obs = self._initial_reset[0]
+            else:
+                initial_obs = self.env.current_obs()
+            if all(
+                isinstance(value, jax.Array)
+                and all(device.platform == "gpu" for device in value.devices())
+                for value in initial_obs.values()
+            ):
+                self.memory_backend = "gpu"
+        print("memory backend : ", self.memory_backend)
         self.obs_normalization = obs_normalization
         self.obs_rms = (
-            RunningMeanStd(epsilon=0.0, shapes=self.observation_space, dtype=np.float32)
+            RunningMeanStd(
+                epsilon=0.0,
+                shapes=self.observation_space,
+                dtype=np.float32,
+                on_device=self.memory_backend == "gpu",
+            )
             if obs_normalization
             else None
         )
@@ -122,7 +166,7 @@ class Actor_Critic_Policy_Gradient_Family:
         if not isinstance(state, ACCheckpointState):
             raise TypeError("Expected ACCheckpointState with observation-normalization state")
         obs_rms = (
-            RunningMeanStd.from_state(state.obs_rms_state)
+            RunningMeanStd.from_state(state.obs_rms_state, on_device=self.memory_backend == "gpu")
             if state.obs_rms_state is not None
             else None
         )
@@ -140,13 +184,20 @@ class Actor_Critic_Policy_Gradient_Family:
 
     def normalize_observation(self, obs):
         """Prepare model inputs using frozen, per-key empirical observation statistics."""
+        if self.memory_backend == "cpu":
+            if self.obs_rms is None:
+                return {key: np.asarray(value) for key, value in obs.items()}
+            return {
+                key: np.asarray(
+                    (np.asarray(value) - self.obs_rms.means[key])
+                    / (np.sqrt(self.obs_rms.vars[key]) + 0.01),
+                    dtype=np.float32,
+                )
+                for key, value in obs.items()
+            }
         if self.obs_rms is None:
             return obs
-        return {
-            key: (value - self.obs_rms.means[key])
-            / (np.sqrt(self.obs_rms.vars[key]) + np.float32(0.01))
-            for key, value in obs.items()
-        }
+        return _normalize_observation(obs, self.obs_rms.means, self.obs_rms.vars)
 
     def get_memory_setup(self):
         self.buffer = EpochBuffer(
@@ -154,6 +205,7 @@ class Actor_Critic_Policy_Gradient_Family:
             self.observation_space,
             self.worker_size,
             [1] if self.action_type == "discrete" else self.action_size,
+            memory_backend=self.memory_backend,
         )
 
     def get_env_setup(self):
@@ -211,19 +263,29 @@ class Actor_Critic_Policy_Gradient_Family:
         return mu, jnp.exp(std)
 
     def action_discrete(self, obs, eval=False):
-        prob = np.asarray(self._get_actions(self.params, obs))
+        prob = self._get_actions(self.params, obs)
+        if self.memory_backend == "cpu":
+            prob = np.asarray(prob)
+            if eval:
+                return np.argmax(prob, axis=1, keepdims=True)
+            cumulative = np.cumsum(prob, axis=1)
+            cumulative[:, -1] = 1.0
+            return np.argmax(np.random.uniform(size=(prob.shape[0], 1)) < cumulative, axis=1)[
+                :, None
+            ]
         if eval:
-            return np.argmax(prob, axis=1, keepdims=True)
-        return np.expand_dims(
-            np.stack([np.random.choice(self.action_size[0], p=p) for p in prob], axis=0),
-            axis=1,
-        )
+            return jnp.argmax(prob, axis=1, keepdims=True)
+        return _sample_discrete(prob, next(self.key_seq))
 
     def action_continuous(self, obs, eval=False):
         mu, std = self._get_actions(self.params, obs)
+        if self.memory_backend == "cpu":
+            if eval:
+                return np.asarray(mu)
+            return np.random.normal(np.asarray(mu), np.asarray(std)).astype(np.float32)
         if eval:
-            return np.asarray(mu)
-        return np.random.normal(mu, std)
+            return mu
+        return _sample_continuous(mu, std, next(self.key_seq))
 
     def get_logprob_discrete(self, prob, action, key, out_prob=False):
         prob = jax.nn.softmax(prob)
@@ -348,7 +410,8 @@ class Actor_Critic_Policy_Gradient_Family:
         )
 
     def learn_SingleEnv(self, ctx):
-        obs, info = self.env.reset()
+        obs, info = self.env.reset() if self._initial_reset is None else self._initial_reset
+        self._initial_reset = None
         obs = self.normalize_observation(batch_observation(obs))
         self.lossque = deque(maxlen=10)
         self.rollout_tracker = EpisodeTracker(ctx.logger_run.log_metric, ctx.log_interval)
@@ -415,6 +478,20 @@ class Actor_Critic_Policy_Gradient_Family:
                 ctx.pbar.set_description(self.description(eval_result))
 
     def learn_VectorizedEnv(self, ctx):
+        raw_obs = self.env.current_obs()
+        device_rollout = self.memory_backend == "gpu" and isinstance(
+            next(iter(raw_obs.values())), jax.Array
+        )
+        if device_rollout:
+            device_state = (
+                jnp.zeros(self.worker_size),
+                jnp.zeros(self.worker_size, dtype=jnp.int32),
+                jnp.zeros(self.worker_size),
+                jnp.zeros(self.worker_size, dtype=bool),
+                jnp.zeros(self.worker_size, dtype=bool),
+            )
+        completed_steps = []
+        completed_rows = []
         self.lossque = deque(maxlen=10)
         self.rollout_tracker = EpisodeTracker(ctx.logger_run.log_metric, ctx.log_interval)
         eval_result = None
@@ -438,7 +515,7 @@ class Actor_Critic_Policy_Gradient_Family:
         # the next send until train_step finishes so the new rollout cannot start
         # with an action sampled from the previous policy. Pair each step with its
         # successor so the final iteration does not leave an env result pending.
-        obs = self.normalize_observation(self.env.current_obs())
+        obs = self.normalize_observation(raw_obs)
         actions = self.actions(obs)
         end = object()
         first = True
@@ -466,43 +543,88 @@ class Actor_Critic_Policy_Gradient_Family:
                 next_actions = self.actions(action_observation)
                 send(next_actions)
 
-            done = np.logical_or(terminateds, truncateds)
-            real_reset = vector_real_reset_mask(self.env, terminateds, truncateds, infos)
-            autoreset = vector_autoreset_mask(self.env, terminateds, truncateds, infos)
-            active = np.ones(self.worker_size, dtype=bool) if prev_done is None else ~prev_done
-            scores[active] += rewards[active]
-            eplens[active] += 1
-            step_original, step_original_present = extract_vector_original_rewards(
-                infos, self.worker_size
-            )
-            active_original = active & step_original_present
-            originals[active_original] += step_original[active_original]
-            original_present[active_original] = True
-
-            if prev_done is not None and prev_done.any():
-                # Flag the dummy step terminal AND zero its reward so it is fully
-                # inert (zero-value target, no episode bridge), independent of
-                # whatever the env reports on the discarded autoreset step.
-                terminateds = np.where(prev_done, True, terminateds)
-                rewards = np.where(prev_done, np.float32(0.0), rewards)
-            self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
-
-            for idx in np.where(done & active)[0]:
-                emit_original = original_present[idx] and real_reset[idx]
-                self.rollout_tracker.record(
-                    steps,
-                    episode_reward=float(scores[idx]),
-                    episode_length=int(eplens[idx]),
-                    timeout=float(truncateds[idx]),
-                    original_reward=float(originals[idx]) if emit_original else None,
+            if device_rollout:
+                if isinstance(infos, dict):
+                    original = (
+                        jnp.broadcast_to(jnp.asarray(infos["original_reward"]), (self.worker_size,))
+                        if "original_reward" in infos
+                        else jnp.zeros_like(rewards)
+                    )
+                    present = (
+                        jnp.broadcast_to(
+                            jnp.asarray(infos["_original_reward"], dtype=bool), (self.worker_size,)
+                        )
+                        if "_original_reward" in infos
+                        else jnp.full_like(terminateds, "original_reward" in infos)
+                    )
+                else:
+                    original, present = extract_vector_original_rewards(infos, self.worker_size)
+                device_state, rewards, terminateds, completed = device_episode_step(
+                    device_state,
+                    rewards,
+                    terminateds,
+                    truncateds,
+                    vector_real_reset_mask(self.env, terminateds, truncateds, infos),
+                    vector_autoreset_mask(self.env, terminateds, truncateds, infos),
+                    original,
+                    present,
                 )
-                scores[idx] = 0.0
-                eplens[idx] = 0
-                if emit_original:
-                    originals[idx] = 0.0
-                    original_present[idx] = False
+                self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
+                completed_steps.append(steps)
+                completed_rows.append(completed)
+                if train_due or next_step is end:
+                    # Transfer logging payload once per rollout; training tensors stay on device.
+                    with jax.profiler.TraceAnnotation("rollout.metrics"):
+                        episode_rows = jax.device_get(jnp.stack(completed_rows))
+                    for time_idx, worker_idx in np.argwhere(episode_rows[..., 0]):
+                        row = episode_rows[time_idx, worker_idx]
+                        self.rollout_tracker.record(
+                            completed_steps[time_idx],
+                            episode_reward=float(row[1]),
+                            episode_length=int(row[2]),
+                            timeout=float(row[3]),
+                            original_reward=float(row[4]) if row[5] else None,
+                        )
+                    completed_steps.clear()
+                    completed_rows.clear()
+            else:
+                done = np.logical_or(terminateds, truncateds)
+                real_reset = vector_real_reset_mask(self.env, terminateds, truncateds, infos)
+                autoreset = vector_autoreset_mask(self.env, terminateds, truncateds, infos)
+                active = np.ones(self.worker_size, dtype=bool) if prev_done is None else ~prev_done
+                scores[active] += rewards[active]
+                eplens[active] += 1
+                step_original, step_original_present = extract_vector_original_rewards(
+                    infos, self.worker_size
+                )
+                active_original = active & step_original_present
+                originals[active_original] += step_original[active_original]
+                original_present[active_original] = True
 
-            prev_done = done & autoreset & active
+                if prev_done is not None and prev_done.any():
+                    # Flag the dummy step terminal AND zero its reward so it is fully
+                    # inert (zero-value target, no episode bridge), independent of
+                    # whatever the env reports on the discarded autoreset step.
+                    terminateds = np.where(prev_done, True, terminateds)
+                    rewards = np.where(prev_done, np.float32(0.0), rewards)
+                self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
+
+                for idx in np.where(done & active)[0]:
+                    emit_original = original_present[idx] and real_reset[idx]
+                    self.rollout_tracker.record(
+                        steps,
+                        episode_reward=float(scores[idx]),
+                        episode_length=int(eplens[idx]),
+                        timeout=float(truncateds[idx]),
+                        original_reward=float(originals[idx]) if emit_original else None,
+                    )
+                    scores[idx] = 0.0
+                    eplens[idx] = 0
+                    if emit_original:
+                        originals[idx] = 0.0
+                        original_present[idx] = False
+
+                prev_done = done & autoreset & active
 
             if train_due:
                 loss = self.train_step(steps, logger_run=ctx.logger_run)

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -86,10 +86,6 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         return critic_loss
 
     def _preprocess(self, params, key, obses, actions, rewards, nxtobses, terminateds, truncateds):
-        actions = jnp.stack(actions)
-        rewards = jnp.stack(rewards)
-        terminateds = jnp.stack(terminateds)
-        truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)

--- a/jax_baselines/C51/apex_c51.py
+++ b/jax_baselines/C51/apex_c51.py
@@ -183,7 +183,8 @@ class APE_X_C51(Ape_X_Family):
 
             def actor(model, preproc, params, obses, key):
                 q_values = jnp.sum(
-                    model(params, key, preproc(params, key, convert_normalized_obs(obses))) * categorial_bar,
+                    model(params, key, preproc(params, key, convert_normalized_obs(obses)))
+                    * categorial_bar,
                     axis=2,
                 )
                 return jnp.argmax(q_values, axis=1)

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -99,7 +99,9 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
+        mu, log_std = self.actor(
+            params, None, self.preproc(params, None, convert_normalized_obs(obses))
+        )
         std = jnp.exp(log_std)
         pi = jax.nn.tanh(mu + std * jax.random.normal(key, std.shape))
         return pi

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -81,7 +81,9 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses)))
+        return self.actor(
+            policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses))
+        )
 
     def description(self, eval_result=None):
         description = ""

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -199,7 +199,9 @@ class IMPALA_Family:
             if action_type == "discrete":
 
                 def actor(actor_model, preproc, params, obses, key=None):
-                    prob = actor_model(params, key, preproc(params, key, convert_normalized_obs(obses)))
+                    prob = actor_model(
+                        params, key, preproc(params, key, convert_normalized_obs(obses))
+                    )
                     return jax.nn.softmax(prob)
 
                 def get_action_prob(actor, params, obses):

--- a/jax_baselines/IQN/apex_iqn.py
+++ b/jax_baselines/IQN/apex_iqn.py
@@ -148,7 +148,9 @@ class APE_X_IQN(Ape_X_Family):
                     jnp.expand_dims(actions.astype(jnp.int32), axis=2),
                     axis=1,
                 )
-                next_q = model(params, key3, preproc(params, key3, convert_normalized_obs(nxtobses)), next_tau)
+                next_q = model(
+                    params, key3, preproc(params, key3, convert_normalized_obs(nxtobses)), next_tau
+                )
                 next_actions = jnp.expand_dims(
                     jnp.argmax(jnp.mean(next_q, axis=2), axis=1), axis=(1, 2)
                 )
@@ -164,7 +166,9 @@ class APE_X_IQN(Ape_X_Family):
                 # mirroring local IQN._get_actions; the priority/TD-error path
                 # (get_abs_td_error) deliberately uses plain U[0,1] like iqn.py _loss/_target.
                 tau = jax.random.uniform(key, (1, n_support)) * CVaR
-                q_values = model(params, key, preproc(params, key, convert_normalized_obs(obses)), tau)
+                q_values = model(
+                    params, key, preproc(params, key, convert_normalized_obs(obses)), tau
+                )
                 return jnp.expand_dims(jnp.argmax(jnp.mean(q_values, axis=2), axis=1), axis=1)
 
             if param_noise:

--- a/jax_baselines/QRDQN/qrdqn.py
+++ b/jax_baselines/QRDQN/qrdqn.py
@@ -62,7 +62,9 @@ class QRDQN(Q_Network_Family):
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         return jnp.expand_dims(
-            jnp.argmax(jnp.mean(self.get_q(params, convert_normalized_obs(obses), key), axis=2), axis=1),
+            jnp.argmax(
+                jnp.mean(self.get_q(params, convert_normalized_obs(obses), key), axis=2), axis=1
+            ),
             axis=1,
         )
 

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -110,7 +110,9 @@ class SAC(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
+        mu, log_std = self.actor(
+            params, None, self.preproc(params, None, convert_normalized_obs(obses))
+        )
         return sample_action(mu, log_std, key)
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -79,7 +79,9 @@ class TD3(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses)))
+        return self.actor(
+            policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses))
+        )
 
     def _policy_action_from_state(self, state, obs, eval, steps):
         return np.asarray(self._get_actions(state["policy"], obs, None))

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -88,10 +88,6 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         return critic_loss
 
     def _preprocess(self, params, key, obses, actions, rewards, nxtobses, terminateds, truncateds):
-        actions = jnp.stack(actions)
-        rewards = jnp.stack(rewards)
-        terminateds = jnp.stack(terminateds)
-        truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
         feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -140,7 +140,9 @@ class XQC(Deteministic_Policy_Gradient_Family):
         return pi
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        (mu, _), _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)), False)
+        (mu, _), _ = self.actor(
+            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
+        )
         return jax.nn.tanh(mu)
 
     def _train_on_batch(self, data, context):

--- a/jax_baselines/core/env_info.py
+++ b/jax_baselines/core/env_info.py
@@ -1,3 +1,5 @@
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 from jax_baselines.core.env_protocols import (
@@ -25,6 +27,8 @@ def _discrete_action_conv(a):
 
 
 def _continuous_action_conv(a):
+    if isinstance(a, jax.Array):
+        return jnp.clip(a, -5.0, 5.0)
     return np.clip(a, -5.0, 5.0)
 
 

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, TypeAlias, TypedDict, runtime_checkable
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 # Keys retain their role from the environment boundary through replay and model input:
@@ -101,27 +103,35 @@ def batch_observation(observation: Observation) -> Observation:
     """Add the leading model batch dimension to a single observation."""
     if not isinstance(observation, dict):
         raise TypeError("observation must be a dict")
-    return {key: np.expand_dims(value, axis=0) for key, value in observation.items()}
+    return {key: value[None, ...] for key, value in observation.items()}
 
 
-def _done_mask(terminateds: Any, truncateds: Any) -> np.ndarray:
+def _done_mask(terminateds: Any, truncateds: Any) -> np.ndarray | jax.Array:
+    if isinstance(terminateds, jax.Array):
+        return jnp.logical_or(terminateds, truncateds)
     return np.logical_or(
         np.asarray(terminateds, dtype=bool),
         np.asarray(truncateds, dtype=bool),
     )
 
 
-def vector_real_reset_mask(env: Any, terminateds: Any, truncateds: Any, infos: Any) -> np.ndarray:
+def vector_real_reset_mask(
+    env: Any, terminateds: Any, truncateds: Any, infos: Any
+) -> np.ndarray | jax.Array:
     real_reset_mask = getattr(env, "real_reset_mask", None)
     if callable(real_reset_mask):
-        return np.asarray(real_reset_mask(terminateds, truncateds, infos), dtype=bool)
+        mask = real_reset_mask(terminateds, truncateds, infos)
+        return mask.astype(bool) if isinstance(mask, jax.Array) else np.asarray(mask, dtype=bool)
     return _done_mask(terminateds, truncateds)
 
 
-def vector_autoreset_mask(env: Any, terminateds: Any, truncateds: Any, infos: Any) -> np.ndarray:
+def vector_autoreset_mask(
+    env: Any, terminateds: Any, truncateds: Any, infos: Any
+) -> np.ndarray | jax.Array:
     autoreset_mask = getattr(env, "autoreset_mask", None)
     if callable(autoreset_mask):
-        return np.asarray(autoreset_mask(terminateds, truncateds, infos), dtype=bool)
+        mask = autoreset_mask(terminateds, truncateds, infos)
+        return mask.astype(bool) if isinstance(mask, jax.Array) else np.asarray(mask, dtype=bool)
     return _done_mask(terminateds, truncateds)
 
 

--- a/jax_baselines/core/epoch_buffer.py
+++ b/jax_baselines/core/epoch_buffer.py
@@ -1,69 +1,137 @@
-"""Runtime-neutral on-policy epoch buffer for actor-critic rollouts."""
+"""Worker-major on-policy batches stored in CPU or GPU memory."""
 
 from __future__ import annotations
 
+from typing import Literal, TypedDict
+
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 
+class EpochBatch(TypedDict):
+    obses: dict[str, np.ndarray | jax.Array]
+    actions: np.ndarray | jax.Array
+    rewards: np.ndarray | jax.Array
+    nxtobses: dict[str, np.ndarray | jax.Array]
+    terminateds: np.ndarray | jax.Array
+    truncateds: np.ndarray | jax.Array
+
+
+@jax.jit
+def _stack_transitions(transitions: list[EpochBatch]) -> EpochBatch:
+    return jax.tree.map(lambda *values: jnp.stack(values, axis=1), *transitions)
+
+
 class EpochBuffer:
-    def __init__(self, epoch_size: int, observation_space: dict, worker_size=1, action_space=1):
+    def __init__(
+        self,
+        epoch_size: int,
+        observation_space: dict,
+        worker_size=1,
+        action_space=1,
+        memory_backend: Literal["cpu", "gpu"] = "cpu",
+    ):
+        if epoch_size < 1 or worker_size < 1:
+            raise ValueError("epoch_size and worker_size must be positive")
+        if not isinstance(observation_space, dict) or not observation_space:
+            raise ValueError("observation_space must be a non-empty dict")
+        if memory_backend not in ("cpu", "gpu"):
+            raise ValueError("memory_backend must be 'cpu' or 'gpu'")
+        self.memory_backend = memory_backend
+        self._device: jax.Device | None = None
+        if memory_backend == "gpu":
+            try:
+                devices = jax.devices("gpu")
+            except RuntimeError as error:
+                raise RuntimeError(
+                    "GPU epoch memory requires an available JAX GPU device"
+                ) from error
+            if not devices:
+                raise RuntimeError("GPU epoch memory requires an available JAX GPU device")
+            self._device = devices[0]
         self.epoch_size = epoch_size
         self.observation_space = observation_space
         self.worker_size = worker_size
-        self.action_space = action_space
-        self.local_buffers = [[] for _ in range(worker_size)]
+        self.action_shape = (
+            (action_space,) if isinstance(action_space, int) else tuple(action_space)
+        )
+        self._transitions: list[EpochBatch] = []
 
     def add(self, obs_t, action, reward, nxtobs_t, terminated, truncated):
-        for worker_idx in range(self.worker_size):
-            self.local_buffers[worker_idx].append(
+        if len(self._transitions) >= self.epoch_size:
+            raise ValueError("EpochBuffer is full; consume the rollout before adding transitions")
+        if (
+            not isinstance(obs_t, dict)
+            or not isinstance(nxtobs_t, dict)
+            or obs_t.keys() != self.observation_space.keys()
+            or nxtobs_t.keys() != obs_t.keys()
+        ):
+            raise ValueError("Observation keys must match observation_space")
+        transition: EpochBatch
+        if self.memory_backend == "cpu":
+            transition = {
+                "obses": {key: np.array(value, copy=True) for key, value in obs_t.items()},
+                "actions": np.array(action, copy=True),
+                "rewards": np.array(reward, copy=True),
+                "nxtobses": {key: np.array(value, copy=True) for key, value in nxtobs_t.items()},
+                "terminateds": np.array(terminated, dtype=bool, copy=True),
+                "truncateds": np.array(truncated, dtype=bool, copy=True),
+            }
+        else:
+            transition = jax.tree.map(
+                lambda value: jnp.array(
+                    value, copy=not isinstance(value, jax.Array), device=self._device
+                ),
                 {
-                    "obses": {
-                        key: np.asarray(obs_t[key][worker_idx]) for key in self.observation_space
-                    },
-                    "action": np.asarray(action[worker_idx]),
-                    "reward": np.asarray(reward[worker_idx]),
-                    "nxtobses": {
-                        key: np.asarray(nxtobs_t[key][worker_idx]) for key in self.observation_space
-                    },
-                    "terminated": np.asarray(terminated[worker_idx]),
-                    "truncated": np.asarray(truncated[worker_idx]),
-                }
+                    "obses": obs_t,
+                    "actions": action,
+                    "rewards": reward,
+                    "nxtobses": nxtobs_t,
+                    "terminateds": terminated,
+                    "truncateds": truncated,
+                },
+                is_leaf=lambda value: isinstance(value, (list, tuple)),
             )
+        transition["rewards"] = transition["rewards"].reshape(self.worker_size)
+        transition["terminateds"] = (
+            transition["terminateds"].astype(bool, copy=False).reshape(self.worker_size)
+        )
+        transition["truncateds"] = (
+            transition["truncateds"].astype(bool, copy=False).reshape(self.worker_size)
+        )
+        for key, shape in self.observation_space.items():
+            expected = (self.worker_size, *shape)
+            if (
+                transition["obses"][key].shape != expected
+                or transition["nxtobses"][key].shape != expected
+            ):
+                raise ValueError(f"Expected observation {key!r} with shape {expected}")
+        if transition["actions"].shape != (self.worker_size, *self.action_shape):
+            raise ValueError(
+                f"Expected actions with shape {(self.worker_size, *self.action_shape)}"
+            )
+        self._transitions.append(transition)
 
-    def get_buffer(self):
-        transitions = {
-            "obses": {},
-            "actions": [],
-            "rewards": [],
-            "nxtobses": {},
-            "terminateds": [],
-            "truncateds": [],
-        }
-        for key in self.observation_space:
-            transitions["obses"][key] = np.asarray(
-                [
-                    [record["obses"][key] for record in worker_buffer]
-                    for worker_buffer in self.local_buffers
-                ]
-            )
-            transitions["nxtobses"][key] = np.asarray(
-                [
-                    [record["nxtobses"][key] for record in worker_buffer]
-                    for worker_buffer in self.local_buffers
-                ]
-            )
-        for worker_buffer in self.local_buffers:
-            transitions["actions"].append(
-                np.asarray([record["action"] for record in worker_buffer])
-            )
-            transitions["rewards"].append(
-                np.asarray([record["reward"] for record in worker_buffer])
-            )
-            transitions["terminateds"].append(
-                np.asarray([record["terminated"] for record in worker_buffer])
-            )
-            transitions["truncateds"].append(
-                np.asarray([record["truncated"] for record in worker_buffer])
-            )
-            worker_buffer.clear()
+    def get_buffer(self) -> EpochBatch:
+        if not self._transitions:
+            raise ValueError("Cannot consume an empty EpochBuffer")
+        if self.memory_backend == "cpu":
+            transitions: EpochBatch = {
+                "obses": {
+                    key: np.stack([row["obses"][key] for row in self._transitions], axis=1)
+                    for key in self.observation_space
+                },
+                "actions": np.stack([row["actions"] for row in self._transitions], axis=1),
+                "rewards": np.stack([row["rewards"] for row in self._transitions], axis=1),
+                "nxtobses": {
+                    key: np.stack([row["nxtobses"][key] for row in self._transitions], axis=1)
+                    for key in self.observation_space
+                },
+                "terminateds": np.stack([row["terminateds"] for row in self._transitions], axis=1),
+                "truncateds": np.stack([row["truncateds"] for row in self._transitions], axis=1),
+            }
+        else:
+            transitions = _stack_transitions(self._transitions)
+        self._transitions.clear()
         return transitions

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -1,3 +1,4 @@
+import jax
 import numpy as np
 
 from jax_baselines.core.env_info import prepare_worker_env
@@ -92,12 +93,10 @@ def _normalize_action_for_step(step_action):
     therefore always returned as a 1-D array. A leading batch dim of size 1
     (single-env rollout) is squeezed in both cases.
     """
-    arr = np.asarray(step_action)
-    if arr.ndim >= 2 and arr.shape[0] == 1:
-        arr = np.asarray(arr[0])
+    arr = step_action if isinstance(step_action, jax.Array) else np.asarray(step_action)
     if np.issubdtype(arr.dtype, np.integer) and arr.size == 1:
-        return arr.reshape(-1)[0].item()
-    return np.reshape(arr, (-1,))
+        return arr.item()
+    return arr.reshape(-1)
 
 
 def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, conv_action=None):

--- a/jax_baselines/core/rollout_stats.py
+++ b/jax_baselines/core/rollout_stats.py
@@ -15,9 +15,43 @@ families keep their own server-side aggregation and do not use this tracker
 
 from collections import deque
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 from jax_baselines.core.eval import log_measurement
+
+
+@jax.jit
+def device_episode_step(
+    state, rewards, terminateds, truncateds, real_reset, autoreset, original, original_present
+):
+    """Accumulate one vector step without transferring episode state to the host.
+
+    State is ``(scores, lengths, originals, seen_original, prev_done)``. Completed
+    rows retain worker order: ``(done, score, length, timeout, original, emit_original)``.
+    """
+    scores, lengths, originals, seen_original, prev_done = state
+    active = ~prev_done
+    done = (terminateds | truncateds) & active
+    scores = scores + jnp.where(active, rewards, 0)
+    lengths = lengths + active.astype(lengths.dtype)
+    originals = originals + jnp.where(active & original_present, original, 0)
+    seen_original = seen_original | (active & original_present)
+    emit_original = done & real_reset & seen_original
+    completed = jnp.stack((done, scores, lengths, truncateds, originals, emit_original), axis=-1)
+    return (
+        (
+            jnp.where(done, 0, scores),
+            jnp.where(done, 0, lengths),
+            jnp.where(emit_original, 0, originals),
+            seen_original & ~emit_original,
+            done & autoreset,
+        ),
+        jnp.where(prev_done, 0, rewards),
+        terminateds | prev_done,
+        completed,
+    )
 
 
 class EpisodeTracker:

--- a/jax_baselines/math/statistics.py
+++ b/jax_baselines/math/statistics.py
@@ -1,3 +1,5 @@
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 
@@ -42,33 +44,86 @@ def compute_ckpt_window_stat(
         )
 
 
+@jax.jit
+def _update_device_moments(xs, means, variances, count):
+    batch_count = next(iter(xs.values())).shape[0]
+    total_count = count + batch_count
+    next_means = {}
+    next_variances = {}
+    for key, mean in means.items():
+        x = jnp.asarray(xs[key], dtype=mean.dtype)
+        delta = jnp.mean(x, axis=0) - mean
+        next_means[key] = mean + delta * batch_count / total_count
+        next_variances[key] = (
+            variances[key] * count
+            + jnp.var(x, axis=0) * batch_count
+            + jnp.square(delta) * count * batch_count / total_count
+        ) / total_count
+    return next_means, next_variances, total_count
+
+
+@jax.jit
+def _normalize_device_observations(xs, means, variances):
+    return {key: (xs[key] - mean) / jnp.sqrt(variances[key] + 1e-8) for key, mean in means.items()}
+
+
 class RunningMeanStd:
     """Tracks the mean, variance and count of values."""
 
-    def __init__(self, epsilon=1e-4, shapes: dict | None = None, dtype=np.float64):
-        """Tracks the mean, variance and count of values."""
+    def __init__(
+        self, epsilon=1e-4, shapes: dict | None = None, dtype=np.float64, *, on_device: bool = False
+    ):
+        """Track running statistics; device mode keeps all runtime state in float32 JAX arrays."""
         if shapes is None:
             shapes = {"unified_obs": ()}
         elif not isinstance(shapes, dict):
             raise TypeError("shapes must be a dict")
-        self.dtype = np.dtype(dtype)
-        self.means = {key: np.zeros(shape, dtype=self.dtype) for key, shape in shapes.items()}
-        self.vars = {key: np.ones(shape, dtype=self.dtype) for key, shape in shapes.items()}
-        self.count = epsilon
+        self.on_device = on_device
+        self.dtype = np.dtype(np.float32 if on_device else dtype)
+        array_module = jnp if on_device else np
+        self.means = {
+            key: array_module.zeros(shape, dtype=self.dtype) for key, shape in shapes.items()
+        }
+        self.vars = {
+            key: array_module.ones(shape, dtype=self.dtype) for key, shape in shapes.items()
+        }
+        self.count = jnp.asarray(epsilon, dtype=jnp.float32) if on_device else epsilon
 
     def normalize(self, xs):
         """Normalizes the input using the running mean and variance."""
+        if self.on_device:
+            return _normalize_device_observations(xs, self.means, self.vars)
         return {
-            key: (xs[key] - self.means[key]) / np.sqrt(self.vars[key] + 1e-8) for key in self.means
+            key: (np.asarray(xs[key]) - self.means[key]) / np.sqrt(self.vars[key] + 1e-8)
+            for key in self.means
         }
 
     def update(self, xs):
         """Updates the mean, var and count from a batch of samples."""
+        if self.on_device:
+            if not isinstance(xs, dict) or xs.keys() != self.means.keys():
+                raise ValueError("Observation batches must match the running-statistics keys")
+            if not self.means:
+                return
+            batch_sizes = set()
+            for key, mean in self.means.items():
+                x = xs[key]
+                if x.ndim != mean.ndim + 1 or x.shape[1:] != mean.shape:
+                    raise ValueError(
+                        f"Observation batch {key!r} must have shape (batch, {mean.shape})"
+                    )
+                batch_sizes.add(x.shape[0])
+            if len(batch_sizes) != 1 or 0 in batch_sizes:
+                raise ValueError("Observation batches must share a positive leading dimension")
+            self.means, self.vars, self.count = _update_device_moments(
+                xs, self.means, self.vars, self.count
+            )
+            return
         means = {}
         vars = {}
         batch_count = None
         for key, mean in self.means.items():
-            x = xs[key]
+            x = np.asarray(xs[key])
             var = self.vars[key]
             batch_mean = np.mean(x, axis=0)
             batch_var = np.var(x, axis=0)
@@ -108,7 +163,7 @@ class RunningMeanStd:
         }
 
     @classmethod
-    def from_state(cls, state):
+    def from_state(cls, state, *, on_device: bool = False):
         """Deserialize running statistics from a saved state."""
         means = state["means"]
         vars_ = state["vars"]
@@ -122,10 +177,19 @@ class RunningMeanStd:
             raise ValueError("Running statistics means and vars must have matching shapes")
         dtype = next(iter(means.values())).dtype if means else np.float64
         shapes = {key: arr.shape for key, arr in means.items()}
-        instance = cls(shapes=shapes, dtype=dtype)
-        instance.means = {key: arr.astype(dtype, copy=False) for key, arr in means.items()}
-        instance.vars = {key: arr.astype(dtype, copy=False) for key, arr in vars_.items()}
-        instance.count = float(np.asarray(state["count"]))
+        instance = cls(shapes=shapes, dtype=dtype, on_device=on_device)
+        array_module = jnp if on_device else np
+        instance.means = {
+            key: array_module.asarray(arr, dtype=instance.dtype) for key, arr in means.items()
+        }
+        instance.vars = {
+            key: array_module.asarray(arr, dtype=instance.dtype) for key, arr in vars_.items()
+        }
+        instance.count = (
+            jnp.asarray(state["count"], dtype=jnp.float32)
+            if on_device
+            else float(np.asarray(state["count"]))
+        )
         return instance
 
 

--- a/tests/test_ac_memory_backend.py
+++ b/tests/test_ac_memory_backend.py
@@ -1,0 +1,150 @@
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+
+from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
+from jax_baselines.core.env_protocols import PreparedEnvSpec
+
+
+class _Env:
+    action_space = object()
+
+    def __init__(self, observation):
+        self.observation_space = {"unified_obs": [2]}
+        self.observation = observation
+        self.resets = 0
+
+    def prepare_envs(self, num_workers=1, seed=None):
+        return PreparedEnvSpec(
+            self,
+            self,
+            {
+                "observation_space": self.observation_space,
+                "action_size": [1],
+                "action_type": "continuous",
+                "env_type": "single",
+                "env_id": "MemoryBackend-v0",
+                "worker_num": 1,
+                "core_env_type": "SingleEnv",
+            },
+        )
+
+    def reset(self):
+        self.resets += 1
+        return {"unified_obs": self.observation}, {}
+
+    def step(self, action):
+        return {"unified_obs": self.observation}, 1.0, False, False, {}
+
+    def close(self):
+        pass
+
+
+@pytest.mark.parametrize("backend", ["auto", "cpu"])
+@pytest.mark.parametrize("jax_observation", [False, True])
+def test_host_environment_keeps_rollout_arrays_on_cpu(backend, jax_observation):
+    observation = np.array([1.0, 2.0], np.float32)
+    if jax_observation:
+        observation = jax.device_put(observation, jax.devices("cpu")[0])
+    agent = Actor_Critic_Policy_Gradient_Family(
+        _Env(observation),
+        None,
+        memory_backend=backend,
+        obs_normalization=True,
+        optimizer_factory=optax.sgd,
+        _init_setup_model=False,
+    )
+    agent.get_memory_setup()
+    assert agent.memory_backend == "cpu"
+    assert agent.buffer.memory_backend == "cpu"
+    assert agent.obs_rms is not None
+    assert all(isinstance(value, np.ndarray) for value in agent.obs_rms.means.values())
+    normalized = agent.normalize_observation({"unified_obs": observation[None, :]})
+    assert isinstance(normalized["unified_obs"], np.ndarray)
+    agent._get_actions = lambda params, obs: (jnp.zeros((1, 1)), jnp.ones((1, 1)))
+    assert isinstance(agent.action_continuous(normalized), np.ndarray)
+    agent._get_actions = lambda params, obs: jnp.array([[0.25, 0.75]])
+    assert isinstance(agent.action_discrete(normalized), np.ndarray)
+
+
+@pytest.mark.parametrize("backend", ["auto", "gpu", "cpu"])
+def test_gpu_environment_selects_device_memory_unless_cpu_requested(backend):
+    gpu_devices = [device for device in jax.devices() if device.platform == "gpu"]
+    if not gpu_devices:
+        pytest.skip("Requires a JAX GPU")
+    agent = Actor_Critic_Policy_Gradient_Family(
+        _Env(jax.device_put(np.ones(2, np.float32), gpu_devices[0])),
+        None,
+        memory_backend=backend,
+        obs_normalization=True,
+        optimizer_factory=optax.sgd,
+        _init_setup_model=False,
+    )
+    agent.get_memory_setup()
+    expected = "cpu" if backend == "cpu" else "gpu"
+    assert agent.memory_backend == expected
+    assert agent.buffer.memory_backend == expected
+    assert agent.obs_rms is not None
+    if expected == "gpu":
+        mean = agent.obs_rms.means["unified_obs"]
+        assert isinstance(mean, jax.Array)
+        assert all(device.platform == "gpu" for device in mean.devices())
+    else:
+        assert isinstance(agent.obs_rms.means["unified_obs"], np.ndarray)
+
+
+def test_forced_gpu_fails_without_gpu():
+    if any(device.platform == "gpu" for device in jax.devices()):
+        pytest.skip("Requires a CPU-only JAX runtime")
+    with pytest.raises(RuntimeError, match="GPU|gpu"):
+        agent = Actor_Critic_Policy_Gradient_Family(
+            _Env(np.ones(2, np.float32)),
+            None,
+            memory_backend="gpu",
+            optimizer_factory=optax.sgd,
+            _init_setup_model=False,
+        )
+        agent.get_memory_setup()
+
+
+@pytest.mark.parametrize("backend", ["numpy", "cuda"])
+def test_invalid_memory_backend_fails_at_construction(backend):
+    with pytest.raises(ValueError, match="memory_backend"):
+        Actor_Critic_Policy_Gradient_Family(
+            _Env(np.ones(2, np.float32)),
+            None,
+            memory_backend=backend,
+            optimizer_factory=optax.sgd,
+            _init_setup_model=False,
+        )
+
+
+def test_auto_detection_reuses_single_environment_reset_in_first_rollout():
+    env = _Env(np.array([7.0, 11.0], np.float32))
+    agent = Actor_Critic_Policy_Gradient_Family(
+        env,
+        None,
+        batch_size=3,
+        optimizer_factory=optax.sgd,
+        _init_setup_model=False,
+    )
+    agent.get_memory_setup()
+    agent.actions = lambda obs: np.zeros((1, 1), np.float32)
+
+    agent.learn_SingleEnv(
+        SimpleNamespace(
+            pbar=range(1, 2),
+            logger_run=SimpleNamespace(log_metric=lambda *args: None),
+            log_interval=100,
+            eval_freq=100,
+        )
+    )
+
+    assert env.resets == 1
+    np.testing.assert_array_equal(
+        agent.buffer.get_buffer()["obses"]["unified_obs"], [[[7.0, 11.0]]]
+    )

--- a/tests/test_ac_observation_normalization.py
+++ b/tests/test_ac_observation_normalization.py
@@ -10,6 +10,8 @@ from jax_baselines.math.statistics import RunningMeanStd
 
 def _agent(enabled=True):
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.observation_space = {"unified_obs": [1]}
     agent.obs_normalization = enabled
     agent.obs_rms = (

--- a/tests/test_device_rollout_stats.py
+++ b/tests/test_device_rollout_stats.py
@@ -1,0 +1,85 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jax_baselines.core.rollout_stats import EpisodeTracker, device_episode_step
+
+
+def test_device_episode_stats_preserve_lifeloss_dummy_steps_and_batched_logging():
+    state = (
+        jnp.zeros(2),
+        jnp.zeros(2, dtype=jnp.int32),
+        jnp.zeros(2),
+        jnp.zeros(2, dtype=bool),
+        jnp.zeros(2, dtype=bool),
+    )
+    # A life loss, real episode ends, poisoned reset dummies, then same-step resets.
+    rewards = jnp.array([[1, 10], [2, 20], [999, 888], [3, 30], [4, 40]], dtype=jnp.float32)
+    terminated = jnp.array([[1, 0], [1, 0], [1, 0], [1, 1], [1, 1]], dtype=bool)
+    truncated = jnp.array([[0, 0], [0, 1], [0, 1], [0, 0], [0, 0]], dtype=bool)
+    real_reset = jnp.array([[0, 0], [1, 1], [1, 1], [1, 1], [1, 1]], dtype=bool)
+    autoreset = jnp.array([[0, 0], [1, 1], [1, 1], [0, 0], [0, 0]], dtype=bool)
+    original = jnp.array(
+        [[100, 1000], [200, 2000], [99999, 88888], [300, 0], [0, 0]], dtype=jnp.float32
+    )
+    original_present = jnp.array([[1, 1], [1, 1], [1, 1], [1, 0], [0, 0]], dtype=bool)
+    step_inputs = list(
+        zip(rewards, terminated, truncated, real_reset, autoreset, original, original_present)
+    )
+    completed_steps = []
+    corrected_rewards = []
+    corrected_terminated = []
+    with jax.transfer_guard("disallow"):
+        for inputs in step_inputs:
+            state, reward, terminal, completed = device_episode_step(state, *inputs)
+            corrected_rewards.append(reward)
+            corrected_terminated.append(terminal)
+            completed_steps.append(completed)
+        completed_batch = jnp.stack(completed_steps)
+
+    np.testing.assert_array_equal(jnp.stack(corrected_rewards)[2], [0, 0])
+    np.testing.assert_array_equal(jnp.stack(corrected_terminated)[2], [True, True])
+    np.testing.assert_array_equal(
+        jnp.stack(corrected_rewards)[[0, 1, 3, 4], :], rewards[[0, 1, 3, 4], :]
+    )
+    observed = []
+    logs = []
+    tracker = EpisodeTracker(lambda *args: logs.append(args), log_interval=2, window=3)
+    for step, completed in enumerate(jax.device_get(completed_batch)):
+        for done, score, length, timeout, original_score, emit_original in completed:
+            if not done:
+                continue
+            observed.append(
+                (step * 2, score, length, timeout, original_score if emit_original else None)
+            )
+            tracker.record(
+                step * 2,
+                episode_reward=score,
+                episode_length=length,
+                timeout=timeout,
+                original_reward=original_score if emit_original else None,
+            )
+    expected = [
+        (0, 1, 1, 0, None),
+        (2, 2, 1, 0, 300),
+        (2, 30, 2, 1, 3000),
+        (6, 3, 1, 0, 300),
+        (6, 30, 1, 0, None),
+        (8, 4, 1, 0, None),
+        (8, 40, 1, 0, None),
+    ]
+    assert observed == expected
+    reference_logs = []
+    reference = EpisodeTracker(lambda *args: reference_logs.append(args), log_interval=2, window=3)
+    for step, score, length, timeout, original_score in expected:
+        reference.record(
+            step,
+            episode_reward=score,
+            episode_length=length,
+            timeout=timeout,
+            original_reward=original_score,
+        )
+    assert logs == reference_logs
+    assert tracker.describe() == reference.describe()
+    for value in state:
+        np.testing.assert_array_equal(value, [0, 0])

--- a/tests/test_device_statistics.py
+++ b/tests/test_device_statistics.py
@@ -1,0 +1,78 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jax_baselines.math.statistics import RunningMeanStd
+
+
+def test_host_statistics_keep_jax_observations_on_numpy_boundary():
+    host = RunningMeanStd(epsilon=0.0, shapes={"actor_obs": (2,)}, on_device=False)
+    observations = {"actor_obs": jnp.array([[1.0, 10.0], [3.0, 14.0]])}
+
+    host.update(observations)
+    normalized = host.normalize(observations)
+
+    assert isinstance(host.means["actor_obs"], np.ndarray)
+    assert isinstance(host.vars["actor_obs"], np.ndarray)
+    assert isinstance(normalized["actor_obs"], np.ndarray)
+    assert not isinstance(host.count, jax.Array)
+    np.testing.assert_array_equal(host.means["actor_obs"], [2.0, 12.0])
+    np.testing.assert_array_equal(host.vars["actor_obs"], [1.0, 4.0])
+    np.testing.assert_allclose(normalized["actor_obs"], [[-1.0, -1.0], [1.0, 1.0]], atol=1e-8)
+
+
+@pytest.mark.parametrize("epsilon", [0.0, 1e-4])
+def test_device_statistics_match_numpy_and_restore_without_runtime_transfers(epsilon):
+    shapes = {"actor_obs": (3,), "critic_obs": (2,)}
+    host = RunningMeanStd(epsilon=epsilon, shapes=shapes, dtype=np.float32)
+    device = RunningMeanStd(epsilon=epsilon, shapes=shapes, on_device=True)
+    rng = np.random.default_rng(7)
+    for batch_size in (7, 3, 11):
+        observations = {
+            key: rng.normal(size=(batch_size, *shape)).astype(np.float32)
+            for key, shape in shapes.items()
+        }
+        device_observations = jax.tree.map(jnp.asarray, observations)
+        host.update(observations)
+        with jax.transfer_guard("disallow"):
+            device.update(device_observations)
+            normalized = device.normalize(device_observations)
+        for key in shapes:
+            assert isinstance(device.means[key], jax.Array)
+            assert isinstance(device.vars[key], jax.Array)
+            assert isinstance(normalized[key], jax.Array)
+            np.testing.assert_allclose(device.means[key], host.means[key], atol=1e-6)
+            np.testing.assert_allclose(device.vars[key], host.vars[key], rtol=1e-5)
+            np.testing.assert_allclose(
+                normalized[key], host.normalize(observations)[key], atol=1e-6
+            )
+    assert isinstance(device.count, jax.Array)
+    assert device.count.dtype == jnp.float32
+    assert float(device.count) == pytest.approx(host.count)
+    restored = RunningMeanStd.from_state(device.to_state(), on_device=True)
+    with jax.transfer_guard("disallow"):
+        restored.update(device_observations)
+        device.update(device_observations)
+    for key in shapes:
+        np.testing.assert_array_equal(restored.means[key], device.means[key])
+        np.testing.assert_array_equal(restored.vars[key], device.vars[key])
+    np.testing.assert_array_equal(restored.count, device.count)
+
+
+@pytest.mark.parametrize(
+    "observations",
+    [
+        {"actor_obs": np.zeros((2, 3)), "critic_obs": np.zeros((3, 2))},
+        {"actor_obs": np.zeros((2, 4)), "critic_obs": np.zeros((2, 2))},
+        {"actor_obs": np.zeros((0, 3)), "critic_obs": np.zeros((0, 2))},
+        {"actor_obs": np.zeros((2, 3))},
+    ],
+)
+def test_device_statistics_validate_batch_before_updating(observations):
+    device = RunningMeanStd(
+        epsilon=0.0, shapes={"actor_obs": (3,), "critic_obs": (2,)}, on_device=True
+    )
+    with pytest.raises(ValueError, match="Observation batch"):
+        device.update(observations)
+    assert float(device.count) == 0.0

--- a/tests/test_env_builder_adapter.py
+++ b/tests/test_env_builder_adapter.py
@@ -344,6 +344,7 @@ def test_infer_action_meta_uses_adapter_normalized_action_type():
     action = np.array([6.0, -6.0])
     np.testing.assert_array_equal(continuous_conv(action), [5.0, -5.0])
     np.testing.assert_array_equal(action, [6.0, -6.0])
+    np.testing.assert_array_equal(action, [6.0, -6.0])
 
 
 def test_env_builder_adapter_prepares_train_eval_pair_and_seed_policy():
@@ -461,6 +462,7 @@ def test_experiments_composition_path_uses_adapter_prepared_envs(monkeypatch):
                 "observation_key": None,
                 "episode_length": None,
                 "device": "cuda:0",
+                "jax_arrays": False,
             },
         ),
         ("prepare_envs", 4, 21),
@@ -485,6 +487,7 @@ def test_mjlab_backend_is_lazy_and_receives_its_supported_options(monkeypatch):
         observation_key="policy.obs",
         episode_length=7,
         device="cpu",
+        jax_arrays=True,
     )
 
     mjlab(3, seed=4, render_mode="rgb_array")
@@ -499,6 +502,7 @@ def test_mjlab_backend_is_lazy_and_receives_its_supported_options(monkeypatch):
                 "episode_length": 7,
                 "device": "cpu",
                 "render_mode": "rgb_array",
+                "jax_arrays": True,
             },
         ),
     ]
@@ -558,6 +562,7 @@ def test_shared_local_cli_env_options_forward_to_builder(monkeypatch):
             "12",
             "--env_device",
             "cpu",
+            "--env_jax_arrays",
         ]
     )
 
@@ -569,6 +574,7 @@ def test_shared_local_cli_env_options_forward_to_builder(monkeypatch):
         "observation_key": "policy.joints",
         "episode_length": 12,
         "device": "cpu",
+        "jax_arrays": True,
     }
 
 

--- a/tests/test_epoch_buffer_device.py
+++ b/tests/test_epoch_buffer_device.py
@@ -1,0 +1,114 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jax_baselines.core.epoch_buffer import EpochBuffer
+from jax_baselines.core.eval import _normalize_action_for_step
+
+
+def test_epoch_buffer_keeps_worker_time_order_and_snapshots_across_rollouts():
+    buffer = EpochBuffer(3, {"actor_obs": [2], "critic_obs": [1]}, 2, [1])
+    assert buffer.memory_backend == "cpu"
+    for _ in range(2):
+        observations = []
+        for step in range(3):
+            obs = {
+                "actor_obs": np.full((2, 2), step, np.float32),
+                "critic_obs": np.array([[step], [10 + step]], np.float32),
+            }
+            observations.append({key: value.copy() for key, value in obs.items()})
+            action = np.array([[step], [step + 1]], np.float32)
+            reward = np.array([step, step + 2], np.float32)
+            terminated = np.array([False, True])
+            truncated = np.array([True, False])
+            buffer.add(obs, action, reward, obs, terminated, truncated)
+            for value in obs.values():
+                value.fill(-99)
+            action.fill(-99)
+            reward.fill(-99)
+            terminated.fill(False)
+            truncated.fill(False)
+        with pytest.raises(ValueError, match="full"):
+            buffer.add({}, [], [], {}, [], [])
+        batch = buffer.get_buffer()
+        assert all(isinstance(value, np.ndarray) for value in jax.tree.leaves(batch))
+        for key in observations[0]:
+            np.testing.assert_array_equal(
+                batch["obses"][key], np.stack([o[key] for o in observations], axis=1)
+            )
+        np.testing.assert_array_equal(batch["actions"], [[[0], [1], [2]], [[1], [2], [3]]])
+        np.testing.assert_array_equal(batch["rewards"], [[0, 1, 2], [2, 3, 4]])
+        np.testing.assert_array_equal(batch["terminateds"], [[False] * 3, [True] * 3])
+        np.testing.assert_array_equal(batch["truncateds"], [[True] * 3, [False] * 3])
+        with pytest.raises(ValueError, match="empty"):
+            buffer.get_buffer()
+
+
+@pytest.fixture
+def gpu_device():
+    try:
+        devices = jax.devices("gpu")
+    except RuntimeError:
+        pytest.skip("JAX GPU backend is unavailable")
+    if not devices:
+        pytest.skip("JAX GPU backend is unavailable")
+    return devices[0]
+
+
+def test_epoch_buffer_accepts_device_arrays_without_host_transfers(gpu_device):
+    buffer = EpochBuffer(2, {"unified_obs": [2]}, 2, [1], memory_backend="gpu")
+    with jax.default_device(gpu_device):
+        obs = {"unified_obs": jnp.arange(4, dtype=jnp.float32).reshape(2, 2)}
+        action, reward, done = jnp.ones((2, 1)), jnp.ones(2), jnp.zeros(2, dtype=bool)
+    with jax.transfer_guard("disallow"):
+        for _ in range(2):
+            buffer.add(obs, action, reward, obs, done, done)
+        batch = buffer.get_buffer()
+        jax.block_until_ready(batch)
+    assert batch["obses"]["unified_obs"].shape == (2, 2, 2)
+    assert len(jax.tree.leaves(batch)) == 6
+    assert all(value.devices() == {gpu_device} for value in jax.tree.leaves(batch))
+
+
+def test_continuous_evaluation_action_preserves_device_array():
+    action = jnp.ones((1, 12), dtype=jnp.float32)
+    with jax.transfer_guard("disallow"):
+        normalized = _normalize_action_for_step(action)
+        jax.block_until_ready(normalized)
+    assert isinstance(normalized, jax.Array)
+    assert normalized.shape == (12,)
+
+
+def test_gpu_epoch_memory_ignores_cpu_default_device_and_snapshots_host_inputs(
+    gpu_device,
+):
+    with jax.default_device(jax.devices("cpu")[0]):
+        buffer = EpochBuffer(1, {"unified_obs": [2]}, 2, [1], memory_backend="gpu")
+        obs = {"unified_obs": np.arange(4, dtype=np.float32).reshape(2, 2)}
+        buffer.add(obs, [[1], [2]], [3, 4], obs, [False, True], [True, False])
+        obs["unified_obs"].fill(-99)
+        batch = buffer.get_buffer()
+        jax.block_until_ready(batch)
+    assert buffer.memory_backend == "gpu"
+    assert all(value.devices() == {gpu_device} for value in jax.tree.leaves(batch))
+    np.testing.assert_array_equal(batch["obses"]["unified_obs"], [[[0, 1]], [[2, 3]]])
+    np.testing.assert_array_equal(batch["rewards"], [[3], [4]])
+    assert batch["terminateds"].dtype == np.bool_
+
+
+def test_gpu_epoch_memory_fails_clearly_when_gpu_is_unavailable(monkeypatch):
+    def unavailable_devices(backend):
+        assert backend == "gpu"
+        raise RuntimeError("GPU backend unavailable")
+
+    monkeypatch.setattr(jax, "devices", unavailable_devices)
+    with pytest.raises(RuntimeError, match="GPU epoch memory requires an available JAX GPU"):
+        EpochBuffer(1, {"unified_obs": [2]}, memory_backend="gpu")
+    assert EpochBuffer(1, {"unified_obs": [2]}).memory_backend == "cpu"
+
+
+@pytest.mark.parametrize("memory_backend", ["auto", "tpu", None])
+def test_epoch_memory_rejects_unresolved_or_invalid_backend(memory_backend):
+    with pytest.raises(ValueError, match="memory_backend must be"):
+        EpochBuffer(1, {"unified_obs": [2]}, memory_backend=memory_backend)

--- a/tests/test_mjlab_env_adapter.py
+++ b/tests/test_mjlab_env_adapter.py
@@ -2,12 +2,16 @@ import builtins
 import sys
 from types import ModuleType, SimpleNamespace
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from env_builder.env_builder import get_env_builder
 from env_builder.mjlab_env import MjlabSingleEnv, MjlabVectorizedEnv, make_mjlab_env
 from jax_baselines.core.env_protocols import SingleEnv, VectorizedEnv
+
+torch = pytest.importorskip("torch")
 
 
 class FakeEnv:
@@ -17,16 +21,16 @@ class FakeEnv:
         self.cfg, self.device = cfg, device
         self.num_envs = cfg.scene.num_envs
         self.single_action_space = SimpleNamespace(shape=(1,))
-        self.obs = np.zeros((self.num_envs, 1), dtype=np.float32)
-        self.critic_obs = np.zeros((self.num_envs, 2), dtype=np.float32)
-        self.rewards = np.zeros(self.num_envs, dtype=np.float32)
-        self.terminated = np.zeros(self.num_envs, dtype=bool)
-        self.truncated = self.terminated.copy()
+        self.obs = torch.zeros((self.num_envs, 1))
+        self.critic_obs = torch.zeros((self.num_envs, 2))
+        self.rewards = torch.zeros(self.num_envs)
+        self.terminated = torch.zeros(self.num_envs, dtype=torch.bool)
+        self.truncated = self.terminated.clone()
         self.resets, self.closed = [], 0
 
     def reset(self, *, seed=None, env_ids=None):
         self.resets.append((seed, env_ids))
-        ids = np.arange(self.num_envs) if env_ids is None else env_ids
+        ids = torch.arange(self.num_envs) if env_ids is None else env_ids
         self.obs[ids] = 0 if seed is None else seed
         self.critic_obs[ids] = 100 if seed is None else seed + 100
         self.rewards[ids] = 0
@@ -71,11 +75,6 @@ def install_runtime(monkeypatch):
         episode_length_s=20,
     )
     modules = {
-        "torch": {
-            "as_tensor": lambda a, dtype, device: np.asarray(a, dtype=dtype),
-            "float32": np.float32,
-            "int64": np.int64,
-        },
         "mjlab": {},
         "mjlab.tasks": {},
         "mjlab.envs": {"ManagerBasedRlEnv": FakeEnv},
@@ -88,9 +87,10 @@ def install_runtime(monkeypatch):
     return cfg
 
 
-def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch):
+@pytest.mark.parametrize("jax_arrays", [False, True])
+def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch, jax_arrays):
     cfg = install_runtime(monkeypatch)
-    env = make_mjlab_env("task", 3, seed=7, episode_length=5, device="cpu")
+    env = make_mjlab_env("task", 3, seed=7, episode_length=5, device="cpu", jax_arrays=jax_arrays)
     assert isinstance(env, MjlabVectorizedEnv)
     assert VectorizedEnv in type(env).__mro__
     assert cfg.scene.num_envs == 3 and cfg.seed == 7 and not cfg.auto_reset
@@ -111,6 +111,7 @@ def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch
     with pytest.raises(RuntimeError, match="in flight"):
         env.reset()
     obs, reward, terminated, truncated, info = env.get_result()
+    assert isinstance(obs["actor_state"], jax.Array if jax_arrays else np.ndarray)
     np.testing.assert_array_equal(obs["actor_state"], [[8], [8], [8]])
     np.testing.assert_array_equal(env.current_obs()["actor_state"], [[0], [0], [8]])
     np.testing.assert_array_equal(obs["critic_obs"], [[117, 117]] * 3)
@@ -128,9 +129,34 @@ def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch
         env.real_reset_mask(terminated, truncated, {}), [True, True, False]
     )
     assert not env.autoreset_mask(terminated, truncated, {}).any()
+    env.step(jnp.zeros((3, 1)) if jax_arrays else np.zeros((3, 1)))
+    env.get_result()
+    np.testing.assert_array_equal(obs["actor_state"], [[8], [8], [8]])
+    np.testing.assert_array_equal(reward, [-1, 2, 1])
+    np.testing.assert_array_equal(info["metric"], [-1, 2, 1])
     env.close()
     env.close()
     assert env.env.closed == 1
+
+
+def test_jax_exchange_does_not_convert_torch_tensors_to_cpu_or_numpy(monkeypatch):
+    install_runtime(monkeypatch)
+
+    def host_conversion(*args, **kwargs):
+        raise AssertionError("JAX tensor exchange must stay on the device")
+
+    with monkeypatch.context() as guard:
+        guard.setattr(torch.Tensor, "cpu", host_conversion)
+        guard.setattr(torch.Tensor, "numpy", host_conversion)
+        env = make_mjlab_env("task", 2, device="cpu", jax_arrays=True)
+        assert isinstance(env, MjlabVectorizedEnv)
+        env.step(jnp.array([[-1.0], [1.0]]))
+        obs, reward, terminated, truncated, info = env.get_result()
+        assert all(
+            isinstance(value, jax.Array)
+            for value in (*obs.values(), reward, terminated, truncated, info["metric"])
+        )
+        env.close()
 
 
 def test_single_reset_cache_explicit_seed_and_default_duration(monkeypatch):
@@ -221,6 +247,7 @@ def test_missing_optional_runtime_has_install_hint(monkeypatch):
 def test_recording_preserves_terminal_frame_until_the_next_reset(monkeypatch):
     install_runtime(monkeypatch)
     env = make_mjlab_env("task", seed=3, device="cpu", render_mode="rgb_array")
+    assert isinstance(env, MjlabSingleEnv)
     assert env.render_mode == "rgb_array" and env.metadata["render_fps"] == 50
     env.reset()
     assert (env.render() == 3).all()
@@ -239,6 +266,7 @@ def test_training_does_not_render(monkeypatch):
 
     monkeypatch.setattr(FakeEnv, "render", unexpected_render)
     env = make_mjlab_env("task", worker_num=2, device="cpu")
+    assert isinstance(env, MjlabVectorizedEnv)
     env.step(np.zeros((2, 1)))
     env.get_result()
     env.close()

--- a/tests/test_pg_ppo2_fidelity_cli.py
+++ b/tests/test_pg_ppo2_fidelity_cli.py
@@ -30,6 +30,7 @@ def test_pg_cli_preserves_ppo2_control_defaults():
         assert "optimizer_eps" not in built
         assert "max_grad_norm" not in built
         assert built["lr_annealing"] is False
+        assert built["memory_backend"] == "auto"
 
     assert ppo["ppo_eps"] == pytest.approx(0.2)
     assert ppo["value_clip"] == pytest.approx(2.0)
@@ -37,6 +38,12 @@ def test_pg_cli_preserves_ppo2_control_defaults():
     assert "ppo_eps" not in tppo
     assert "ppo_eps" not in a2c
     assert "value_clip" not in a2c
+
+
+@pytest.mark.parametrize("algo", ["A2C", "PPO", "TPPO", "SPO"])
+@pytest.mark.parametrize("backend", ["cpu", "gpu"])
+def test_pg_cli_forwards_memory_backend(algo, backend):
+    assert _build(algo, ["--memory_backend", backend])["memory_backend"] == backend
 
 
 @pytest.mark.parametrize(

--- a/tests/test_returns_episode_boundary.py
+++ b/tests/test_returns_episode_boundary.py
@@ -346,6 +346,8 @@ class _Ctx:
 
 def test_a2c_vectorized_flags_autoreset_dummy_step_as_terminal():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     # step0 normal, step1 worker0 terminates, step2 worker0 emits autoreset dummy.
     agent.env = _ScriptEnv(
@@ -381,6 +383,8 @@ def test_a2c_vectorized_flags_autoreset_dummy_step_as_terminal():
 
 def test_a2c_vectorized_stores_successor_but_acts_on_current_observation():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     agent.env = _DistinctObservationEnv()
     agent.buffer = _RecordingBuffer()
@@ -403,6 +407,8 @@ def test_a2c_vectorized_stores_successor_but_acts_on_current_observation():
 
 def test_a2c_vectorized_preserves_continuous_actions_before_env_step():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     agent.env = _ScriptEnv([np.array([False, False])])
     agent.buffer = _RecordingBuffer()
@@ -423,6 +429,8 @@ def test_a2c_vectorized_preserves_continuous_actions_before_env_step():
 
 def test_a2c_vectorized_recomputes_pipelined_action_after_policy_update():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     agent.env = _ScriptEnv([np.array([False, False]), np.array([False, False])])
     agent.buffer = _RecordingBuffer()
@@ -454,6 +462,8 @@ def test_a2c_vectorized_recomputes_pipelined_action_after_policy_update():
 
 def test_a2c_vectorized_can_run_twice_without_a_pending_step():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     agent.env = _ScriptEnv([np.array([False, False]), np.array([False, False])])
     agent.buffer = _RecordingBuffer()
@@ -474,6 +484,8 @@ def test_a2c_vectorized_can_run_twice_without_a_pending_step():
 
 def test_a2c_vectorized_keeps_post_lifeloss_step_real():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     agent.env = _LivesScriptEnv(
         [
@@ -500,6 +512,8 @@ def test_a2c_vectorized_keeps_post_lifeloss_step_real():
 
 def test_a2c_vectorized_drops_gymnasium_lifeloss_autoreset_dummy():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     env = _LivesScriptEnv(
         [
@@ -559,6 +573,8 @@ def test_a2c_single_env_action_plumbing_and_buffer_shape(action_type, action, ex
     # env.step ever ran. The loop now mirrors eval: conv_action(self.actions(obs))
     # normalized exactly once.
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent._initial_reset = None
     agent.obs_rms = None
     env = _ScriptSingleEnv()
     agent.env = env
@@ -609,6 +625,8 @@ def test_pipelined_loop_drives_real_async_envpool_end_to_end():
     env = eb.EnvPoolVectorizedEnv("CartPole-v1", worker_num=worker, seed=0)
     try:
         agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
+        agent.memory_backend = "cpu"
+        agent._initial_reset = None
         agent.obs_rms = None
         agent.env = env
         agent.worker_size = worker

--- a/tests/test_review_replay_env_regressions.py
+++ b/tests/test_review_replay_env_regressions.py
@@ -1,3 +1,4 @@
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -157,11 +158,22 @@ def test_gym_vector_env_exposes_normalized_continuous_actions():
         env.close()
 
 
-def test_envpool_maps_normalized_actions_to_backend_bounds():
+def test_envpool_maps_normalized_actions_to_backend_bounds(monkeypatch):
     pytest.importorskip("envpool")
     env = EnvPoolVectorizedEnv("Pendulum-v1", worker_num=2, seed=7)
     try:
-        converted = env.action_conv(np.array([[-1.0], [1.0]], dtype=np.float32))
-        assert np.array_equal(converted, np.array([[-2.0], [2.0]], dtype=np.float32))
+        send = env.env.send
+
+        def send_numpy(actions, env_ids):
+            assert isinstance(actions, np.ndarray)
+            np.testing.assert_array_equal(actions, np.array([[-2.0], [2.0]], dtype=np.float32))
+            return send(actions, env_ids)
+
+        monkeypatch.setattr(env.env, "send", send_numpy)
+        env.step(jnp.asarray([[-1.0], [1.0]], dtype=jnp.float32))
+        observations, rewards, terminateds, truncateds, _ = env.get_result()
+        assert all(isinstance(value, np.ndarray) for value in observations.values())
+        assert rewards.shape == terminateds.shape == truncateds.shape == (2,)
+        assert np.isfinite(rewards).all()
     finally:
         env.close()

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -73,7 +73,9 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
     obses, actions, scalars = _rollout(timesteps=2)
 
     if kind == "local":
-        obses = {"unified_obs": np.stack([observation["unified_obs"] for observation in obses])}
+        obses = {"unified_obs": jnp.asarray([observation["unified_obs"] for observation in obses])}
+        actions = jnp.asarray(actions)
+        scalars = jnp.asarray(scalars).squeeze(-1)
         agent.gae_normalize = False
         agent.gae_normalize_scope = "batch"
         agent.value_clip = 0.3

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -13,6 +13,7 @@ Behaviors pinned:
 - ``save_params`` is called once with the logger's local path.
 """
 
+import numpy as np
 import pytest
 
 from jax_baselines.A2C.a2c import A2C
@@ -306,8 +307,10 @@ class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
         self.calls = []
         self.eval_env = "eval-env"
         self.eval_eps = 3
-        self.actions = lambda obs, eval=False: (obs, eval)
-        self.record_test_fn = lambda builder, logger, actions, episode, conv_action: actions("obs")
+        self.actions = lambda obs, eval=False: (obs["unified_obs"].tolist(), eval)
+        self.record_test_fn = lambda builder, logger, actions, episode, conv_action: actions(
+            {"unified_obs": np.array([1.0, 2.0])}
+        )
         self.conv_action = "conv-action"
         # Mirror the real base __init__ defaults (base_class.py:68,70) so the
         # hardened prepare_run (direct attribute access) keeps its no-op
@@ -315,6 +318,7 @@ class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
         self.lr_annealing = False
         self.params = None
         self.obs_rms = None
+        self.memory_backend = "cpu"
 
     def learn_SingleEnv(self, ctx):
         self.calls.append(("single", ctx))
@@ -383,7 +387,16 @@ def test_on_policy_eval_uses_run_context_logger(monkeypatch):
     rec = []
 
     def fake_evaluate_policy(eval_env, eval_eps, actions, logger_run, steps, conv_action):
-        rec.append((eval_env, eval_eps, actions("obs"), logger_run, steps, conv_action))
+        rec.append(
+            (
+                eval_env,
+                eval_eps,
+                actions({"unified_obs": np.array([1.0, 2.0])}),
+                logger_run,
+                steps,
+                conv_action,
+            )
+        )
         return {"score": 1.0}
 
     monkeypatch.setattr(
@@ -396,14 +409,14 @@ def test_on_policy_eval_uses_run_context_logger(monkeypatch):
     result = agent.eval(ctx, 42)
 
     assert result == {"score": 1.0}
-    assert rec == [("eval-env", 3, ("obs", True), "ctx-logger", 42, "conv-action")]
+    assert rec == [("eval-env", 3, ([1.0, 2.0], True), "ctx-logger", 42, "conv-action")]
 
 
 def test_on_policy_recording_uses_eval_actions():
     agent = FakeOnPolicyAgent()
     agent.env_builder = "builder"
 
-    assert agent.test_eval_env("logger", 1) == ("obs", True)
+    assert agent.test_eval_env("logger", 1) == ([1.0, 2.0], True)
 
 
 class _MetricLoggerRun:


### PR DESCRIPTION
AC에 `memory_backend=auto|cpu|gpu`를 추가하고 EpochBuffer·RMS·rollout 통계를 선택한 장치에서 처리합니다. auto는 환경이 실제로 반환하는 배열의 장치를 따릅니다. MJLab은 DLPack과 스냅샷을 통해 GPU 배열을 전달하고, CPU 환경과 EnvPool 경계는 NumPy를 사용합니다.

스택 7/8 · base: `stack/mjlab-06-ac-normalization` · head: `stack/mjlab-07-device-memory`. 이 PR의 base 대비 diff를 리뷰하고 1→8 순서로 병합합니다.

| 순서 | PR | 상태 |
| --- | --- | --- |
| 1 | [#19 관측 정규화 변환 함수의 이름을 명확히 변경](https://github.com/tinker495/jax-baseline/pull/19) | 리뷰 가능 |
| 2 | [#20 로컬 생성물 제외와 저장소 설정 정리](https://github.com/tinker495/jax-baseline/pull/20) | 리뷰 가능 |
| 3 | [#21 관측 키와 actor·critic 입력 역할을 통일](https://github.com/tinker495/jax-baseline/pull/21) | 리뷰 가능 |
| 4 | [#22 AC 에피소드 경계·행동·평가 계산 수정](https://github.com/tinker495/jax-baseline/pull/22) | 리뷰 가능 |
| 5 | [#23 MJLab 환경 adapter와 Go1 실험 설정 추가](https://github.com/tinker495/jax-baseline/pull/23) | 리뷰 가능 |
| 6 | [#24 AC 관측 정규화와 체크포인트 상태 저장](https://github.com/tinker495/jax-baseline/pull/24) | Draft |
| 7 | [#25 AC 버퍼·정규화를 CPU 또는 GPU에 유지](https://github.com/tinker495/jax-baseline/pull/25) | Draft |
| 8 | [#26 Go1 롤아웃 성능·장치 전송 프로파일러 추가](https://github.com/tinker495/jax-baseline/pull/26) | 리뷰 가능 |


| 항목 | 내용 |
| --- | --- |
| git hash/diff | `1cf583770bb0b955bec1d5d088f74338f518afd6`. 이 PR의 Files changed가 검증 diff이며 미커밋 소스 변경 없음. |
| logging link | N/A — 외부 로그 서비스 미사용. 로컬 기록: `runs/pr_stack/07-cli.log, 07-tests.log, 07-gpu-tests.log, 07-gpu-retry.log, 07-ruff.log, 07-ty.log`. 주요 출력은 아래 실제 결과에 보존. |
| Command | `JAX_PLATFORMS=cpu SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy .venv/bin/python -m experiments.cli.pg --algo PPO --env CartPole-v1 --steps 32 --batch 8 --mini_batch 8 --epoch_num 1 --node 16 --hidden_n 1 --eval_num 1 --seed 3 --memory_backend auto --obs_normalization` |
| Comments | 준비된 .venv. CPU CLI 시드 3, BLAS/OMP 스레드 1, 별도 logdir로 측정. GPU 검증은 RTX 4080 SUPER에서 실시. 교차 장치 테스트에는 JAX_PLATFORMS=cuda,cpu가 필요. |
| 성공 기준 | CPU 환경에서 auto가 cpu를 선택하고 32스텝 학습·평가 완료. GPU에서는 buffer·RMS·rollout leaf의 장치 유지와 snapshot 계약 통과. |
| 실제 결과 | CPU CLI에서 memory backend : cpu 출력, 종료 0. 관련 통합 테스트 143개 통과·5개 skip. GPU 실행 23개 통과·1개 skip 후, CUDA만 활성화해 실패한 CPU 비교 3개를 JAX_PLATFORMS=cuda,cpu로 재실행하여 모두 통과. 실제 Go1 device guard는 8번 PR에서 통과. |

변경 경로 Ruff 18개, ty 131개 진단이 남습니다. 기존 브랜치 61dc7dd7과 동일한 소스를 보존했으며 전체 정적 검사 통과를 주장하지 않습니다. 일부 off-policy 파일은 길어진 변환 함수 호출의 줄바꿈만 포함합니다.

**Draft 사유:** GPU 버퍼 교체 이후 보고된 장기 학습 안정성 저하의 원인은 아직 확정되지 않았습니다. 짧은 device/수치 검증은 통과했지만 이 PR을 안정성 해결로 간주하지 않습니다. JAX sampling은 기존 NumPy와 난수 소비 및 minibatch 순서를 바꾸므로 동일 seed의 곡선 일치를 보장하지 않습니다.

검증 명령은 해당 PR head를 체크아웃한 저장소 루트에서 실행합니다. 전체 스택의 최종 코드 내용은 원래 `feat/mjlab-env-adapter`의 `61dc7dd7`과 동일하게 보존했습니다.
