### PR TITLE
[1/2] 학습 환경 수에 맞춰 정책 평가 병렬화

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Literal
+from typing import Any, Literal
 
 import gymnasium as gym
 import numpy as np
@@ -15,6 +15,7 @@ from env_builder.seeding import seed_env
 from jax_baselines.core.env_protocols import (
     Env,
     EnvInfo,
+    Observation,
     PreparedEnvSpec,
     PreparedWorkerEnvSpec,
     SingleEnv,
@@ -183,7 +184,7 @@ def get_env_builder(
         env = eval_env = None
         try:
             env = env_builder(num_workers, seed=seed)
-            eval_env = env_builder(1, seed=eval_seed)
+            eval_env = env_builder(num_workers, seed=eval_seed)
             return PreparedEnvSpec(
                 env=env,
                 eval_env=eval_env,
@@ -341,12 +342,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
         self._all_env_ids = np.arange(worker_num, dtype=np.int32)
         self._awaiting_recv = False
 
-        # Async handshake: async_reset() launches every reset on the C++ side,
-        # the first recv() collects the initial observation. From here the
-        # contract is a strict send (step) / recv (get_result) alternation.
-        self.env.async_reset()
-        raw_obs, _, _, _, info = self.env.recv()
-        self.obs = self._process_observations(raw_obs, np.argsort(info["env_id"]))
+        self.reset()
 
     def _check_atari_env(self, env_id: str) -> bool:
         """Check if the environment is an Atari game."""
@@ -360,6 +356,17 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
 
     def current_obs(self):
         return self.obs
+
+    def reset(self, *, seed: int | None = None) -> tuple[Observation, dict[str, Any]]:
+        if self._awaiting_recv:
+            raise RuntimeError("reset() called while a step is in flight")
+        if seed is not None:
+            raise ValueError("EnvPool seeds are fixed at construction; recreate the env to reseed")
+        self.env.async_reset()
+        raw_obs, _, _, _, info = self.env.recv()
+        order = np.argsort(info["env_id"])
+        self.obs = self._process_observations(raw_obs, order)
+        return self.obs, self._reorder_info(info, order)
 
     def step(self, actions):
         """Fire actions into all environments without blocking.
@@ -487,7 +494,7 @@ class GymVectorizedEnv(VectorizedEnv):
             # Non-Atari: prefer the registry's efficient make_vec, falling back to
             # explicit AsyncVectorEnv if the env has no vectorized entry point.
             try:
-                self.env = gym.make_vec(
+                vector_env = gym.make_vec(
                     env_id,
                     num_envs=worker_num,
                     vectorization_mode="async",
@@ -495,15 +502,19 @@ class GymVectorizedEnv(VectorizedEnv):
                     wrappers=(_normalize_action_space,),
                 )
             except Exception:
-                self.env = gym.vector.AsyncVectorEnv(
+                vector_env = gym.vector.AsyncVectorEnv(
                     [make_env() for _ in range(worker_num)], context="spawn"
                 )
         else:
             # Atari needs the custom wrappers, so build AsyncVectorEnv from the
             # explicit per-env constructors.
-            self.env = gym.vector.AsyncVectorEnv(
+            vector_env = gym.vector.AsyncVectorEnv(
                 [make_env() for _ in range(worker_num)], context="spawn"
             )
+
+        if not isinstance(vector_env, gym.vector.AsyncVectorEnv):
+            raise TypeError("GymVectorizedEnv requires an AsyncVectorEnv")
+        self.env = vector_env
 
         # Store environment info
         action_size, action_type = _action_meta(self.env.single_action_space)
@@ -525,28 +536,24 @@ class GymVectorizedEnv(VectorizedEnv):
         else:
             self.action_conv = lambda a: np.asarray(a)
 
-        # gymnasium vector envs split into step_async()/step_wait(); for
-        # AsyncVectorEnv each sub-env runs in its own subprocess, so
-        # step_async() returns immediately and the envs advance while the
-        # caller works, with step_wait() collecting. Every construction path
-        # above builds an async-capable vector env; fail loudly if one without
-        # the split slips through (e.g. SyncVectorEnv lacks it).
-        if not (hasattr(self.env, "step_async") and hasattr(self.env, "step_wait")):
-            raise TypeError(
-                f"{type(self.env).__name__} lacks step_async/step_wait; "
-                "GymVectorizedEnv requires an async-capable vector env."
-            )
-
-        # Initialize
-        self.obs, _ = self.env.reset(seed=seed)
-        self.obs = normalize_observation(self.obs, self._observation_key)
         self._awaiting_result = False
+        self.reset(seed=seed)
 
     def get_info(self):
         return self.env_info
 
     def current_obs(self):
         return self.obs
+
+    def reset(self, *, seed: int | None = None) -> tuple[Observation, dict[str, Any]]:
+        if self._awaiting_result:
+            raise RuntimeError("reset() called while a step is in flight")
+        if self._is_atari:
+            # Restart the game before outer wrappers rebuild their frame/reward state.
+            self.env.set_attr("was_real_done", True)
+        obs, info = self.env.reset(seed=seed)
+        self.obs = normalize_observation(obs, self._observation_key)
+        return self.obs, info
 
     def step(self, actions):
         """Dispatch actions without blocking (gymnasium ``step_async``)."""

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -652,7 +652,7 @@ class Actor_Critic_Policy_Gradient_Family:
             lambda obs: self.actions(self.normalize_observation(obs), eval=True),
             logger_run=ctx.logger_run,
             steps=steps,
-            conv_action=self.conv_action,
+            conv_action=self.conv_action if self.action_type == "continuous" else None,
         )
 
     def test(self, episode=10):

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -522,15 +522,10 @@ class Deteministic_Policy_Gradient_Family(object):
         )
 
     def eval(self, ctx, steps):
-        # Evaluation should use the public actions() API with eval=True so that
-        # subclasses can implement snapshot-aware behavior consistently.
-        def eval_action_fn(obs):
-            return self.actions(obs, steps, eval=True)
-
         return evaluate_policy(
             self.eval_env,
             self.eval_eps,
-            eval_action_fn,
+            lambda obs: self.actions(obs, steps, eval=True),
             logger_run=ctx.logger_run,
             steps=steps,
         )

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -533,19 +533,10 @@ class Q_Network_Family:
         )
 
     def eval(self, ctx, steps):
-        # Deterministic greedy evaluation using public actions() API.
-        def eval_action_fn(obs):
-            a = self.actions(obs, 0.0, eval_mode=True)
-            arr = np.asarray(a)
-            if arr.size == 1:
-                return int(arr.item())
-            else:
-                return int(arr[0][0])
-
         return evaluate_policy(
             self.eval_env,
             self.eval_eps,
-            eval_action_fn,
+            lambda obs: self.actions(obs, 0.0, eval_mode=True),
             logger_run=ctx.logger_run,
             steps=steps,
         )

--- a/jax_baselines/core/env_info.py
+++ b/jax_baselines/core/env_info.py
@@ -8,6 +8,7 @@ from jax_baselines.core.env_protocols import (
     PreparedWorkerEnvSpec,
     SingleEnv,
     VectorizedEnv,
+    VectorizedEvalEnv,
 )
 
 REQUIRED_ENV_INFO_KEYS = (
@@ -86,13 +87,29 @@ def get_local_env_info(env_builder, num_workers=1, seed=None, include_action_typ
     worker_size = int(env_info["worker_num"])
     env_type = _validate_core_env_type(env_info)
 
-    if env_type == "VectorizedEnv" and not isinstance(prepared.env, VectorizedEnv):
-        raise ValueError(
-            "Prepared train env metadata says VectorizedEnv but env is not VectorizedEnv"
-        )
-    if env_type == "SingleEnv":
+    if env_type == "VectorizedEnv":
+        if not isinstance(prepared.env, VectorizedEnv):
+            raise ValueError(
+                "Prepared train env metadata says VectorizedEnv but env is not VectorizedEnv"
+            )
+        if not isinstance(prepared.eval_env, VectorizedEvalEnv):
+            raise ValueError("Prepared eval env must satisfy the VectorizedEvalEnv protocol")
+        eval_info = _require_env_info(prepared.eval_env.get_info())
+        if _validate_core_env_type(eval_info) != env_type or eval_info["worker_num"] != worker_size:
+            raise ValueError(
+                "Prepared train and eval envs must have the same type and worker count"
+            )
+    else:
+        if (
+            worker_size != 1
+            or isinstance(prepared.env, VectorizedEnv)
+            or isinstance(prepared.eval_env, VectorizedEnv)
+        ):
+            raise ValueError(
+                "Prepared single train and eval envs must be single-worker environments"
+            )
         _require_single_env(prepared.env, "Prepared train env")
-    _require_single_env(prepared.eval_env, "Prepared eval env")
+        _require_single_env(prepared.eval_env, "Prepared eval env")
 
     result = (
         prepared.env,

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -95,6 +95,14 @@ class VectorizedEnv(Protocol):
         ...
 
 
+@runtime_checkable
+class VectorizedEvalEnv(VectorizedEnv, Protocol):
+    """Vector environment that can start an independent evaluation measurement."""
+
+    def reset(self, *, seed: int | None = None) -> tuple[Observation, dict[str, Any]]:
+        ...
+
+
 # Backward-compatible name exported by env_builder; no separate ABC needed.
 Env = VectorizedEnv
 

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -3,9 +3,12 @@ import numpy as np
 
 from jax_baselines.core.env_info import prepare_worker_env
 from jax_baselines.core.env_protocols import (
+    VectorizedEvalEnv,
     batch_observation,
     reset_for_evaluation,
     single_real_episode_end,
+    vector_autoreset_mask,
+    vector_real_reset_mask,
 )
 
 
@@ -99,12 +102,7 @@ def _normalize_action_for_step(step_action):
     return arr.reshape(-1)
 
 
-def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, conv_action=None):
-    """General evaluation helper used by multiple base classes.
-
-    act_eval_fn: callable(obs) -> action (already formatted for step)
-    conv_action: optional function to convert action before stepping (A2C)
-    """
+def _evaluate_single_episodes(eval_env, eval_eps, act_eval_fn, conv_action):
     original_rewards = []
     total_reward = np.zeros(eval_eps)
     total_ep_len = np.zeros(eval_eps)
@@ -129,8 +127,8 @@ def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, c
 
             observation, reward, terminated, truncated, info = eval_env.step(action_to_step)
             obs = batch_observation(observation)
-            if have_original_reward:
-                original_reward += info.get("original_reward", 0)
+            if have_original_reward and "original_reward" in info:
+                original_reward += info["original_reward"]
             total_reward[ep] += reward
             eplen += 1
 
@@ -146,11 +144,78 @@ def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, c
         truncated = False
         eplen = 0
 
+    return total_reward, total_ep_len, total_truncated, original_rewards
+
+
+def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn, conv_action):
+    workers = eval_env.get_info()["worker_num"]
+    if workers < 1:
+        raise ValueError("Evaluation worker count must be positive")
+    # Fixed quotas prevent fast, short episodes from dominating the measurement.
+    # ponytail: life quotas may omit Atari game scores; use game quotas for full-game eval.
+    targets = (eval_eps + np.arange(workers)) // workers
+    counts = np.zeros(workers, dtype=np.int64)
+    rewards_sum = np.zeros(workers)
+    lengths = np.zeros(workers, dtype=np.int64)
+    _, info = eval_env.reset()
+    originals, original_present = extract_vector_original_rewards(info, workers)
+    prev_done = np.zeros(workers, dtype=bool)
+    total_reward = np.zeros(eval_eps)
+    total_ep_len = np.zeros(eval_eps)
+    total_truncated = np.zeros(eval_eps)
+    original_rewards = []
+    completed = 0
+
+    while completed < eval_eps:
+        # Keep the full batch, including workers that have exhausted their quotas.
+        actions = act_eval_fn(eval_env.current_obs())
+        eval_env.step(conv_action(actions) if conv_action is not None else actions)
+        _, rewards, terminateds, truncateds, infos = eval_env.get_result()
+        rewards, terminateds, truncateds = jax.device_get((rewards, terminateds, truncateds))
+        done = np.logical_or(terminateds, truncateds)
+        active = ~prev_done & (counts < targets)
+        rewards_sum[active] += rewards[active]
+        lengths[active] += 1
+        original, present = extract_vector_original_rewards(infos, workers)
+        originals[active & present] += original[active & present]
+        original_present[active & present] = True
+        real_reset = np.asarray(vector_real_reset_mask(eval_env, terminateds, truncateds, infos))
+        autoreset = np.asarray(vector_autoreset_mask(eval_env, terminateds, truncateds, infos))
+        finished = done & active
+        emit_original = finished & real_reset & original_present
+        original_rewards.extend(originals[emit_original].tolist())
+        originals[emit_original] = 0
+        original_present[emit_original] = False
+        end = completed + int(finished.sum())
+        total_reward[completed:end] = rewards_sum[finished]
+        total_ep_len[completed:end] = lengths[finished]
+        total_truncated[completed:end] = truncateds[finished]
+        completed = end
+        counts[finished] += 1
+        rewards_sum[finished] = 0
+        lengths[finished] = 0
+        prev_done = done & autoreset & active
+
+    return total_reward, total_ep_len, total_truncated, original_rewards
+
+
+def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, conv_action=None):
+    """Measure exactly eval_eps episodes using the environment's native batch shape."""
+    if eval_eps < 1:
+        raise ValueError("eval_eps must be positive")
+    collect = (
+        _evaluate_vector_episodes
+        if isinstance(eval_env, VectorizedEvalEnv)
+        else _evaluate_single_episodes
+    )
+    total_reward, total_ep_len, total_truncated, original_rewards = collect(
+        eval_env, eval_eps, act_eval_fn, conv_action
+    )
     mean_reward = np.mean(total_reward)
     mean_ep_len = np.mean(total_ep_len)
 
     mean_original_score = None
-    if have_original_reward and len(original_rewards) > 0:
+    if original_rewards:
         mean_original_score = np.mean(original_rewards)
 
     if logger_run:

--- a/tests/test_ac_observation_normalization.py
+++ b/tests/test_ac_observation_normalization.py
@@ -11,6 +11,7 @@ from jax_baselines.math.statistics import RunningMeanStd
 def _agent(enabled=True):
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.memory_backend = "cpu"
+    agent.action_type = "continuous"
     agent._initial_reset = None
     agent.observation_space = {"unified_obs": [1]}
     agent.obs_normalization = enabled

--- a/tests/test_env_builder_adapter.py
+++ b/tests/test_env_builder_adapter.py
@@ -56,8 +56,9 @@ class _FakeSingleEnv:
 
 
 class _FakeVectorizedEnv(VectorizedEnv):
-    def __init__(self, worker_num=3):
+    def __init__(self, worker_num=3, seed=None):
         self.worker_num = worker_num
+        self.seed = seed
         self.env_info = {
             "observation_space": {"unified_obs": [5]},
             "action_size": [2],
@@ -73,6 +74,9 @@ class _FakeVectorizedEnv(VectorizedEnv):
 
     def current_obs(self):
         return {"unified_obs": np.zeros((self.worker_num, 5), dtype=np.float32)}
+
+    def reset(self, *, seed=None):
+        return self.current_obs(), {}
 
     def step(self, action):
         pass
@@ -261,7 +265,11 @@ def test_get_local_env_info_consumes_adapter_prepared_vectorized_envs():
         def prepare_envs(self, num_workers=1, seed=None):
             calls.append((num_workers, seed))
             env = _FakeVectorizedEnv(worker_num=num_workers)
-            return PreparedEnvSpec(env=env, eval_env=_FakeSingleEnv(), env_info=env.env_info)
+            return PreparedEnvSpec(
+                env=env,
+                eval_env=_FakeVectorizedEnv(worker_num=num_workers),
+                env_info=env.env_info,
+            )
 
     _, _, observation_space, action_size, worker_size, env_type = get_local_env_info(
         _Builder(),
@@ -280,7 +288,11 @@ def test_get_local_env_info_requires_explicit_vectorized_env_info_contract():
     class _Builder:
         def prepare_envs(self, num_workers=1, seed=None):
             env = _BrokenVectorizedEnv(worker_num=num_workers)
-            return PreparedEnvSpec(env=env, eval_env=_FakeSingleEnv(), env_info=env.env_info)
+            return PreparedEnvSpec(
+                env=env,
+                eval_env=_FakeVectorizedEnv(worker_num=num_workers),
+                env_info=env.env_info,
+            )
 
     try:
         get_local_env_info(_Builder(), num_workers=2)
@@ -347,40 +359,28 @@ def test_infer_action_meta_uses_adapter_normalized_action_type():
     np.testing.assert_array_equal(action, [6.0, -6.0])
 
 
-def test_env_builder_adapter_prepares_train_eval_pair_and_seed_policy():
+@pytest.mark.parametrize("worker_num", [1, 4])
+def test_env_builder_adapter_prepares_train_eval_pair_and_seed_policy(monkeypatch, worker_num):
     calls = []
 
-    def fake_env_builder(worker=1, render_mode=None, seed=None):
-        calls.append((worker, seed))
-        return _FakeVectorizedEnv(worker_num=worker) if worker > 1 else _FakeSingleEnv()
-
-    # Replace the attached method with a deterministic local equivalent so this
-    # test stays backend-free while asserting the adapter-owned contract shape.
-    def prepare_envs(num_workers=1, seed=None):
-        eval_seed = None if seed is None else seed + 1
-        env = fake_env_builder(num_workers, seed=seed)
-        eval_env = fake_env_builder(1, seed=eval_seed)
-        return PreparedEnvSpec(
-            env=env,
-            eval_env=eval_env,
-            env_info=env.env_info
-            if isinstance(env, VectorizedEnv)
-            else {
-                "observation_space": {"unified_obs": [4]},
-                "action_size": [3],
-                "action_type": "discrete",
-                "env_type": "single",
-                "env_id": "FakeSingle-v0",
-                "worker_num": 1,
-                "core_env_type": "SingleEnv",
-            },
+    def make_mjlab_env(env_id, *, worker_num, seed, **kwargs):
+        calls.append((worker_num, seed))
+        return (
+            _FakeVectorizedEnv(worker_num=worker_num, seed=seed)
+            if worker_num > 1
+            else _FakeSingleEnv(seed=seed)
         )
 
-    fake_env_builder.prepare_envs = prepare_envs
+    monkeypatch.setitem(
+        sys.modules, "env_builder.mjlab_env", SimpleNamespace(make_mjlab_env=make_mjlab_env)
+    )
+    builder, _ = importlib.import_module("env_builder.env_builder").get_env_builder(
+        "Fake-v0", "mjlab"
+    )
+    env, eval_env, *_ = get_local_env_info(builder, num_workers=worker_num, seed=21)
 
-    get_local_env_info(fake_env_builder, num_workers=4, seed=21)
-
-    assert calls == [(4, 21), (1, 22)]
+    assert env is not eval_env
+    assert calls == [(worker_num, 21), (worker_num, 22)]
 
 
 def test_experiments_build_env_returns_prepared_env_builder():
@@ -412,7 +412,9 @@ def test_experiments_composition_path_uses_adapter_prepared_envs(monkeypatch):
         def prepare_envs(num_workers=1, seed=None):
             calls.append(("prepare_envs", num_workers, seed))
             env = _FakeVectorizedEnv(worker_num=num_workers)
-            eval_env = _FakeSingleEnv(seed=None if seed is None else seed + 100)
+            eval_env = _FakeVectorizedEnv(
+                worker_num=num_workers, seed=None if seed is None else seed + 100
+            )
             return PreparedEnvSpec(env=env, eval_env=eval_env, env_info=env.env_info)
 
         def prepare_worker_env(seed=None):

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -304,6 +304,7 @@ class FakeOnPolicySession(TrainingSession):
 class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
     def __init__(self, env_type="SingleEnv"):
         self.env_type = env_type
+        self.action_type = "continuous"
         self.calls = []
         self.eval_env = "eval-env"
         self.eval_eps = 3


### PR DESCRIPTION
학습을 여러 환경으로 실행해도 평가가 단일 환경에 고정되던 동작을 바꿉니다. 학습이 단일 환경이면 평가도 단일 환경을 사용하고, 병렬 학습이면 같은 worker 수와 전체 액션 batch를 유지해 평가합니다.

- worker별 고정 에피소드 할당으로 정확히 `eval_eps`개를 집계하고, 자동 리셋의 더미 전이를 제외합니다.
- PG의 이산·연속 액션 변환과 DPG·Q-Net의 공개 평가 액션 경로를 공통 평가기에 연결합니다.
- `pg_mjlab_go1.yaml`도 공통 factory를 통해 학습과 같은 환경 수로 평가합니다.

스택 1/2: `main` → `feature/vectorized-eval`. 후속 PR #29는 이 평가 경로에 학습 환경 상태 보존·재사용을 추가합니다. 이 PR을 먼저 리뷰·병합합니다.

검증: 스택 최종 상태에서 공통 평가·rollout·환경 adapter·import 경계 회귀 테스트와 PPO/TD3의 단일·병렬 실제 학습을 확인했습니다. 검증 전용 코드와 상세 로그는 로컬에 보관합니다.

Refs #17
