### PR TITLE
[2/2] 학습 환경 상태를 보존해 Gymnasium·mjlab 평가에 재사용

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -1,9 +1,14 @@
+import random
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from copy import deepcopy
 from typing import Any, Literal
 
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
+from gymnasium.vector.utils import concatenate, iterate
 from gymnasium.wrappers.utils import rescale_box
 
 from env_builder.observations import (
@@ -121,11 +126,14 @@ def get_env_builder(
     episode_length=None,
     device="cuda:0",
     jax_arrays=False,
+    reuse_for_eval=False,
 ):
     if env_backend not in _ENV_BACKENDS:
         raise ValueError(f"env_backend must be one of {_ENV_BACKENDS}, got {env_backend!r}")
     if jax_arrays and env_backend != "mjlab":
         raise ValueError("jax_arrays requires env_backend='mjlab'")
+    if reuse_for_eval and env_backend == "envpool":
+        raise ValueError("EnvPool does not support training environment state preservation")
 
     def env_builder(worker=1, render_mode=None, seed=None):
         if env_backend == "mjlab":
@@ -140,6 +148,7 @@ def get_env_builder(
                 device=device,
                 render_mode=render_mode,
                 jax_arrays=jax_arrays,
+                reuse_for_eval=reuse_for_eval and render_mode is None,
             )
         if worker > 1:
             # Vectorized backend is an explicit choice: gymnasium AsyncVectorEnv
@@ -161,6 +170,7 @@ def get_env_builder(
                 worker_num=worker,
                 seed=seed,
                 observation_key=observation_key,
+                reuse_for_eval=reuse_for_eval and render_mode is None,
             )
         else:
             from env_builder.atari_wrappers import get_env_type, make_wrap_atari
@@ -176,6 +186,16 @@ def get_env_builder(
                 spaces.Dict(flatten_observation_space(env.observation_space, observation_key)),
             )
             env = _normalize_action_space(env)
+            if reuse_for_eval and render_mode is None:
+                from env_builder.gym_state import GymStateWrapper
+
+                try:
+                    env = GymStateWrapper(env)
+                except (TypeError, ValueError):
+                    env.close()
+                    raise
+                if seed is None:
+                    env.reset()
             seed_env(env, seed)
             return env
 
@@ -184,7 +204,7 @@ def get_env_builder(
         env = eval_env = None
         try:
             env = env_builder(num_workers, seed=seed)
-            eval_env = env_builder(num_workers, seed=eval_seed)
+            eval_env = env if reuse_for_eval else env_builder(num_workers, seed=eval_seed)
             return PreparedEnvSpec(
                 env=env,
                 eval_env=eval_env,
@@ -468,10 +488,15 @@ class GymVectorizedEnv(VectorizedEnv):
     Used when EnvPool doesn't support the requested environment.
     """
 
-    def __init__(self, env_id, worker_num=8, seed=None, observation_key=None):
+    def __init__(
+        self, env_id, worker_num=8, seed=None, observation_key=None, *, reuse_for_eval=False
+    ):
         self.env_id = env_id
         self.worker_num = worker_num
         self._observation_key = observation_key
+        self._reuse_for_eval = reuse_for_eval
+        self._evaluation_active = False
+        self._pending_result: tuple[Observation, Any, Any, Any, dict[str, Any]] | None = None
 
         # Create vectorized environment using gymnasium
         # For Atari, we need to use custom wrappers, so we use AsyncVectorEnv with explicit constructors
@@ -479,18 +504,35 @@ class GymVectorizedEnv(VectorizedEnv):
 
         env_type, _ = get_env_type(env_id)
         self._is_atari = env_type == "atari_env"
+        spec = gym.spec(env_id)
 
         def make_env():
             def _make():
                 if self._is_atari:
                     env = make_wrap_atari(env_id, clip_rewards=True)
                 else:
-                    env = gym.make(env_id)
-                return _normalize_action_space(env)
+                    env = gym.make(spec)
+                env = _normalize_action_space(env)
+                if reuse_for_eval:
+                    from env_builder.gym_state import GymStateWrapper
+
+                    try:
+                        return GymStateWrapper(gym.wrappers.Autoreset(env))
+                    except (TypeError, ValueError):
+                        env.close()
+                        raise
+                return env
 
             return _make
 
-        if env_type != "atari_env":
+        if reuse_for_eval:
+            # Keep NEXT_STEP reset state inside a wrapper that can be snapshotted.
+            vector_env = gym.vector.AsyncVectorEnv(
+                [make_env() for _ in range(worker_num)],
+                context="spawn",
+                autoreset_mode=gym.vector.AutoresetMode.DISABLED,
+            )
+        elif env_type != "atari_env":
             # Non-Atari: prefer the registry's efficient make_vec, falling back to
             # explicit AsyncVectorEnv if the env has no vectorized entry point.
             try:
@@ -557,6 +599,8 @@ class GymVectorizedEnv(VectorizedEnv):
 
     def step(self, actions):
         """Dispatch actions without blocking (gymnasium ``step_async``)."""
+        if self._awaiting_result:
+            raise RuntimeError("step() called before collecting the preceding result")
         self.env.step_async(self.action_conv(actions))
         self._awaiting_result = True
 
@@ -565,12 +609,54 @@ class GymVectorizedEnv(VectorizedEnv):
         if not self._awaiting_result:
             raise RuntimeError("get_result() called without a preceding step()")
         self._awaiting_result = False
+        if self._pending_result is not None:
+            result, self._pending_result = self._pending_result, None
+            self.obs = result[0]
+            return result
 
         next_obs, rewards, terminateds, truncateds, infos = self.env.step_wait()
         next_obs = normalize_observation(next_obs, self._observation_key)
         self.obs = next_obs
 
         return next_obs, rewards, terminateds, truncateds, infos
+
+    @contextmanager
+    def evaluation_context(self) -> Iterator[None]:
+        if not self._reuse_for_eval:
+            yield
+            return
+        if self._evaluation_active:
+            raise RuntimeError("Training environment is already borrowed for evaluation")
+        from env_builder.gym_state import preserve_gym_spaces
+
+        observation = self.obs
+        awaiting = self._awaiting_result
+        pending = self.get_result() if awaiting else None
+        vector_observation = deepcopy(self.env.observations)
+        global_rng = random.getstate(), np.random.get_state()
+        with preserve_gym_spaces(self.env.action_space, self.env.observation_space):
+            self._evaluation_active = True
+            try:
+                self.env.call("save_training_state")
+                try:
+                    yield
+                finally:
+                    # Finish an evaluation step even when its action callback raises.
+                    if self._awaiting_result:
+                        self.get_result()
+                    self.env.call("restore_training_state")
+            finally:
+                concatenate(
+                    self.env.single_observation_space,
+                    tuple(iterate(self.env.observation_space, vector_observation)),
+                    self.env.observations,
+                )
+                self.obs = observation
+                self._pending_result = pending
+                self._awaiting_result = awaiting
+                self._evaluation_active = False
+                random.setstate(global_rng[0])
+                np.random.set_state(global_rng[1])
 
     def real_reset_mask(self, terminateds, truncateds, infos):
         return _real_reset_mask(self._is_atari, terminateds, truncateds, infos)

--- a/env_builder/gym_state.py
+++ b/env_builder/gym_state.py
@@ -1,0 +1,330 @@
+"""Borrow Gymnasium environments by restoring their existing state objects.
+
+Python instance dictionaries form the state protocol; slots and opaque native
+objects require an environment-owned ``evaluation_context``. Code, classes and
+module globals are configuration, while instance-owned containers and arrays are
+restored in place. MuJoCo model/data buffers use the engine's native copy API.
+"""
+
+import ctypes
+import inspect
+import random
+from collections import deque
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from copy import copy, deepcopy
+from functools import lru_cache
+from importlib.metadata import version
+from importlib.resources import files
+from importlib.util import find_spec
+from types import BuiltinFunctionType, CellType, FunctionType, MethodType, ModuleType
+from typing import TYPE_CHECKING, Any, TypeGuard
+
+import gymnasium as gym
+import numpy as np
+
+from jax_baselines.core.env_protocols import EvaluationContextEnv
+
+if TYPE_CHECKING:
+    from gymnasium.envs.mujoco import MujocoEnv
+
+
+def _is_mapping(value: object) -> TypeGuard[dict[object, object]]:
+    return type(value) is dict
+
+
+def _is_set(value: object) -> TypeGuard[set[object]]:
+    return type(value) is set
+
+
+class _PythonState:
+    """Memoized undo log over validated native Python serialization dictionaries."""
+
+    def __init__(self, external: tuple[object, ...] = ()):
+        self.stack = ExitStack()
+        self.seen = {id(value) for value in external}
+
+    def capture(self, value: object, path: str) -> None:
+        if id(value) in self.seen:
+            return
+        self.seen.add(id(value))
+        if isinstance(value, np.void):
+            raise TypeError(f"{path}: mutable NumPy record scalars need an evaluation_context")
+        if value is None or isinstance(
+            value,
+            (
+                bool,
+                int,
+                float,
+                complex,
+                str,
+                bytes,
+                range,
+                slice,
+                np.generic,
+                np.dtype,
+                type,
+                ModuleType,
+            ),
+        ):
+            return
+        if isinstance(value, FunctionType):
+            self.capture(value.__defaults__, path + ".defaults")
+            self.capture(value.__kwdefaults__, path + ".keyword_defaults")
+            self.capture(value.__closure__, path + ".closure")
+            self.capture(object.__getstate__(value), path + ".state")
+            return
+        if isinstance(value, BuiltinFunctionType):
+            self.capture(value.__self__, path + ".owner")
+            return
+        if isinstance(value, MethodType):
+            self.capture(value.__self__, path + ".owner")
+            return
+        if isinstance(value, CellType):
+            try:
+                content = value.cell_contents
+            except ValueError:
+
+                def restore_empty_cell() -> None:
+                    del value.cell_contents
+
+                self.stack.callback(restore_empty_cell)
+                return
+
+            def restore_cell() -> None:
+                value.cell_contents = content
+
+            self.stack.callback(restore_cell)
+            self.capture(content, path + ".content")
+            return
+        if isinstance(value, np.ndarray):
+            if type(value) is not np.ndarray:
+                raise TypeError(f"{path}: NumPy subclasses need an evaluation_context")
+            saved = value.copy()
+            writable = value.flags.writeable
+            self.capture(value.base, path + ".base")
+            if value.dtype.hasobject:
+                for index, item in enumerate(value.flat):
+                    self.capture(item, f"{path}[{index}]")
+
+            def restore_array() -> None:
+                if value.shape != saved.shape or value.dtype != saved.dtype:
+                    raise RuntimeError(f"{path}: evaluation changed an array's storage layout")
+                if value.tobytes() != saved.tobytes():
+                    if not value.flags.writeable:
+                        value.setflags(write=True)
+                    np.copyto(value, saved)
+                if value.flags.writeable != writable:
+                    value.setflags(write=writable)
+
+            self.stack.callback(restore_array)
+            return
+        if type(value) is np.random.Generator:
+            generator_state = deepcopy(value.bit_generator.state)
+
+            def restore_generator() -> None:
+                value.bit_generator.state = generator_state
+
+            self.stack.callback(restore_generator)
+            return
+        if type(value) is np.random.RandomState:
+            self.stack.callback(value.set_state, value.get_state())
+            return
+        if type(value) is random.Random:
+            self.stack.callback(value.setstate, value.getstate())
+            return
+        if _is_mapping(value):
+            saved_mapping = value.copy()
+
+            def restore_mapping() -> None:
+                value.clear()
+                value.update(saved_mapping)
+
+            self.stack.callback(restore_mapping)
+            for key, item in saved_mapping.items():
+                self.capture(key, path + ".key")
+                self.capture(item, f"{path}[{key!r}]")
+            return
+        if type(value) is list or type(value) is deque:
+            saved_items = list(value)
+            self.stack.callback(value.extend, saved_items)
+            self.stack.callback(value.clear)
+            for index, item in enumerate(saved_items):
+                self.capture(item, f"{path}[{index}]")
+            return
+        if _is_set(value):
+            saved_members = value.copy()
+
+            def restore_set() -> None:
+                value.clear()
+                value.update(saved_members)
+
+            self.stack.callback(restore_set)
+            for item in value:
+                self.capture(item, path + ".member")
+            return
+        if type(value) is tuple or type(value) is frozenset:
+            for index, item in enumerate(value):
+                self.capture(item, f"{path}[{index}]")
+            return
+        # Reject extension bases even when a Python subclass exposes a dictionary:
+        # its native buffers are absent from the default serialization state.
+        for cls in type(value).__mro__:
+            if cls is object:
+                continue
+            try:
+                source = inspect.getsourcefile(cls)
+            except TypeError as error:
+                raise TypeError(
+                    f"{path}: native {type(value).__name__} needs an evaluation_context"
+                ) from error
+            if source is None:
+                raise TypeError(
+                    f"{path}: native {type(value).__name__} needs an evaluation_context"
+                )
+        # Bypass EzPickle.__getstate__, which only stores constructor arguments.
+        # This is Python's native serialization mapping, not dynamic field access.
+        state = object.__getstate__(value)
+        if state is not None and (
+            type(state) is not dict or any(not isinstance(key, str) for key in state)
+        ):
+            raise TypeError(f"{path}: non-dictionary instance state needs an evaluation_context")
+        if state is None:
+
+            def restore_empty() -> None:
+                current = object.__getstate__(value)
+                if current is not None:
+                    if type(current) is not dict:
+                        raise TypeError(f"{path}: evaluation introduced non-dictionary state")
+                    current.clear()
+
+            self.stack.callback(restore_empty)
+            return
+        self.capture(state, path + ".state")
+
+
+@contextmanager
+def preserve_gym_spaces(*spaces: gym.Space) -> Iterator[None]:
+    """Preserve vector-parent spaces, including all nested space generators."""
+    snapshot = _PythonState()
+    for index, space in enumerate(spaces):
+        snapshot.capture(space, f"space[{index}]")
+    try:
+        yield
+    finally:
+        snapshot.stack.close()
+
+
+@lru_cache(maxsize=1)
+def _copy_model_function() -> Callable[[int, int], int]:
+    libraries = [
+        path for path in files("mujoco").iterdir() if path.name.startswith("libmujoco.so.")
+    ]
+    if len(libraries) != 1:
+        raise RuntimeError("Expected one installed MuJoCo shared library for native state copying")
+    function = ctypes.CDLL(str(libraries[0])).mj_copyModel
+    function.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    function.restype = ctypes.c_void_p
+    return function
+
+
+@contextmanager
+def _preserve_mujoco(env: "MujocoEnv") -> Iterator[None]:
+    if TYPE_CHECKING:
+        # Upstream C bindings omit this export's Python declaration.
+        def mj_copyData(destination: Any, model: Any, source: Any) -> None:
+            ...
+
+    else:
+        from mujoco import mj_copyData
+
+    model, data = env.model, env.data
+    saved_model, saved_data = copy(model), copy(data)
+    try:
+        yield
+    finally:
+        if _copy_model_function()(model._address, saved_model._address) != model._address:
+            raise RuntimeError("MuJoCo failed to restore the existing model buffer")
+        mj_copyData(data, model, saved_data)
+
+
+class GymStateWrapper(gym.Wrapper):
+    """Keep worker-local snapshots without constructing another environment.
+
+    Custom native environments can implement ``EvaluationContextEnv`` and own
+    their simulator restoration. Their surrounding Python wrappers and spaces
+    still participate in this snapshot. Environment topology must stay fixed.
+    """
+
+    def __init__(self, env: gym.Env):
+        super().__init__(env)
+        if version("gymnasium") != "1.3.0":
+            raise ValueError("Training-env evaluation requires Gymnasium 1.3.0")
+        if env.render_mode is not None:
+            raise ValueError("Training-env evaluation requires a headless Gymnasium environment")
+        self._native_context = (
+            env.unwrapped if isinstance(env.unwrapped, EvaluationContextEnv) else None
+        )
+        self._mujoco: MujocoEnv | None = None
+        if find_spec("mujoco") is not None:
+            from gymnasium.envs.mujoco import MujocoEnv as NativeMujocoEnv
+
+            if isinstance(env.unwrapped, NativeMujocoEnv):
+                self._mujoco = env.unwrapped
+        if self._mujoco is not None and self._native_context is None:
+            if version("mujoco") != "3.8.1":
+                raise ValueError("Training-env evaluation requires MuJoCo 3.8.1")
+            if self._mujoco.model.nplugin:
+                raise ValueError("MuJoCo plugins require an environment-owned evaluation_context")
+            _copy_model_function()
+        self._evaluation_stack: ExitStack | None = None
+        # Also validate the currently initialized graph at construction. Lazy task
+        # state is checked while taking the snapshot, before evaluation can reset.
+        snapshot = self._python_snapshot()
+        snapshot.stack.close()
+
+    def _python_snapshot(self) -> _PythonState:
+        external: tuple[object, ...] = ()
+        if self._native_context is not None:
+            external = (self._native_context,)
+        elif self._mujoco is not None:
+            external = (
+                self._mujoco.model,
+                self._mujoco.data,
+                self._mujoco.model.body_mass.base,
+                self._mujoco.data.qpos.base,
+            )
+        snapshot = _PythonState(external)
+        snapshot.capture(self.env, "env")
+        if self._native_context is not None:
+            snapshot.capture(self.action_space, "action_space")
+            snapshot.capture(self.observation_space, "observation_space")
+        return snapshot
+
+    def save_training_state(self) -> None:
+        if self._evaluation_stack is not None:
+            raise RuntimeError("Training environment is already borrowed for evaluation")
+        snapshot = self._python_snapshot()
+        with ExitStack() as stack:
+            stack.callback(random.setstate, random.getstate())
+            stack.callback(np.random.set_state, np.random.get_state())
+            if self._native_context is not None:
+                stack.enter_context(self._native_context.evaluation_context())
+            elif self._mujoco is not None:
+                stack.enter_context(_preserve_mujoco(self._mujoco))
+            stack.callback(snapshot.stack.close)
+            self._evaluation_stack = stack.pop_all()
+
+    def restore_training_state(self) -> None:
+        if self._evaluation_stack is None:
+            raise RuntimeError("No saved training environment state")
+        stack, self._evaluation_stack = self._evaluation_stack, None
+        stack.close()
+
+    @contextmanager
+    def evaluation_context(self) -> Iterator[None]:
+        self.save_training_state()
+        try:
+            yield
+        finally:
+            self.restore_training_state()

--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from typing import Any, TypeAlias
 
 import jax
@@ -25,16 +26,31 @@ Array: TypeAlias = np.ndarray | jax.Array
 class MjlabVectorizedEnv(VectorizedEnv):
     env_info: EnvInfo
 
-    def __init__(self, env_id, env, torch, seed=None, observation_key=None, jax_arrays=False):
+    def __init__(
+        self,
+        env_id,
+        env,
+        torch,
+        seed=None,
+        observation_key=None,
+        jax_arrays=False,
+        *,
+        reuse_for_eval=False,
+    ):
         self.env = env
         self._torch = torch
         self.jax_arrays = jax_arrays
+        self._reuse_for_eval = reuse_for_eval
         self.worker_num = env.num_envs
         self._observation_key = observation_key
         self._pending: tuple[Observation, Array, Array, Array, dict[str, Any]] | None = None
         self._closed = False
         self._frame = None
         self.reset(seed=seed)
+        if reuse_for_eval:
+            from env_builder.mjlab_state import validate_state_preservation
+
+            validate_state_preservation(env)
         shape = tuple(env.single_action_space.shape)
         self.action_space = spaces.Box(-1.0, 1.0, shape=shape, dtype=np.float32)
         self.observation_space: ObservationSpace = {
@@ -103,6 +119,24 @@ class MjlabVectorizedEnv(VectorizedEnv):
 
     def current_obs(self) -> Observation:
         return self._obs
+
+    @contextmanager
+    def evaluation_context(self) -> Iterator[None]:
+        if not self._reuse_for_eval:
+            yield
+            return
+        if self._closed:
+            raise RuntimeError("Cannot evaluate a closed environment")
+        from env_builder.mjlab_state import preserve_mjlab_state
+
+        observation, frame, pending = self._obs, self._frame, self._pending
+        with preserve_mjlab_state(self.env):
+            # mjlab.step has finished; _pending contains copied transition data.
+            self._pending = None
+            try:
+                yield
+            finally:
+                self._obs, self._frame, self._pending = observation, frame, pending
 
     def get_info(self) -> EnvInfo:
         return self.env_info
@@ -178,6 +212,19 @@ class MjlabSingleEnv(SingleEnv):
     def _current(self) -> Observation:
         return {key: value[0].copy() for key, value in self._vector.current_obs().items()}
 
+    @contextmanager
+    def evaluation_context(self) -> Iterator[None]:
+        if not self._vector._reuse_for_eval:
+            yield
+            return
+        cached_reset = self._cached_reset
+        with self._vector.evaluation_context():
+            self._cached_reset = None
+            try:
+                yield
+            finally:
+                self._cached_reset = cached_reset
+
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[Observation, dict[str, Any]]:
@@ -222,6 +269,7 @@ def make_mjlab_env(
     device="cuda:0",
     render_mode=None,
     jax_arrays=False,
+    reuse_for_eval=False,
 ) -> MjlabSingleEnv | MjlabVectorizedEnv:
     if render_mode not in (None, "rgb_array"):
         raise ValueError("mjlab supports only render_mode=None or 'rgb_array'")
@@ -229,6 +277,8 @@ def make_mjlab_env(
         raise ValueError("worker_num must be at least 1")
     if episode_length is not None and episode_length < 1:
         raise ValueError("episode_length must be at least 1")
+    if reuse_for_eval and render_mode is not None:
+        raise ValueError("reuse_for_eval requires a headless training environment")
     try:
         import mjlab.tasks  # noqa: F401 - registers built-in tasks
         import torch
@@ -247,7 +297,15 @@ def make_mjlab_env(
         cfg.episode_length_s = episode_length * (cfg.sim.mujoco.timestep * cfg.decimation)
     env = ManagerBasedRlEnv(cfg, device=device, render_mode=render_mode)
     try:
-        vector = MjlabVectorizedEnv(env_id, env, torch, seed, observation_key, jax_arrays)
+        vector = MjlabVectorizedEnv(
+            env_id,
+            env,
+            torch,
+            seed,
+            observation_key,
+            jax_arrays,
+            reuse_for_eval=reuse_for_eval,
+        )
         return MjlabSingleEnv(vector) if worker_num == 1 else vector
     except Exception:
         env.close()

--- a/env_builder/mjlab_physics_state.py
+++ b/env_builder/mjlab_physics_state.py
@@ -1,0 +1,158 @@
+"""Native mjlab integration state and randomized model buffers, restored in place."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import mujoco_warp as mjwarp
+import warp as wp
+from mjlab.envs import ManagerBasedRlEnv
+
+from env_builder.mjlab_scene_state import _preserve_tensors
+
+
+def _model_arrays(model: mjwarp.Model) -> dict[str, wp.array]:
+    # mjlab's declared DR fields plus MuJoCo's derived model constants.
+    return {
+        "actuator_acc0": model.actuator_acc0,
+        "actuator_biasprm": model.actuator_biasprm,
+        "actuator_forcerange": model.actuator_forcerange,
+        "actuator_gainprm": model.actuator_gainprm,
+        "body_inertia": model.body_inertia,
+        "body_invweight0": model.body_invweight0,
+        "body_ipos": model.body_ipos,
+        "body_iquat": model.body_iquat,
+        "body_mass": model.body_mass,
+        "body_pos": model.body_pos,
+        "body_quat": model.body_quat,
+        "body_subtreemass": model.body_subtreemass,
+        "cam_fovy": model.cam_fovy,
+        "cam_intrinsic": model.cam_intrinsic,
+        "cam_mat0": model.cam_mat0,
+        "cam_pos": model.cam_pos,
+        "cam_pos0": model.cam_pos0,
+        "cam_poscom0": model.cam_poscom0,
+        "cam_quat": model.cam_quat,
+        "dof_armature": model.dof_armature,
+        "dof_damping": model.dof_damping,
+        "dof_frictionloss": model.dof_frictionloss,
+        "dof_invweight0": model.dof_invweight0,
+        "eq_data": model.eq_data,
+        "geom_aabb": model.geom_aabb,
+        "geom_dataid": model.geom_dataid,
+        "geom_friction": model.geom_friction,
+        "geom_matid": model.geom_matid,
+        "geom_pos": model.geom_pos,
+        "geom_quat": model.geom_quat,
+        "geom_rbound": model.geom_rbound,
+        "geom_rgba": model.geom_rgba,
+        "geom_size": model.geom_size,
+        "jnt_actfrcrange": model.jnt_actfrcrange,
+        "jnt_range": model.jnt_range,
+        "jnt_stiffness": model.jnt_stiffness,
+        "light_ambient": model.light_ambient,
+        "light_attenuation": model.light_attenuation,
+        "light_cutoff": model.light_cutoff,
+        "light_diffuse": model.light_diffuse,
+        "light_dir": model.light_dir,
+        "light_dir0": model.light_dir0,
+        "light_exponent": model.light_exponent,
+        "light_pos": model.light_pos,
+        "light_pos0": model.light_pos0,
+        "light_poscom0": model.light_poscom0,
+        "light_specular": model.light_specular,
+        "mat_emission": model.mat_emission,
+        "mat_rgba": model.mat_rgba,
+        "mat_shininess": model.mat_shininess,
+        "mat_specular": model.mat_specular,
+        "mat_texid": model.mat_texid,
+        "mat_texrepeat": model.mat_texrepeat,
+        "pair_friction": model.pair_friction,
+        "qpos0": model.qpos0,
+        "qpos_spring": model.qpos_spring,
+        "site_pos": model.site_pos,
+        "site_quat": model.site_quat,
+        "stat.meaninertia": model.stat.meaninertia,
+        "tendon_actfrcrange": model.tendon_actfrcrange,
+        "tendon_armature": model.tendon_armature,
+        "tendon_damping": model.tendon_damping,
+        "tendon_frictionloss": model.tendon_frictionloss,
+        "tendon_invweight0": model.tendon_invweight0,
+        "tendon_length0": model.tendon_length0,
+        "tendon_lengthspring": model.tendon_lengthspring,
+        "tendon_stiffness": model.tendon_stiffness,
+    }
+
+
+def validate_physics_state(env: ManagerBasedRlEnv) -> None:
+    if env.sim.nan_guard.enabled:
+        raise ValueError("State preservation requires NaN recording to be disabled")
+    if env.sim.mj_model.nplugin:
+        raise ValueError("State preservation does not support native plugin-owned state")
+    unsupported = env.sim.expanded_fields - _model_arrays(env.sim.wp_model).keys()
+    if unsupported:
+        raise ValueError(f"Unsupported randomized model fields: {sorted(unsupported)}")
+
+
+@contextmanager
+def preserve_physics_state(env: ManagerBasedRlEnv) -> Iterator[None]:
+    sim = env.sim
+    model, data = sim.wp_model, sim.wp_data
+    default_fields = sim.default_model_fields.copy()
+    with wp.ScopedDevice(sim.wp_device):
+        # MuJoCo 3.8 INTEGRATION layout, including warmstart and history.
+        state = wp.array2d(
+            shape=(
+                env.num_envs,
+                1
+                + model.nq
+                + 3 * model.nv
+                + model.na
+                + model.nu
+                + 6 * model.nbody
+                + model.neq
+                + 7 * model.nmocap
+                + model.nuserdata
+                + model.nhistory,
+            ),
+            dtype=float,
+        )
+        mjwarp.get_state(model, data, state, int(mjwarp.State.INTEGRATION))
+        model_state = [(array, wp.clone(array)) for array in _model_arrays(model).values()]
+        caches = [
+            (array, wp.clone(array))
+            for array in (
+                data.qacc,
+                data.actuator_force,
+                data.qfrc_actuator,
+                data.sensordata,
+                sim._reset_mask_wp,
+            )
+        ]
+        sleep_state = [
+            (array, wp.clone(array))
+            for array in (
+                data.tree_asleep,
+                data.tree_awake,
+                data.body_awake,
+                data.body_awake_ind,
+                data.dof_awake_ind,
+                data.ntree_awake,
+                data.nbody_awake,
+                data.nv_awake,
+            )
+        ]
+    with _preserve_tensors(tuple(default_fields.values())):
+        try:
+            yield
+        finally:
+            with wp.ScopedDevice(sim.wp_device):
+                for destination, saved in (*model_state, *sleep_state):
+                    wp.copy(destination, saved)
+                mjwarp.set_state(model, data, state, int(mjwarp.State.INTEGRATION))
+                sim.forward()
+                # Forward reconstructs derived poses and overwrites warmstart/caches.
+                mjwarp.set_state(model, data, state, int(mjwarp.State.INTEGRATION))
+                for destination, saved in (*sleep_state, *caches):
+                    wp.copy(destination, saved)
+            sim.default_model_fields.clear()
+            sim.default_model_fields.update(default_fields)

--- a/env_builder/mjlab_scene_state.py
+++ b/env_builder/mjlab_scene_state.py
@@ -1,0 +1,298 @@
+"""mjlab scene, actuator, terrain, and sensor state around evaluation."""
+
+from collections.abc import Iterator, Sequence
+from contextlib import ExitStack, contextmanager
+from copy import deepcopy
+from typing import TypeVar
+
+import torch
+import warp as wp
+from mjlab.actuator.builtin_actuator import (
+    BuiltinDcMotorActuator,
+    BuiltinMotorActuator,
+    BuiltinMuscleActuator,
+    BuiltinPdActuator,
+    BuiltinPositionActuator,
+    BuiltinVelocityActuator,
+)
+from mjlab.actuator.dc_actuator import DcMotorActuator
+from mjlab.actuator.learned_actuator import LearnedMlpActuator
+from mjlab.actuator.pd_actuator import IdealPdActuator
+from mjlab.actuator.xml_actuator import XmlActuator
+from mjlab.entity import Entity
+from mjlab.scene import Scene
+from mjlab.sensor.builtin_sensor import BuiltinSensor
+from mjlab.sensor.camera_sensor import CameraSensor
+from mjlab.sensor.contact_sensor import ContactSensor
+from mjlab.sensor.raycast_sensor import RayCastSensor
+from mjlab.sensor.sensor import Sensor
+from mjlab.sensor.terrain_height_sensor import TerrainHeightSensor
+from mjlab.terrains.terrain_entity import TerrainEntity
+from mjlab.utils.buffers.circular_buffer import CircularBuffer
+from mjlab.utils.buffers.delay_buffer import DelayBuffer
+
+SensorData = TypeVar("SensorData")
+
+
+@contextmanager
+def _preserve_tensors(tensors: Sequence[torch.Tensor | None]) -> Iterator[None]:
+    saved = [(tensor, tensor.detach().clone()) for tensor in tensors if tensor is not None]
+    try:
+        yield
+    finally:
+        for tensor, value in saved:
+            tensor.copy_(value)
+
+
+@contextmanager
+def _preserve_history(buffer: CircularBuffer) -> Iterator[None]:
+    storage, pointer = buffer._buffer, buffer._pointer
+    with _preserve_tensors((storage, buffer._num_pushes)):
+        try:
+            yield
+        finally:
+            buffer._buffer, buffer._pointer = storage, pointer
+
+
+@contextmanager
+def _preserve_learned_network(actuator: LearnedMlpActuator) -> Iterator[None]:
+    network = actuator.network
+    assert network is not None
+    # TorchScript state includes ordinary attributes and parameters, beyond buffers.
+    actuator.network = deepcopy(network)
+    try:
+        yield
+    finally:
+        actuator.network = network
+
+
+@contextmanager
+def _preserve_delay(delay: DelayBuffer) -> Iterator[None]:
+    ring = delay._buffer
+    buffer, pointer, lags = ring._buffer, ring._pointer, delay._current_lags
+    generator_state = None if delay.generator is None else delay.generator.get_state()
+    with _preserve_tensors(
+        (buffer, ring._num_pushes, lags, delay._step_count, delay._phase_offsets)
+    ):
+        try:
+            yield
+        finally:
+            ring._buffer, ring._pointer, delay._current_lags = buffer, pointer, lags
+            if generator_state is not None:
+                assert delay.generator is not None
+                delay.generator.set_state(generator_state)
+
+
+@contextmanager
+def _preserve_contact(sensor: ContactSensor) -> Iterator[None]:
+    cache, valid = sensor._cached_data, sensor._cache_valid
+    tensors: list[torch.Tensor | None] = []
+    if sensor._air_time_state is not None:
+        tensors.extend(
+            (
+                sensor._air_time_state.current_air_time,
+                sensor._air_time_state.last_air_time,
+                sensor._air_time_state.current_contact_time,
+                sensor._air_time_state.last_contact_time,
+            )
+        )
+    history = None if sensor._history_state is None else sensor._history_state.copy()
+    if history is not None:
+        tensors.extend(history.values())
+    with _preserve_tensors(tensors):
+        try:
+            yield
+        finally:
+            sensor._cached_data, sensor._cache_valid = cache, valid
+            if history is not None:
+                assert sensor._history_state is not None
+                sensor._history_state.clear()
+                sensor._history_state.update(history)
+
+
+@contextmanager
+def _preserve_height(sensor: RayCastSensor) -> Iterator[None]:
+    cache, valid = sensor._cached_data, sensor._cache_valid
+    references = (
+        sensor._distances,
+        sensor._normals_w,
+        sensor._hit_pos_w,
+        sensor._pos_w,
+        sensor._quat_w,
+        sensor._frame_pos_w,
+        sensor._frame_quat_w,
+        sensor._cached_world_origins,
+        sensor._cached_world_rays,
+        sensor._cached_frame_pos,
+        sensor._cached_frame_mat,
+    )
+    ray_buffers = (
+        sensor._ray_pnt,
+        sensor._ray_vec,
+        sensor._ray_dist,
+        sensor._ray_geomid,
+        sensor._ray_normal,
+    )
+    with _preserve_tensors(
+        [
+            *references,
+            *(wp.to_torch(buffer) for buffer in ray_buffers if buffer is not None),
+        ]
+    ):
+        try:
+            yield
+        finally:
+            (
+                sensor._distances,
+                sensor._normals_w,
+                sensor._hit_pos_w,
+                sensor._pos_w,
+                sensor._quat_w,
+                sensor._frame_pos_w,
+                sensor._frame_quat_w,
+                sensor._cached_world_origins,
+                sensor._cached_world_rays,
+                sensor._cached_frame_pos,
+                sensor._cached_frame_mat,
+            ) = references
+            sensor._cached_data, sensor._cache_valid = cache, valid
+
+
+@contextmanager
+def _preserve_builtin(sensor: Sensor[SensorData]) -> Iterator[None]:
+    cache, valid = sensor._cached_data, sensor._cache_valid
+    try:
+        yield
+    finally:
+        sensor._cached_data, sensor._cache_valid = cache, valid
+
+
+def validate_scene_state(scene: Scene) -> None:
+    if type(scene) is not Scene:
+        raise TypeError("State preservation does not support custom Scene classes")
+    for entity in scene.entities.values():
+        if type(entity) not in (Entity, TerrainEntity):
+            raise TypeError(f"Unsupported entity type: {type(entity).__name__}")
+        for actuator in entity.actuators:
+            if type(actuator) not in (
+                BuiltinPositionActuator,
+                BuiltinPdActuator,
+                BuiltinMotorActuator,
+                BuiltinDcMotorActuator,
+                BuiltinVelocityActuator,
+                BuiltinMuscleActuator,
+                XmlActuator,
+                IdealPdActuator,
+                DcMotorActuator,
+                LearnedMlpActuator,
+            ):
+                raise TypeError(f"Unsupported actuator type: {type(actuator).__name__}")
+    for sensor in scene.sensors.values():
+        if isinstance(sensor, RayCastSensor) and any(
+            buffer is None
+            for buffer in (
+                sensor._ray_pnt,
+                sensor._ray_vec,
+                sensor._ray_dist,
+                sensor._ray_geomid,
+                sensor._ray_normal,
+            )
+        ):
+            raise ValueError("Ray sensors must be initialized before state preservation")
+        if type(sensor) not in (
+            BuiltinSensor,
+            ContactSensor,
+            RayCastSensor,
+            TerrainHeightSensor,
+            CameraSensor,
+        ):
+            raise TypeError(f"Unsupported sensor type: {type(sensor).__name__}")
+
+
+@contextmanager
+def preserve_scene_state(scene: Scene) -> Iterator[None]:
+    """Preserve scene buffers; physics and global RNG are owned by the caller."""
+    with ExitStack() as stack:
+        stack.enter_context(_preserve_tensors((scene.env_origins,)))
+        if scene.terrain is not None and scene.terrain.terrain_origins is not None:
+            stack.enter_context(
+                _preserve_tensors((scene.terrain.terrain_levels, scene.terrain.terrain_types))
+            )
+        if scene.sensor_context is not None:
+            context = scene.sensor_context
+            stack.enter_context(
+                _preserve_tensors(
+                    (
+                        context._rgb_torch,
+                        context._depth_torch,
+                        context._seg_torch,
+                        wp.to_torch(context.render_context.rgb_data),
+                    )
+                )
+            )
+        delays: dict[int, DelayBuffer] = {}
+        for entity in scene.entities.values():
+            data = entity.data
+            stack.enter_context(
+                _preserve_tensors(
+                    (
+                        data.default_root_state,
+                        data.default_joint_pos,
+                        data.default_joint_vel,
+                        data.default_joint_pos_limits,
+                        data.joint_pos_limits,
+                        data.soft_joint_pos_limits,
+                        data.gravity_vec_w,
+                        data.forward_vec_b,
+                        data.joint_pos_target,
+                        data.joint_vel_target,
+                        data.joint_effort_target,
+                        data.tendon_len_target,
+                        data.tendon_vel_target,
+                        data.tendon_effort_target,
+                        data.site_effort_target,
+                        data.encoder_bias,
+                    )
+                )
+            )
+            for actuator in entity.actuators:
+                if isinstance(actuator, IdealPdActuator):
+                    stack.enter_context(
+                        _preserve_tensors(
+                            (
+                                actuator.stiffness,
+                                actuator.damping,
+                                actuator.force_limit,
+                                actuator.default_stiffness,
+                                actuator.default_damping,
+                                actuator.default_force_limit,
+                            )
+                        )
+                    )
+                if isinstance(actuator, DcMotorActuator):
+                    stack.enter_context(
+                        _preserve_tensors(
+                            (
+                                actuator.saturation_effort,
+                                actuator.velocity_limit_motor,
+                                actuator._joint_vel_clipped,
+                            )
+                        )
+                    )
+                if isinstance(actuator, LearnedMlpActuator):
+                    stack.enter_context(_preserve_learned_network(actuator))
+                    for history in (actuator._pos_error_history, actuator._vel_history):
+                        if history is not None:
+                            stack.enter_context(_preserve_history(history))
+                if actuator._delay_buffer is not None:
+                    delays[id(actuator._delay_buffer)] = actuator._delay_buffer
+        for delay in delays.values():
+            stack.enter_context(_preserve_delay(delay))
+        for sensor in scene.sensors.values():
+            if isinstance(sensor, RayCastSensor):
+                stack.enter_context(_preserve_height(sensor))
+            elif isinstance(sensor, ContactSensor):
+                stack.enter_context(_preserve_contact(sensor))
+            elif isinstance(sensor, (BuiltinSensor, CameraSensor)):
+                stack.enter_context(_preserve_builtin(sensor))
+        yield

--- a/env_builder/mjlab_state.py
+++ b/env_builder/mjlab_state.py
@@ -1,0 +1,219 @@
+"""Version-scoped mjlab state preservation for evaluation on the training env.
+
+GPU simulation is not bitwise deterministic. Restoring transition inputs does not
+guarantee an identical future trajectory. The caller preserves adapter observations
+and pending results; custom terms own their state through evaluation_context().
+"""
+
+import random
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from importlib.metadata import version
+
+import numpy as np
+import torch
+from mjlab.envs import ManagerBasedRlEnv
+from mjlab.managers.action_manager import ActionManager
+from mjlab.managers.command_manager import CommandManager, NullCommandManager
+from mjlab.managers.curriculum_manager import CurriculumManager, NullCurriculumManager
+from mjlab.managers.event_manager import EventManager
+from mjlab.managers.manager_base import ManagerTermBaseCfg
+from mjlab.managers.metrics_manager import MetricsManager, NullMetricsManager
+from mjlab.managers.observation_manager import ObservationManager
+from mjlab.managers.recorder_manager import NullRecorderManager
+from mjlab.managers.reward_manager import RewardManager
+from mjlab.managers.termination_manager import TerminationManager
+from mjlab.tasks.velocity.mdp.curriculums import commands_vel
+from mjlab.tasks.velocity.mdp.velocity_command import UniformVelocityCommand
+from mjlab.utils.buffers.circular_buffer import CircularBuffer
+from mjlab.utils.buffers.delay_buffer import DelayBuffer
+from mjlab.utils.noise.noise_cfg import NoiseCfg
+
+from env_builder.mjlab_physics_state import (
+    preserve_physics_state,
+    validate_physics_state,
+)
+from env_builder.mjlab_scene_state import (
+    _preserve_delay,
+    _preserve_history,
+    _preserve_tensors,
+    preserve_scene_state,
+    validate_scene_state,
+)
+from env_builder.mjlab_term_state import preserve_term_state, validate_term_state
+
+
+def _manager_terms(env: ManagerBasedRlEnv) -> Iterator[ManagerTermBaseCfg]:
+    yield from env.reward_manager._term_cfgs
+    yield from env.termination_manager._term_cfgs
+    for terms in env.event_manager._mode_term_cfgs.values():
+        yield from terms
+    if isinstance(env.curriculum_manager, CurriculumManager):
+        yield from env.curriculum_manager._term_cfgs
+    if isinstance(env.metrics_manager, MetricsManager):
+        yield from env.metrics_manager._term_cfgs
+    for group in env.observation_manager._group_obs_term_cfgs.values():
+        yield from group
+
+
+def validate_state_preservation(env: ManagerBasedRlEnv) -> None:
+    """Validate component contracts once, independently of task or term names."""
+    for package, audited in (
+        ("mjlab", "1.6.0"),
+        ("mujoco", "3.8.1"),
+        ("mujoco-warp", "3.11.0"),
+        ("warp-lang", "1.15.0"),
+    ):
+        if version(package) != audited:
+            raise ValueError(f"Training-env evaluation requires {package}=={audited}")
+    if type(env) is not ManagerBasedRlEnv:
+        raise TypeError("State preservation requires ManagerBasedRlEnv")
+    if env.cfg.auto_reset:
+        raise ValueError("State preservation requires adapter-managed reset")
+    if env.render_mode is not None or type(env.recorder_manager) is not NullRecorderManager:
+        raise ValueError("State preservation requires headless execution without recorders")
+    for manager, types in (
+        (env.action_manager, (ActionManager,)),
+        (env.command_manager, (CommandManager, NullCommandManager)),
+        (env.curriculum_manager, (CurriculumManager, NullCurriculumManager)),
+        (env.metrics_manager, (MetricsManager, NullMetricsManager)),
+        (env.event_manager, (EventManager,)),
+        (env.observation_manager, (ObservationManager,)),
+        (env.reward_manager, (RewardManager,)),
+        (env.termination_manager, (TerminationManager,)),
+    ):
+        if type(manager) not in types:
+            raise TypeError(f"Unsupported mjlab manager: {type(manager).__name__}")
+    validate_physics_state(env)
+    validate_scene_state(env.scene)
+    for name in env.action_manager.active_terms:
+        validate_term_state(env.action_manager.get_term(name))
+    for name in env.command_manager.active_terms:
+        validate_term_state(env.command_manager.get_term(name))
+    for cfg in _manager_terms(env):
+        validate_term_state(cfg.func)
+        if cfg.func is commands_vel and not isinstance(
+            env.command_manager.get_term(cfg.params["command_name"]),
+            UniformVelocityCommand,
+        ):
+            raise ValueError("Velocity curricula require a UniformVelocityCommand target")
+    observation = env.observation_manager
+    for group in observation._group_obs_term_cfgs.values():
+        for cfg in group:
+            if isinstance(cfg.noise, NoiseCfg):
+                validate_term_state(cfg.noise)
+    for group in observation._group_obs_class_instances.values():
+        for noise in group.values():
+            validate_term_state(noise)
+    for group in observation._group_obs_term_delay_buffer.values():
+        if any(type(buffer) is not DelayBuffer for buffer in group.values()):
+            raise TypeError("Unsupported observation delay buffer")
+    for group in observation._group_obs_term_history_buffer.values():
+        if any(type(buffer) is not CircularBuffer for buffer in group.values()):
+            raise TypeError("Unsupported observation history buffer")
+
+
+@contextmanager
+def _preserve_managers(env: ManagerBasedRlEnv) -> Iterator[None]:
+    observation = env.observation_manager
+    metrics = env.metrics_manager
+    tensors = [
+        env.episode_length_buf,
+        env._manual_reset_pending,
+        env._command_dt,
+        env.action_manager.action,
+        env.action_manager.prev_action,
+        env.action_manager.prev_prev_action,
+        env.reward_manager._reward_buf,
+        env.reward_manager._step_reward,
+        *env.reward_manager._episode_sums.values(),
+        env.termination_manager._terminated_buf,
+        env.termination_manager._truncated_buf,
+        *env.termination_manager._term_dones.values(),
+        *env.event_manager._interval_term_time_left,
+        *env.event_manager._reset_term_last_triggered_step_id,
+        *env.event_manager._reset_term_last_triggered_once,
+    ]
+    substep_count = 0
+    if isinstance(metrics, MetricsManager):
+        substep_count = metrics._substep_count
+        tensors.extend(
+            (
+                metrics._step_count,
+                metrics._step_values,
+                *metrics._episode_sums.values(),
+                *metrics._episode_max.values(),
+                *metrics._substep_accum,
+            )
+        )
+    sim_steps, common_steps = env._sim_step_counter, env.common_step_counter
+    obs_buf, obs_cache = env.obs_buf, observation._obs_buffer
+    extras = env.extras.copy()
+    curriculum_state = env.curriculum_manager._curriculum_state.copy()
+    configs = list(_manager_terms(env))
+    params = [(cfg, cfg.params.copy()) for cfg in configs]
+    weights = [(cfg, cfg.weight) for cfg in env.reward_manager._term_cfgs]
+    timeouts = [(cfg, cfg.time_out) for cfg in env.termination_manager._term_cfgs]
+    terms: dict[int, object] = {id(cfg.func): cfg.func for cfg in configs}
+    for name in env.action_manager.active_terms:
+        action = env.action_manager.get_term(name)
+        terms[id(action)] = action
+    for name in env.command_manager.active_terms:
+        command = env.command_manager.get_term(name)
+        terms[id(command)] = command
+    for group in observation._group_obs_term_cfgs.values():
+        for cfg in group:
+            if isinstance(cfg.noise, NoiseCfg):
+                terms[id(cfg.noise)] = cfg.noise
+    for group in observation._group_obs_class_instances.values():
+        for noise in group.values():
+            terms[id(noise)] = noise
+    with ExitStack() as stack:
+        stack.enter_context(_preserve_tensors(tensors))
+        for term in terms.values():
+            stack.enter_context(preserve_term_state(term))
+        for group in observation._group_obs_term_history_buffer.values():
+            for buffer in group.values():
+                stack.enter_context(_preserve_history(buffer))
+        for group in observation._group_obs_term_delay_buffer.values():
+            for buffer in group.values():
+                stack.enter_context(_preserve_delay(buffer))
+        try:
+            yield
+        finally:
+            env._sim_step_counter, env.common_step_counter = sim_steps, common_steps
+            if isinstance(metrics, MetricsManager):
+                metrics._substep_count = substep_count
+            env.obs_buf, observation._obs_buffer = obs_buf, obs_cache
+            env.extras.clear()
+            env.extras.update(extras)
+            env.curriculum_manager._curriculum_state.clear()
+            env.curriculum_manager._curriculum_state.update(curriculum_state)
+            for cfg, saved_params in params:
+                cfg.params.clear()
+                cfg.params.update(saved_params)
+            for cfg, weight in weights:
+                cfg.weight = weight
+            for cfg, time_out in timeouts:
+                cfg.time_out = time_out
+
+
+@contextmanager
+def preserve_mjlab_state(env: ManagerBasedRlEnv) -> Iterator[None]:
+    """Preserve a validated environment; topology/config changes require rebuilding it."""
+    rng = random.getstate(), np.random.get_state(), torch.get_rng_state()
+    cuda_rng = (
+        torch.cuda.get_rng_state(env.device) if torch.device(env.device).type == "cuda" else None
+    )
+    try:
+        with ExitStack() as stack:
+            stack.enter_context(_preserve_managers(env))
+            stack.enter_context(preserve_scene_state(env.scene))
+            stack.enter_context(preserve_physics_state(env))
+            yield
+    finally:
+        random.setstate(rng[0])
+        np.random.set_state(rng[1])
+        torch.set_rng_state(rng[2])
+        if cuda_rng is not None:
+            torch.cuda.set_rng_state(cuda_rng, env.device)

--- a/env_builder/mjlab_term_state.py
+++ b/env_builder/mjlab_term_state.py
@@ -1,0 +1,295 @@
+"""Explicit state adapters for mjlab 1.6 action, command, and manager terms."""
+
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from types import FunctionType
+
+from mjlab.envs.mdp.actions.actions import (
+    BaseAction,
+    JointEffortAction,
+    JointPositionAction,
+    JointVelocityAction,
+    RelativeJointPositionAction,
+    SiteEffortAction,
+    TendonEffortAction,
+    TendonLengthAction,
+    TendonVelocityAction,
+)
+from mjlab.envs.mdp.actions.differential_ik import DifferentialIKAction
+from mjlab.envs.mdp.curriculums import reward_curriculum, termination_curriculum
+from mjlab.envs.mdp.events import apply_body_impulse
+from mjlab.envs.mdp.rewards import electrical_power_cost, posture
+from mjlab.managers.command_manager import CommandTerm
+from mjlab.tasks.manipulation.mdp.commands import (
+    LiftingCommand,
+    MultiCubeLiftingCommand,
+)
+from mjlab.tasks.tracking.mdp.commands import MotionCommand
+from mjlab.tasks.velocity.mdp.rewards import (
+    feet_swing_height,
+    upright,
+    variable_posture,
+)
+from mjlab.tasks.velocity.mdp.velocity_command import UniformVelocityCommand
+from mjlab.utils.noise.noise_cfg import (
+    ConstantNoiseCfg,
+    GaussianNoiseCfg,
+    NoiseCfg,
+    UniformNoiseCfg,
+)
+from mjlab.utils.noise.noise_model import NoiseModel, NoiseModelWithAdditiveBias
+
+from env_builder.mjlab_scene_state import _preserve_tensors
+from jax_baselines.core.env_protocols import EvaluationContextEnv
+
+_ACTION_TYPES = (
+    JointPositionAction,
+    RelativeJointPositionAction,
+    JointVelocityAction,
+    JointEffortAction,
+    TendonLengthAction,
+    TendonVelocityAction,
+    TendonEffortAction,
+    SiteEffortAction,
+    DifferentialIKAction,
+)
+_COMMAND_TYPES = (
+    UniformVelocityCommand,
+    MotionCommand,
+    LiftingCommand,
+    MultiCubeLiftingCommand,
+)
+_CALLABLE_TYPES = (
+    feet_swing_height,
+    upright,
+    variable_posture,
+    posture,
+    electrical_power_cost,
+    apply_body_impulse,
+    reward_curriculum,
+    termination_curriculum,
+)
+_NOISE_TYPES = (ConstantNoiseCfg, UniformNoiseCfg, GaussianNoiseCfg)
+# These installed functions mutate only the env/scene/model or manager buffers
+# covered by the snapshot. User callables must declare their own state context.
+_FUNCTION_MODULES = {
+    "mjlab.envs.mdp.observations",
+    "mjlab.envs.mdp.rewards",
+    "mjlab.envs.mdp.terminations",
+    "mjlab.envs.mdp.events",
+    "mjlab.envs.mdp.metrics",
+    "mjlab.tasks.cartpole.cartpole_env_cfg",
+    *(
+        f"mjlab.envs.mdp.dr.{name}"
+        for name in (
+            "actuator",
+            "body",
+            "camera",
+            "geom",
+            "joint",
+            "light",
+            "material",
+            "pair",
+            "site",
+            "tendon",
+        )
+    ),
+    *(
+        f"mjlab.tasks.{task}.mdp.{module}"
+        for task, modules in (
+            ("velocity", ("observations", "rewards", "terminations", "curriculums")),
+            ("manipulation", ("observations", "rewards", "terminations")),
+            ("tracking", ("observations", "rewards", "terminations", "metrics")),
+        )
+        for module in modules
+    ),
+}
+
+
+def validate_term_state(term: object) -> None:
+    """Accept audited built-ins or a custom term with an explicit state context."""
+    if isinstance(term, EvaluationContextEnv):
+        return
+    if isinstance(term, FunctionType) and term.__module__ in _FUNCTION_MODULES:
+        return
+    if type(term) not in (
+        *_ACTION_TYPES,
+        *_COMMAND_TYPES,
+        *_CALLABLE_TYPES,
+        *_NOISE_TYPES,
+        NoiseModel,
+        NoiseModelWithAdditiveBias,
+    ):
+        raise TypeError(
+            f"Unsupported mjlab term {type(term).__name__}; custom terms must implement "
+            "evaluation_context() to preserve their mutable state"
+        )
+    if isinstance(term, UniformVelocityCommand) and term._joystick_enabled is not None:
+        raise ValueError("State preservation does not support interactive command overrides")
+    if isinstance(term, NoiseModel):
+        validate_term_state(term._noise_model_cfg.noise_cfg)
+    if isinstance(term, NoiseModelWithAdditiveBias):
+        validate_term_state(term._bias_noise_cfg)
+    if isinstance(term, reward_curriculum) and any(
+        set(stage) - {"step", "weight", "params"} for stage in term._stages
+    ):
+        raise ValueError("Reward curricula may change only weight and params")
+    if isinstance(term, termination_curriculum) and any(
+        set(stage) - {"step", "time_out", "params"} for stage in term._stages
+    ):
+        raise ValueError("Termination curricula may change only time_out and params")
+
+
+@contextmanager
+def _preserve_command(term: CommandTerm) -> Iterator[None]:
+    metrics = term.metrics.copy()
+    with _preserve_tensors((term.time_left, term.command_counter, *metrics.values())):
+        try:
+            if isinstance(term, UniformVelocityCommand):
+                heading = term.heading_error
+                ranges = (
+                    term.cfg.ranges.lin_vel_x,
+                    term.cfg.ranges.lin_vel_y,
+                    term.cfg.ranges.ang_vel_z,
+                    term.cfg.ranges.heading,
+                )
+                with _preserve_tensors(
+                    (
+                        term.vel_command_b,
+                        term.vel_command_w,
+                        term.heading_target,
+                        heading,
+                        term.is_heading_env,
+                        term.is_standing_env,
+                        term.is_world_env,
+                        term.is_forward_env,
+                    )
+                ):
+                    try:
+                        yield
+                    finally:
+                        term.heading_error = heading
+                        (
+                            term.cfg.ranges.lin_vel_x,
+                            term.cfg.ranges.lin_vel_y,
+                            term.cfg.ranges.ang_vel_z,
+                            term.cfg.ranges.heading,
+                        ) = ranges
+                return
+            if isinstance(term, MotionCommand):
+                poses = term.body_pos_relative_w, term.body_quat_relative_w
+                failed, pending = term.bin_failed_count, term._pending_forward
+                with _preserve_tensors((term.time_steps, *poses, failed, term._current_bin_failed)):
+                    try:
+                        yield
+                    finally:
+                        term.body_pos_relative_w, term.body_quat_relative_w = poses
+                        term.bin_failed_count, term._pending_forward = failed, pending
+                return
+            if isinstance(term, (LiftingCommand, MultiCubeLiftingCommand)):
+                success, pending = term.episode_success, term._pending_forward
+                with ExitStack() as stack:
+                    stack.enter_context(_preserve_tensors((term.target_pos, success)))
+                    if isinstance(term, MultiCubeLiftingCommand):
+                        target = term._cached_target_obj_pos
+                        stack.enter_context(_preserve_tensors((term.target_selection, target)))
+                        try:
+                            yield
+                        finally:
+                            term._cached_target_obj_pos = target
+                            term.episode_success, term._pending_forward = (
+                                success,
+                                pending,
+                            )
+                    else:
+                        try:
+                            yield
+                        finally:
+                            term.episode_success, term._pending_forward = (
+                                success,
+                                pending,
+                            )
+                return
+            raise TypeError(f"Unsupported command: {type(term).__name__}")
+        finally:
+            term.metrics.clear()
+            term.metrics.update(metrics)
+
+
+@contextmanager
+def preserve_term_state(term: object) -> Iterator[None]:
+    """Preserve a term accepted by validate_term_state, including rebound tensors."""
+    if isinstance(term, EvaluationContextEnv):
+        with term.evaluation_context():
+            yield
+        return
+    if isinstance(term, CommandTerm):
+        with _preserve_command(term):
+            yield
+        return
+    if isinstance(term, BaseAction):
+        processed = term._processed_actions
+        with _preserve_tensors((term._raw_actions, processed)):
+            try:
+                yield
+            finally:
+                term._processed_actions = processed
+        return
+    if isinstance(term, DifferentialIKAction):
+        with _preserve_tensors(
+            (
+                term._raw_actions,
+                term._desired_pos,
+                term._desired_quat,
+                term._jacp_torch,
+                term._jacr_torch,
+                term._point_torch,
+            )
+        ):
+            yield
+        return
+    if isinstance(term, feet_swing_height):
+        peak = term.peak_heights
+        with _preserve_tensors((peak,)):
+            try:
+                yield
+            finally:
+                term.peak_heights = peak
+        return
+    if isinstance(term, apply_body_impulse):
+        with _preserve_tensors((term._time_remaining, term._active, term._interval_time_left)):
+            yield
+        return
+    if isinstance(term, NoiseCfg):
+        cache = {device: values.copy() for device, values in term._tensor_cache.items()}
+        try:
+            yield
+        finally:
+            term._tensor_cache.clear()
+            term._tensor_cache.update(cache)
+        return
+    if isinstance(term, NoiseModel):
+        with ExitStack() as stack:
+            stack.enter_context(preserve_term_state(term._noise_model_cfg.noise_cfg))
+            if isinstance(term, NoiseModelWithAdditiveBias):
+                bias, components, initialized = (
+                    term._bias,
+                    term._num_components,
+                    term._bias_initialized,
+                )
+                stack.enter_context(preserve_term_state(term._bias_noise_cfg))
+                stack.enter_context(_preserve_tensors((bias,)))
+                try:
+                    yield
+                finally:
+                    term._bias, term._num_components, term._bias_initialized = (
+                        bias,
+                        components,
+                        initialized,
+                    )
+            else:
+                yield
+        return
+    # Built-in posture/reward callables have construction-only tensor constants;
+    # curriculum target config mutations are restored by the manager snapshot.
+    yield

--- a/experiments/cli/_env.py
+++ b/experiments/cli/_env.py
@@ -14,6 +14,11 @@ def add_env_args(parser):
     parser.add_argument(
         "--env_jax_arrays", action="store_true", help="exchange mjlab tensors with JAX via DLPack"
     )
+    parser.add_argument(
+        "--env_reuse_for_eval",
+        action="store_true",
+        help="reuse the training environment for evaluation (Gymnasium or mjlab)",
+    )
 
 
 def env_builder_kwargs(args):
@@ -23,4 +28,5 @@ def env_builder_kwargs(args):
         "episode_length": args.env_episode_length,
         "device": args.env_device,
         "jax_arrays": args.env_jax_arrays,
+        "reuse_for_eval": args.env_reuse_for_eval,
     }

--- a/experiments/configs/pg_mjlab_go1.yaml
+++ b/experiments/configs/pg_mjlab_go1.yaml
@@ -6,6 +6,7 @@ base:
   env_backend: mjlab
   env_device: cuda:0
   env_jax_arrays: true
+  env_reuse_for_eval: true
   worker: 4096
   steps: 491520000
   eval_num: 5

--- a/jax_baselines/core/env_info.py
+++ b/jax_baselines/core/env_info.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from jax_baselines.core.env_protocols import (
     EnvInfo,
+    EvaluationContextEnv,
     PreparedEnvSpec,
     PreparedWorkerEnvSpec,
     SingleEnv,
@@ -71,6 +72,8 @@ def _prepare_envs(env_builder, num_workers=1, seed=None):
         raise ValueError("prepare_envs must return PreparedEnvSpec")
     if prepared.eval_env is None:
         raise ValueError("Prepared local eval_env is required")
+    if prepared.env is prepared.eval_env and not isinstance(prepared.env, EvaluationContextEnv):
+        raise ValueError("Shared train/eval env must provide an evaluation_context()")
     return prepared
 
 

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -7,6 +7,7 @@ instead of concrete backend packages.
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, TypeAlias, TypedDict, runtime_checkable
 
@@ -100,6 +101,18 @@ class VectorizedEvalEnv(VectorizedEnv, Protocol):
     """Vector environment that can start an independent evaluation measurement."""
 
     def reset(self, *, seed: int | None = None) -> tuple[Observation, dict[str, Any]]:
+        ...
+
+
+@runtime_checkable
+class EvaluationContextEnv(Protocol):
+    """Adapter-owned evaluation isolation, including restoration on failure.
+
+    Shared train/eval environments must preserve their simulator, task, RNG,
+    observation caches and any completed result waiting for collection.
+    """
+
+    def evaluation_context(self) -> AbstractContextManager[None]:
         ...
 
 

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -1,8 +1,11 @@
+from contextlib import nullcontext
+
 import jax
 import numpy as np
 
 from jax_baselines.core.env_info import prepare_worker_env
 from jax_baselines.core.env_protocols import (
+    EvaluationContextEnv,
     VectorizedEvalEnv,
     batch_observation,
     reset_for_evaluation,
@@ -208,9 +211,14 @@ def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, c
         if isinstance(eval_env, VectorizedEvalEnv)
         else _evaluate_single_episodes
     )
-    total_reward, total_ep_len, total_truncated, original_rewards = collect(
-        eval_env, eval_eps, act_eval_fn, conv_action
-    )
+    with (
+        eval_env.evaluation_context()
+        if isinstance(eval_env, EvaluationContextEnv)
+        else nullcontext()
+    ):
+        total_reward, total_ep_len, total_truncated, original_rewards = collect(
+            eval_env, eval_eps, act_eval_fn, conv_action
+        )
     mean_reward = np.mean(total_reward)
     mean_ep_len = np.mean(total_ep_len)
 

--- a/tests/test_ac_memory_backend.py
+++ b/tests/test_ac_memory_backend.py
@@ -21,7 +21,7 @@ class _Env:
     def prepare_envs(self, num_workers=1, seed=None):
         return PreparedEnvSpec(
             self,
-            self,
+            _Env(self.observation),
             {
                 "observation_space": self.observation_space,
                 "action_size": [1],

--- a/tests/test_env_builder_adapter.py
+++ b/tests/test_env_builder_adapter.py
@@ -465,6 +465,7 @@ def test_experiments_composition_path_uses_adapter_prepared_envs(monkeypatch):
                 "episode_length": None,
                 "device": "cuda:0",
                 "jax_arrays": False,
+                "reuse_for_eval": False,
             },
         ),
         ("prepare_envs", 4, 21),
@@ -505,6 +506,7 @@ def test_mjlab_backend_is_lazy_and_receives_its_supported_options(monkeypatch):
                 "device": "cpu",
                 "render_mode": "rgb_array",
                 "jax_arrays": True,
+                "reuse_for_eval": False,
             },
         ),
     ]
@@ -577,6 +579,7 @@ def test_shared_local_cli_env_options_forward_to_builder(monkeypatch):
         "episode_length": 12,
         "device": "cpu",
         "jax_arrays": True,
+        "reuse_for_eval": False,
     }
 
 

--- a/tests/test_vectorized_env_fixes.py
+++ b/tests/test_vectorized_env_fixes.py
@@ -134,7 +134,7 @@ def test_is_envpool_supported_false_and_quiet_for_unknown_env(recwarn):
 
 
 def _fake_vec(tag):
-    def _make(env_id, worker_num, seed=None, observation_key=None):
+    def _make(env_id, worker_num, seed=None, observation_key=None, *, reuse_for_eval=False):
         return (tag, env_id, worker_num, observation_key)
 
     return _make


### PR DESCRIPTION
주기 평가마다 별도 시뮬레이터를 유지하는 비용을 줄이기 위해 `--env_reuse_for_eval`을 추가합니다. 학습 중인 환경의 상태를 보존하고 실제로 리셋해 평가한 뒤, 정상 종료와 예외 모두에서 복원하여 학습을 이어갑니다. 단일·병렬 환경 수는 학습 설정을 그대로 따릅니다.

- 공통 평가 컨텍스트를 통해 PG·DPG에서 같은 환경 객체를 재사용합니다. `pg_mjlab_go1.yaml`의 PPO/SPO 변형에 옵션을 켭니다.
- Gymnasium은 환경 ID 목록 없이 Python 객체·래퍼·RNG·공유 배열을 복원하며, MuJoCo는 모델·데이터의 네이티브 상태를 복원합니다. 병렬 Dict/Tuple 관측과 수집 대기 중인 결과도 보존합니다.
- mjlab은 작업 이름에 의존하지 않고 물리·매니저·명령·관측 이력·센서·액추에이터 상태를 보존합니다.

스택 2/2: `feature/vectorized-eval` → `feat/issue17-borrow-training-env`. 선행 PR #28을 먼저 병합합니다. 이 PR의 diff에는 상태 보존·재사용 변경만 표시됩니다.

지원 조건: headless 평가와 현재 검증한 Gymnasium 1.3.0 / MuJoCo 3.8.1 / mjlab 1.6.0 / mujoco-warp 3.11.0 / Warp 1.15.0이 대상입니다. 지원하지 않는 네이티브 상태와 사용자 정의 상태 보유 구성 요소는 자체 `evaluation_context`가 필요합니다. EnvPool 재사용은 거부합니다.

검증: PPO/TD3의 단일·4개 병렬 실제 학습, 사용자 정의 Gymnasium·FrozenLake·모델 질량을 변경하는 MuJoCo, mjlab의 보행·조작·카메라·모션 추적에서 정상·예외·종료 경계 복원을 확인했습니다. 관련 회귀 테스트와 커밋 훅이 통과했으며 새 린트·타입 진단은 없습니다. 검증 전용 코드·보고서·로그는 PR에 포함하지 않습니다.

Refs #17
