### PR TITLE
feat: DPG GPU 리플레이와 Go1 학습 설정 개선

### DIFF
--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -56,7 +56,7 @@ class MjlabVectorizedEnv(VectorizedEnv):
         self.observation_space: ObservationSpace = {
             key: list(value.shape[1:]) for key, value in self._obs.items()
         }
-        self.env_info = {
+        self.env_info: EnvInfo = {
             "observation_space": self.observation_space,
             "action_size": list(shape),
             "action_type": "continuous",
@@ -64,6 +64,7 @@ class MjlabVectorizedEnv(VectorizedEnv):
             "env_id": env_id,
             "worker_num": self.worker_num,
             "core_env_type": "VectorizedEnv",
+            "autoreset_steps": False,
         }
 
     def _array(self, value) -> Array:

--- a/experiments/cli/dpg.py
+++ b/experiments/cli/dpg.py
@@ -30,6 +30,12 @@ def add_args(parser):
     )
     parser.add_argument("--batch", type=int, default=32, help="batch size")
     parser.add_argument("--buffer_size", type=float, default=100000, help="buffer_size")
+    parser.add_argument(
+        "--memory_backend",
+        choices=("auto", "cpu", "gpu"),
+        default="auto",
+        help="replay storage device; auto follows environment observations",
+    )
     parser.add_argument("--per", action="store_true")
     parser.add_argument(
         "--n_step",
@@ -115,6 +121,7 @@ def _common(a):
         "learning_rate": a.learning_rate,
         "batch_size": a.batch,
         "buffer_size": int(a.buffer_size),
+        "memory_backend": a.memory_backend,
         "learning_starts": a.learning_starts,
         "prioritized_replay": a.per,
         "scaled_by_reset": a.scaled_by_reset,
@@ -207,6 +214,7 @@ ALGOS = {
             "learning_rate": a.learning_rate,
             "batch_size": a.batch,
             "buffer_size": int(a.buffer_size),
+            "memory_backend": a.memory_backend,
             "target_network_update_freq": 250,
             "learning_starts": a.learning_starts,
             "action_noise": a.action_noise,

--- a/experiments/configs/dpg_mjlab_go1.yaml
+++ b/experiments/configs/dpg_mjlab_go1.yaml
@@ -1,21 +1,35 @@
 family: dpg
+# Sampling schedule: FlashSAC's GPU-simulator recipe, adapted to local SAC.
+# https://github.com/Holiday-Robot/FlashSAC/blob/87edc9061150ae9e962dd84e6544e27a1554b3ab/scripts/run_isaaclab.sh
 runtime:
   device: 0
 base:
   env: Mjlab-Velocity-Flat-Unitree-Go1
   env_backend: mjlab
   env_device: cuda:0
-  worker: 4096
-  train_freq: 4096
-  steps: 491520000
+  env_jax_arrays: true
+  env_reuse_for_eval: true
+  worker: 1024
+  # train_freq counts transitions across all workers: two updates per vector step.
+  train_freq: 1024
+  gradient_steps: 2
+  steps: 50000896
   eval_num: 5
   learning_rate: 0.0003
-  buffer_size: 1e6
-  batch: 24576
+  buffer_size: 1e7
+  batch: 2048
+  learning_starts: 100000
+  gamma: 0.99
+  n_step: 3
+  # Local observation normalization uses the SIMBA residual-network variant.
+  simba: true
   node: 512
-  hidden_n: 3
-  target_update_tau: 5e-3
-  learning_starts: 50000
+  hidden_n: 2
+  reward_normalization: true
+  target_update_tau: 0.01
+  ent_coef: auto_0.005
+  sigma_target: 0.15
+  actor_update_period: 2
   optimizer: adam
 variants:
-  - {algo: SAC, enabled: true}
+  - {algo: TQC, enabled: true}

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -40,7 +40,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         }
 
         self._ent_coef = ent_coef
-        self.ent_coef_learning_rate = 1e-4
+        self.ent_coef_learning_rate = 3e-4
         self.policy_delay = policy_delay
 
         super().__init__(env_builder, model_builder_maker, **crossq_kwargs)

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -32,7 +33,7 @@ from jax_baselines.math.statistics import RewardNormalizer, RunningMeanStd
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
-class Deteministic_Policy_Gradient_Family(object):
+class Deteministic_Policy_Gradient_Family:
     _run_name = "DPG_network"
 
     supports_bulk_training = False
@@ -76,7 +77,10 @@ class Deteministic_Policy_Gradient_Family(object):
         ckpt_baseline_q=None,
         checkpoint_store: CheckpointStore | None = None,
         reward_normalization=False,
+        memory_backend: Literal["auto", "cpu", "gpu"] = "auto",
     ):
+        if memory_backend not in ("auto", "cpu", "gpu"):
+            raise ValueError("memory_backend must be 'auto', 'cpu', or 'gpu'")
         self.env_builder = env_builder
         self.model_builder_maker = model_builder_maker
         self.num_workers = num_workers
@@ -116,19 +120,51 @@ class Deteministic_Policy_Gradient_Family(object):
         self.reward_normalization = bool(reward_normalization)
 
         self.get_env_setup()
-        self.reward_normalizer = (
-            RewardNormalizer(self.worker_size, self.gamma) if self.reward_normalization else None
-        )
+        self._initial_reset = None
+        self.memory_backend: Literal["cpu", "gpu"] = "cpu"
+        self.memory_device = None
+        if memory_backend != "cpu":
+            if self.env_type == "SingleEnv":
+                self._initial_reset = self.env.reset()
+                initial_obs = self._initial_reset[0]
+            else:
+                initial_obs = self.env.current_obs()
+            if all(isinstance(value, jax.Array) for value in initial_obs.values()):
+                devices = set().union(*(value.devices() for value in initial_obs.values()))
+                if len(devices) == 1 and next(iter(devices)).platform == "gpu":
+                    self.memory_device = next(iter(devices))
+            if memory_backend == "gpu" and self.memory_device is None:
+                try:
+                    self.memory_device = jax.devices("gpu")[0]
+                except RuntimeError as error:
+                    raise ValueError("memory_backend='gpu' requires a JAX GPU device") from error
+            if self.memory_device is not None:
+                self.memory_backend = "gpu"
+        print("memory backend : ", self.memory_backend)
+        with jax.default_device(self.memory_device):
+            self.reward_normalizer = (
+                RewardNormalizer(
+                    self.worker_size, self.gamma, on_device=self.memory_backend == "gpu"
+                )
+                if self.reward_normalization
+                else None
+            )
         self.get_memory_setup()
 
         # Control model initialization timing across children
         self._init_setup_model = _init_setup_model
         if self._init_setup_model:
-            self.setup_model()
+            with jax.default_device(self.memory_device):
+                self.setup_model()
 
         self.eval_snapshot = None
         if self.simba:
-            self.obs_rms = RunningMeanStd(shapes=self.observation_space, dtype=np.float64)
+            with jax.default_device(self.memory_device):
+                self.obs_rms = RunningMeanStd(
+                    shapes=self.observation_space,
+                    dtype=np.float64,
+                    on_device=self.memory_backend == "gpu",
+                )
             self.action_obs_rms = None
             self.checkpoint_obs_rms = None
 
@@ -209,32 +245,45 @@ class Deteministic_Policy_Gradient_Family(object):
         )
 
     def _restore_checkpoint_state(self, state: CheckpointState):
-        self.load_checkpoint_params(state.params)
+        self.load_checkpoint_params(
+            jax.device_put(state.params, self.memory_device)
+            if self.memory_backend == "gpu"
+            else state.params
+        )
         self.train_steps_count = int(np.asarray(state.train_steps_count).item())
         self._ckpt_update_residual = float(np.asarray(state.ckpt_residual).item())
         self.ckpt.from_state(state.controller_state)
-        self.eval_snapshot = state.eval_snapshot
+        self.eval_snapshot = (
+            jax.device_put(state.eval_snapshot, self.memory_device)
+            if self.memory_backend == "gpu"
+            else state.eval_snapshot
+        )
 
-        if self.simba:
-            if state.obs_rms_state is not None:
-                self.obs_rms = RunningMeanStd.from_state(state.obs_rms_state)
-            self.action_obs_rms = (
-                RunningMeanStd.from_state(state.action_obs_rms_state)
-                if state.action_obs_rms_state is not None
-                else None
-            )
-            self.checkpoint_obs_rms = (
-                RunningMeanStd.from_state(state.checkpoint_obs_rms_state)
-                if state.checkpoint_obs_rms_state is not None
-                else None
-            )
+        with jax.default_device(self.memory_device):
+            if self.simba:
+                if state.obs_rms_state is not None:
+                    self.obs_rms = RunningMeanStd.from_state(
+                        state.obs_rms_state, on_device=self.memory_backend == "gpu"
+                    )
+                self.action_obs_rms = (
+                    RunningMeanStd.from_state(
+                        state.action_obs_rms_state, on_device=self.memory_backend == "gpu"
+                    )
+                    if state.action_obs_rms_state is not None
+                    else None
+                )
+                self.checkpoint_obs_rms = (
+                    RunningMeanStd.from_state(
+                        state.checkpoint_obs_rms_state, on_device=self.memory_backend == "gpu"
+                    )
+                    if state.checkpoint_obs_rms_state is not None
+                    else None
+                )
 
-        # getattr guards against pre-reward_rms checkpoints, not against self.
-        reward_rms_state = getattr(state, "reward_rms_state", None)
-        if self.reward_normalizer is not None:
-            self.reward_normalizer.reset()
-            if reward_rms_state is not None:
-                self.reward_normalizer.restore(reward_rms_state)
+            if self.reward_normalizer is not None:
+                self.reward_normalizer.reset()
+                if state.reward_rms_state is not None:
+                    self.reward_normalizer.restore(state.reward_rms_state)
 
     def get_env_setup(self):
         # Use common helper to standardize environment info
@@ -246,6 +295,13 @@ class Deteministic_Policy_Gradient_Family(object):
             self.worker_size,
             self.env_type,
         ) = get_local_env_info(self.env_builder, self.num_workers, seed=self.seed)
+        self.autoreset_steps = True
+        if self.env_type == "VectorizedEnv":
+            env_info = self.env.get_info()
+            if "autoreset_steps" in env_info:
+                self.autoreset_steps = env_info["autoreset_steps"]
+                if not isinstance(self.autoreset_steps, bool):
+                    raise TypeError("Environment autoreset_steps must be a bool")
         print("observation size : ", self.observation_space)
         print("action size : ", self.action_size)
         print("worker_size : ", self.worker_size)
@@ -267,6 +323,9 @@ class Deteministic_Policy_Gradient_Family(object):
                 n_step=self.n_step if self.n_step_method else 1,
                 gamma=self.gamma,
                 priority=priority,
+                memory_backend=self.memory_backend,
+                device=self.memory_device,
+                seed=self.seed,
             )
         )
 
@@ -323,7 +382,7 @@ class Deteministic_Policy_Gradient_Family(object):
         if len(reports) == 1:
             return reports[-1]
         counts = jnp.array([report.update_count for report in reports])
-        total = jnp.sum(counts)
+        total = sum(report.update_count for report in reports)
         metrics = {
             name: jnp.sum(jnp.array([report.metrics[name] for report in reports]) * counts) / total
             for name in reports[-1].metrics
@@ -336,7 +395,7 @@ class Deteministic_Policy_Gradient_Family(object):
             loss=jnp.sum(jnp.array([report.loss for report in reports]) * counts) / total,
             target=target,
             metrics=metrics,
-            update_count=int(total),
+            update_count=total,
         )
 
     def get_behavior_state(self):
@@ -360,10 +419,16 @@ class Deteministic_Policy_Gradient_Family(object):
             return self._random_warmup_actions(eval=eval)
         state = self._select_action_state(eval, steps)
         actions = self._policy_action_from_state(state, obs, eval, steps)
+        if self.memory_backend == "cpu":
+            actions = np.asarray(actions)
         return self._apply_action_noise(actions, steps, eval)
 
     def _random_warmup_actions(self, eval=False):
         worker_size = 1 if eval else self.worker_size
+        if self.memory_backend == "gpu":
+            return jax.random.uniform(
+                next(self.key_seq), (worker_size, self.action_size[0]), minval=-1.0, maxval=1.0
+            )
         return np.random.uniform(-1.0, 1.0, size=(worker_size, self.action_size[0]))
 
     def _select_action_state(self, eval, steps):
@@ -373,8 +438,8 @@ class Deteministic_Policy_Gradient_Family(object):
 
     def _policy_action_from_state(self, state, obs, eval, steps):
         if eval:
-            return np.asarray(self._get_eval_actions(state["policy"], obs))
-        return np.asarray(self._get_actions(state["policy"], obs, next(self.key_seq)))
+            return self._get_eval_actions(state["policy"], obs)
+        return self._get_actions(state["policy"], obs, next(self.key_seq))
 
     def _apply_action_noise(self, actions, steps, eval):
         return actions
@@ -405,7 +470,7 @@ class Deteministic_Policy_Gradient_Family(object):
         elif self.simba:
             run_name = "Simba_" + run_name
         if self.n_step_method:
-            run_name = "{}Step_".format(self.n_step) + run_name
+            run_name = f"{self.n_step}Step_" + run_name
         if self.prioritized_replay:
             run_name = run_name + "+PER"
         return run_name
@@ -482,9 +547,10 @@ class Deteministic_Policy_Gradient_Family(object):
 
     def make_rollout_spec(self, ctx):
         self.rollout_tracker = EpisodeTracker(ctx.logger_run.log_metric, ctx.log_interval)
-        train = lambda steps, gradient_steps: self.train_step(  # noqa: E731
-            steps, gradient_steps, ctx.logger_run, ctx.log_interval
-        )
+
+        def train(steps, gradient_steps):
+            return self.train_step(steps, gradient_steps, ctx.logger_run, ctx.log_interval)
+
         pulse = CheckpointTrainPulse(
             train_freq=self.train_freq,
             gradient_steps=self.gradient_steps,
@@ -494,7 +560,7 @@ class Deteministic_Policy_Gradient_Family(object):
             write_residual=self._write_ckpt_residual,
             post_pulse=self._snapshot_action_normalizer,
         )
-        return RolloutSpec(
+        spec = RolloutSpec(
             env=self.env,
             replay_buffer=self.replay_buffer,
             learning_starts=self.learning_starts,
@@ -519,7 +585,12 @@ class Deteministic_Policy_Gradient_Family(object):
             record_transition=(
                 self.reward_normalizer.record if self.reward_normalizer is not None else None
             ),
+            memory_device=self.memory_device,
+            autoreset_steps=self.autoreset_steps,
+            initial_reset=self._initial_reset,
         )
+        self._initial_reset = None
+        return spec
 
     def eval(self, ctx, steps):
         return evaluate_policy(

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -42,7 +42,11 @@ class DDPG(Deteministic_Policy_Gradient_Family):
 
         super().__init__(env_builder, model_builder_maker, **kwargs)
 
-        self.noise = OUNoise(action_size=self.action_size[0], worker_size=self.worker_size)
+        self.noise = OUNoise(
+            action_size=self.action_size[0],
+            worker_size=self.worker_size,
+            key=next(self.key_seq) if self.memory_backend == "gpu" else None,
+        )
 
     def setup_model(self):
         model_builder = self.model_builder_maker(
@@ -97,13 +101,17 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         return description
 
     def _policy_action_from_state(self, state, obs, eval, steps):
-        return np.asarray(self._get_actions(state["policy"], obs, None))
+        return self._get_actions(state["policy"], obs, None)
 
     def _apply_action_noise(self, actions, steps, eval):
         if eval:
             return actions
-        self.epsilon = float(self.exploration(steps))
-        return np.clip(actions + self.noise() * self.epsilon, -1, 1)
+        self.epsilon = self.exploration(steps)
+        if self.memory_backend == "cpu":
+            self.epsilon = float(self.epsilon)
+        return (jnp if self.memory_backend == "gpu" else np).clip(
+            actions + self.noise() * self.epsilon, -1, 1
+        )
 
     def prepare_run(self, total_timesteps):
         self.exploration = optax.linear_schedule(

--- a/jax_baselines/DDPG/ou_noise.py
+++ b/jax_baselines/DDPG/ou_noise.py
@@ -1,17 +1,33 @@
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 
-class OUNoise(object):
-    def __init__(self, sigma=0.2, theta=0.1, action_size=1, worker_size=1):
+@jax.jit(static_argnames=("theta", "sigma"))
+def _device_noise(previous, key, theta, sigma):
+    key, sample_key = jax.random.split(key)
+    return previous - theta * previous + sigma * jax.random.normal(sample_key, previous.shape), key
+
+
+class OUNoise:
+    def __init__(self, sigma=0.2, theta=0.1, action_size=1, worker_size=1, key=None):
         self._theta = theta
         self._sigma = sigma
         self.action_size = action_size
         self.worker_size = worker_size
-        self.noise_prev = np.random.normal(
-            0, self._sigma, size=(self.worker_size, self.action_size)
+        self.key = key
+        self.noise_prev = (
+            sigma * jax.random.normal(key, (worker_size, action_size))
+            if key is not None
+            else np.random.normal(0, self._sigma, size=(self.worker_size, self.action_size))
         )
 
-    def __call__(self) -> np.ndarray:
+    def __call__(self):
+        if self.key is not None:
+            self.noise_prev, self.key = _device_noise(
+                self.noise_prev, self.key, self._theta, self._sigma
+            )
+            return self.noise_prev
         noise = (
             self.noise_prev
             - self._theta * self.noise_prev
@@ -21,6 +37,14 @@ class OUNoise(object):
         return noise
 
     def reset(self, worker) -> None:
+        if self.key is not None:
+            self.key, sample_key = jax.random.split(self.key)
+            self.noise_prev = (
+                jnp.asarray(self.noise_prev)
+                .at[worker]
+                .set(self._sigma * jax.random.normal(sample_key, (len(worker), self.action_size)))
+            )
+            return
         self.noise_prev[worker] = np.random.normal(
             0, self._sigma, size=(len(worker), self.action_size)
         )

--- a/jax_baselines/DDPG/training.py
+++ b/jax_baselines/DDPG/training.py
@@ -8,9 +8,12 @@ in `jax_baselines.core.rollout`.
 
 from dataclasses import dataclass, field
 
+import jax
+
 from jax_baselines.core.bulk_training import (
     bulk_chunk_schedule,
     bulk_train_hook,
+    flatten_priority_values,
     host_priority_values,
     make_train_contexts,
     normalize_bulk_weights,
@@ -136,8 +139,13 @@ class DPGTrainingLifecycle:
 
     def _update_priorities(self, data, report):
         if self.agent.prioritized_replay:
-            indexes = host_priority_values(data["indexes"])
-            priorities = host_priority_values(report.new_priorities)
+            convert = (
+                flatten_priority_values
+                if isinstance(data["indexes"], jax.Array)
+                else host_priority_values
+            )
+            indexes = convert(data["indexes"])
+            priorities = convert(report.new_priorities)
             self.agent.replay_buffer.update_priorities(indexes, priorities)
 
     def _log_report(self, report, steps, logger_run, log_interval):

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -48,7 +48,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
             raise ValueError("actor_update_period must be greater than 0")
 
         self._ent_coef = ent_coef
-        self.ent_coef_learning_rate = 1e-4
+        self.ent_coef_learning_rate = 3e-4
         self.actor_update_period = actor_update_period
 
         super().__init__(env_builder, model_builder_maker, **kwargs)

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -84,11 +84,17 @@ class TD3(Deteministic_Policy_Gradient_Family):
         )
 
     def _policy_action_from_state(self, state, obs, eval, steps):
-        return np.asarray(self._get_actions(state["policy"], obs, None))
+        return self._get_actions(state["policy"], obs, None)
 
     def _apply_action_noise(self, actions, steps, eval):
         if eval:
             return actions
+        if self.memory_backend == "gpu":
+            return jnp.clip(
+                actions + self.action_noise * jax.random.normal(next(self.key_seq), actions.shape),
+                -1,
+                1,
+            )
         return np.clip(
             actions
             + self.action_noise

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -40,7 +40,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
         **kwargs,
     ):
         # Set TD7-specific defaults - always enable checkpointing
-        td7_kwargs = {
+        td7_kwargs: dict[str, Any] = {
             "n_step": 1,
             "target_network_update_tau": 0,
             "prioritized_replay": True,
@@ -132,11 +132,17 @@ class TD7(Deteministic_Policy_Gradient_Family):
         return self.get_behavior_state()
 
     def _policy_action_from_state(self, state, obs, eval, steps):
-        return np.asarray(self._get_actions(state["encoder"], state["policy"], obs, None))
+        return self._get_actions(state["encoder"], state["policy"], obs, None)
 
     def _apply_action_noise(self, actions, steps, eval):
         if eval:
             return actions
+        if self.memory_backend == "gpu":
+            return jnp.clip(
+                actions + self.action_noise * jax.random.normal(next(self.key_seq), actions.shape),
+                -1,
+                1,
+            )
         return np.clip(
             actions
             + self.action_noise
@@ -280,7 +286,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
 
     def _aggregate_train_reports(self, reports):
         counts = jnp.array([report.update_count for report in reports])
-        total = jnp.sum(counts)
+        total = sum(report.update_count for report in reports)
         mean_repr_loss = (
             jnp.sum(jnp.array([report.metrics["loss/encoder_loss"] for report in reports]) * counts)
             / total
@@ -290,7 +296,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
         return DPGTrainReport(
             loss=mean_loss,
             target=mean_target,
-            update_count=int(total),
+            update_count=total,
             metrics={
                 "loss/encoder_loss": mean_repr_loss,
                 "loss/min_value": self.critic_params["values"]["min_value"],
@@ -515,5 +521,5 @@ class TD7(Deteministic_Policy_Gradient_Family):
         if self.simba:
             run_name = "Simba_" + run_name
         if self.n_step_method:
-            run_name = "{}Step_".format(self.n_step) + run_name
+            run_name = f"{self.n_step}Step_" + run_name
         return run_name

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -9,7 +9,15 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, TypeAlias, TypedDict, runtime_checkable
+from typing import (
+    Any,
+    Literal,
+    NotRequired,
+    Protocol,
+    TypeAlias,
+    TypedDict,
+    runtime_checkable,
+)
 
 import jax
 import jax.numpy as jnp
@@ -31,6 +39,7 @@ class EnvInfo(TypedDict):
     env_id: str
     worker_num: int
     core_env_type: str
+    autoreset_steps: NotRequired[bool]
 
 
 @dataclass(frozen=True)

--- a/jax_baselines/core/replay_protocol.py
+++ b/jax_baselines/core/replay_protocol.py
@@ -6,13 +6,29 @@ cpprb-backed implementations directly.
 """
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
+
+import jax
 
 
 @dataclass(frozen=True)
 class PriorityNeed:
     alpha: float
     eps: float
+
+
+class ReplayWriter(Protocol):
+    def add(
+        self,
+        obs_t,
+        action,
+        reward,
+        nxtobs_t,
+        terminated,
+        truncated=False,
+        store_mask=None,
+    ) -> None:
+        ...
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -26,6 +42,9 @@ class LocalReplayNeed:
     priority: PriorityNeed | None = None
     compress_observations: bool = False
     n_frames: int = 4
+    memory_backend: Literal["cpu", "gpu"] = "cpu"
+    device: jax.Device | None = None
+    seed: int = 0
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/jax_baselines/core/rollout.py
+++ b/jax_baselines/core/rollout.py
@@ -22,12 +22,15 @@ family serializes it as part of the checkpoint state.
 """
 
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 
 from jax_baselines.core.env_protocols import (
+    VectorizedEnv,
     batch_observation,
     single_real_episode_end,
     vector_autoreset_mask,
@@ -37,6 +40,8 @@ from jax_baselines.core.eval import (
     extract_original_reward,
     extract_vector_original_rewards,
 )
+from jax_baselines.core.replay_protocol import ReplayWriter
+from jax_baselines.core.rollout_stats import device_episode_step
 
 
 @dataclass(frozen=True)
@@ -70,7 +75,7 @@ class CheckpointTrainPulse:
         record_loss: Callable[[object], None],
         read_residual: Callable[[], int],
         write_residual: Callable[[int], None],
-        post_pulse: Optional[Callable[[], None]] = None,
+        post_pulse: Callable[[], None] | None = None,
     ):
         self._train_freq = train_freq
         self._gradient_steps = gradient_steps
@@ -101,7 +106,7 @@ class RolloutSpec:
     """Narrow contract the :class:`RolloutEngine` needs from a training agent."""
 
     env: object
-    replay_buffer: object
+    replay_buffer: ReplayWriter
     learning_starts: int
     train_freq: int
     gradient_steps: int
@@ -126,6 +131,9 @@ class RolloutSpec:
     checkpoint_monitor_worker: int = 0
     reward_normalization: bool = False
     record_transition: Callable[..., None] | None = None
+    memory_device: jax.Device | None = None
+    autoreset_steps: bool = True
+    initial_reset: tuple | None = None
 
 
 class RolloutEngine:
@@ -141,7 +149,7 @@ class RolloutEngine:
 
     def learn_single_env(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
-        obs, info = spec.env.reset()
+        obs, info = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
         obs = batch_observation(obs)
         lossque = self._begin()
         eval_result = None
@@ -198,6 +206,8 @@ class RolloutEngine:
 
     def learn_vectorized_env(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
+        if spec.memory_device is not None and not spec.autoreset_steps:
+            return self._learn_vectorized_device(pbar, log_interval, checkpointing=False)
         lossque = self._begin()
         eval_result = None
         scores = np.zeros([spec.worker_size], dtype=np.float64)
@@ -275,7 +285,7 @@ class RolloutEngine:
     def learn_single_env_checkpointing(self, pbar, callback=None, log_interval=1000, obs=None):
         spec = self.spec
         if obs is None:
-            obs, info = spec.env.reset()
+            obs, info = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
             obs = batch_observation(obs)
         lossque = self._begin()
         eval_result = None
@@ -343,6 +353,8 @@ class RolloutEngine:
 
     def learn_vectorized_env_checkpointing(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
+        if spec.memory_device is not None and not spec.autoreset_steps:
+            return self._learn_vectorized_device(pbar, log_interval, checkpointing=True)
         lossque = self._begin()
         eval_result = None
 
@@ -461,3 +473,122 @@ class RolloutEngine:
                 pbar.set_description(spec.describe(eval_result))
 
         flush_checkpoint_pulses()
+
+    def _learn_vectorized_device(self, pbar, log_interval, *, checkpointing):
+        """Keep same-step autoreset rollouts resident; copy only episode reports."""
+        spec = self.spec
+        env = spec.env
+        if not isinstance(env, VectorizedEnv):
+            raise TypeError("Device rollouts require a VectorizedEnv")
+        if checkpointing and spec.force_reset is not None:
+            raise ValueError("Device checkpoint rollouts require same-step environment resets")
+        lossque = self._begin()
+        eval_result = None
+        train_residual = 0
+        with jax.default_device(spec.memory_device):
+            zeros = jnp.zeros(spec.worker_size)
+            false = jnp.zeros(spec.worker_size, dtype=bool)
+            true = jnp.ones(spec.worker_size, dtype=bool)
+            state = (zeros, jnp.zeros(spec.worker_size, dtype=jnp.int32), zeros, false, false)
+        completed_steps = []
+        completed_rows = []
+        pending_pulses = deque()
+        pending_evals = deque()
+
+        def flush_checkpoint_pulses():
+            nonlocal eval_result
+            while pending_pulses:
+                spec.checkpoint_pulse(*pending_pulses.popleft())
+            while pending_evals:
+                eval_result = spec.evaluate(pending_evals.popleft())
+
+        def flush_reports():
+            if not completed_rows:
+                return
+            with jax.profiler.TraceAnnotation("rollout.metrics"):
+                rows = np.asarray(jax.device_get(jnp.stack(completed_rows)))
+            for time_idx, worker_idx in np.argwhere(rows[..., 0]):
+                row = rows[time_idx, worker_idx]
+                spec.record_rollout_episode(
+                    completed_steps[time_idx],
+                    episode_reward=float(row[1]),
+                    episode_length=int(row[2]),
+                    timeout=float(row[3]),
+                    original_reward=float(row[4]) if row[5] else None,
+                )
+            completed_steps.clear()
+            completed_rows.clear()
+
+        for steps in pbar:
+            spec.refresh_exploration(steps)
+            obs = env.current_obs()
+            sel = spec.vector_action(obs, steps)
+            env.step(sel.env_action)
+            flush_checkpoint_pulses()
+            next_obs, rewards, terminated, truncated, infos = env.get_result()
+            if spec.reward_normalization and spec.record_transition is not None:
+                spec.record_transition(rewards, jnp.logical_or(terminated, truncated))
+            if isinstance(infos, dict):
+                original = zeros
+                if "original_reward" in infos:
+                    original = infos["original_reward"]
+                present = true if "original_reward" in infos else false
+                if "_original_reward" in infos:
+                    present = infos["_original_reward"]
+            else:
+                original, present = extract_vector_original_rewards(infos, spec.worker_size)
+            state, _, _, completed = device_episode_step(
+                state,
+                rewards,
+                terminated if not checkpointing or steps > spec.learning_starts else false,
+                truncated if not checkpointing or steps > spec.learning_starts else false,
+                vector_real_reset_mask(env, terminated, truncated, infos),
+                false,
+                original,
+                present,
+            )
+            if not checkpointing and steps > spec.learning_starts:
+                train_residual += spec.worker_size
+                update_iters, train_residual = divmod(train_residual, spec.train_freq)
+                if update_iters:
+                    lossque.append(spec.train(steps, update_iters * spec.gradient_steps))
+            spec.replay_buffer.add(obs, sel.store_action, rewards, next_obs, terminated, truncated)
+
+            if checkpointing and steps > spec.learning_starts:
+                # The checkpoint controller changes the policy at episode boundaries.
+                # Only this compact payload must synchronize on every step.
+                rows = np.asarray(jax.device_get(completed))
+                ended = np.flatnonzero(rows[:, 0]).tolist()
+                monitor = spec.checkpoint_monitor_worker
+                for worker in [idx for idx in ended if idx != monitor] + (
+                    [monitor] if monitor in ended else []
+                ):
+                    spec.checkpoint_on_episode_end(
+                        steps,
+                        float(rows[worker, 1]),
+                        int(rows[worker, 2]),
+                        lambda pulse_steps, count: pending_pulses.append((pulse_steps, count)),
+                        advance_criterion=worker == monitor,
+                    )
+                    spec.record_rollout_episode(
+                        steps,
+                        episode_reward=float(rows[worker, 1]),
+                        episode_length=int(rows[worker, 2]),
+                        timeout=float(rows[worker, 3]),
+                        original_reward=float(rows[worker, 4]) if rows[worker, 5] else None,
+                    )
+            if not checkpointing:
+                completed_steps.append(steps)
+                completed_rows.append(completed)
+            if steps % spec.eval_freq == 0:
+                flush_reports()
+                if pending_pulses:
+                    pending_evals.append(steps)
+                else:
+                    eval_result = spec.evaluate(steps)
+            if steps % log_interval == 0:
+                flush_reports()
+                if eval_result is not None and lossque:
+                    pbar.set_description(spec.describe(eval_result))
+        flush_checkpoint_pulses()
+        flush_reports()

--- a/jax_baselines/math/statistics.py
+++ b/jax_baselines/math/statistics.py
@@ -193,6 +193,30 @@ class RunningMeanStd:
         return instance
 
 
+@jax.jit(static_argnames=("gamma",))
+def _record_device_returns(returns, means, variances, count, rewards, dones, active, gamma):
+    returns = jnp.where(active, gamma * returns + rewards, returns)
+    batch_count = jnp.sum(active)
+    batch_mean = jnp.sum(jnp.where(active, returns, 0)) / jnp.maximum(batch_count, 1)
+    batch_var = jnp.sum(jnp.where(active, jnp.square(returns - batch_mean), 0)) / jnp.maximum(
+        batch_count, 1
+    )
+    total = count + batch_count
+    delta = batch_mean - means["return"]
+    mean = means["return"] + delta * batch_count / total
+    variance = (
+        variances["return"] * count
+        + batch_var * batch_count
+        + jnp.square(delta) * count * batch_count / total
+    ) / total
+    return jnp.where(active & dones, 0, returns), {"return": mean}, {"return": variance}, total
+
+
+@jax.jit
+def _normalize_device_rewards(rewards, variance):
+    return rewards / jnp.sqrt(variance + 1e-8)
+
+
 class RewardNormalizer:
     """Scales rewards by the running std of the discounted return (Engstrom et al. 2020).
 
@@ -202,17 +226,19 @@ class RewardNormalizer:
     ``std(G)``), effectively bounding Q-values for fixed-support critics (XQC).
     """
 
-    def __init__(self, worker_size: int, gamma: float):
+    def __init__(self, worker_size: int, gamma: float, *, on_device: bool = False):
         self.gamma = float(gamma)
-        self.rms = RunningMeanStd(shapes={"return": ()}, dtype=np.float64)
-        self.discounted_returns = np.zeros(int(worker_size), dtype=np.float64)
+        self.rms = RunningMeanStd(shapes={"return": ()}, dtype=np.float64, on_device=on_device)
+        self.discounted_returns = (jnp if on_device else np).zeros(
+            int(worker_size), dtype=self.rms.dtype
+        )
+        self._all_active = (jnp if on_device else np).ones(int(worker_size), dtype=bool)
 
     def record(self, rewards, dones, active=None):
-        rewards = np.atleast_1d(np.asarray(rewards, dtype=np.float64))
-        dones = np.atleast_1d(np.asarray(dones, dtype=bool))
-        active = (
-            np.ones(rewards.shape, dtype=bool) if active is None else np.asarray(active, dtype=bool)
-        )
+        array_module = jnp if self.rms.on_device else np
+        rewards = array_module.atleast_1d(array_module.asarray(rewards, dtype=self.rms.dtype))
+        dones = array_module.atleast_1d(array_module.asarray(dones, dtype=bool))
+        active = self._all_active if active is None else array_module.asarray(active, dtype=bool)
         expected_shape = self.discounted_returns.shape
         if rewards.shape != expected_shape or dones.shape != expected_shape:
             raise ValueError(
@@ -224,6 +250,23 @@ class RewardNormalizer:
                 "active must match the configured worker shape "
                 f"{expected_shape}, got {active.shape}"
             )
+        if self.rms.on_device:
+            (
+                self.discounted_returns,
+                self.rms.means,
+                self.rms.vars,
+                self.rms.count,
+            ) = _record_device_returns(
+                self.discounted_returns,
+                self.rms.means,
+                self.rms.vars,
+                self.rms.count,
+                rewards,
+                dones,
+                active,
+                self.gamma,
+            )
+            return
         if not np.any(active):
             return
 
@@ -236,9 +279,13 @@ class RewardNormalizer:
     @property
     def scale(self):
         """Current reward divisor: std of the recorded discounted returns."""
+        if self.rms.on_device:
+            return jnp.sqrt(self.rms.vars["return"] + 1e-8)
         return float(np.sqrt(self.rms.vars["return"] + 1e-8))
 
     def normalize(self, rewards):
+        if self.rms.on_device:
+            return _normalize_device_rewards(rewards, self.rms.vars["return"])
         rewards = np.asarray(rewards)
         dtype = np.result_type(rewards.dtype, np.float32)
         return (rewards / self.scale).astype(dtype, copy=False)
@@ -247,8 +294,11 @@ class RewardNormalizer:
         return self.rms.to_state()
 
     def reset(self):
-        self.discounted_returns.fill(0.0)
+        if self.rms.on_device:
+            self.discounted_returns = jnp.zeros_like(self.discounted_returns)
+        else:
+            self.discounted_returns = np.zeros(self.discounted_returns.shape, dtype=self.rms.dtype)
 
     def restore(self, state):
-        self.rms = RunningMeanStd.from_state(state)
+        self.rms = RunningMeanStd.from_state(state, on_device=self.rms.on_device)
         self.reset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "chex",
     "cpprb",
     "dm_pix",
+    "flashbax>=0.1.3,<0.2",
     "flax",
     "gymnasium",
     "jax",

--- a/replay_memory/flashbax_buffer.py
+++ b/replay_memory/flashbax_buffer.py
@@ -1,0 +1,284 @@
+"""Device-resident replay with Flashbax storage, sampling and priority trees."""
+
+from math import prod
+
+import flashbax
+import jax
+import jax.numpy as jnp
+from flashbax.buffers import prioritised_trajectory_buffer, sum_tree, trajectory_buffer
+
+from jax_baselines.core.replay_protocol import LocalReplayNeed
+
+
+class FlashbaxReplayBuffer:
+    def __init__(self, need: LocalReplayNeed):
+        if need.buffer_size < 1 or need.worker_size < 1 or need.n_step < 1:
+            raise ValueError("buffer_size, worker_size and n_step must be positive")
+        if not isinstance(need.observation_space, dict) or not need.observation_space:
+            raise ValueError("observation_space must be a non-empty dict")
+        if not 0 <= need.gamma <= 1:
+            raise ValueError("gamma must be between zero and one")
+        if need.priority is not None and (
+            not 0 <= need.priority.alpha <= 1 or need.priority.eps < 0
+        ):
+            raise ValueError("priority alpha must be in [0, 1] and eps must be nonnegative")
+        if need.device is None:
+            try:
+                self.device = jax.devices("gpu")[0]
+            except (RuntimeError, IndexError) as error:
+                raise RuntimeError("GPU replay requires an available JAX GPU device") from error
+        else:
+            self.device = need.device
+        self.max_size = need.buffer_size
+        self.worker_size = need.worker_size
+        self.n_step = need.n_step
+        self.gamma = need.gamma
+        self.priority = need.priority
+        self.observation_space = need.observation_space
+        self.action_shape = (
+            (need.action_shape_or_n,)
+            if isinstance(need.action_shape_or_n, int)
+            else tuple(need.action_shape_or_n)
+        )
+        self.seed = need.seed
+        if self.priority is None:
+            self.buffer = flashbax.make_item_buffer(
+                max_length=self.max_size, min_length=1, sample_batch_size=1, add_batches=True
+            )
+        else:
+            self.buffer = flashbax.make_prioritised_trajectory_buffer(
+                add_batch_size=1,
+                sample_batch_size=1,
+                sample_sequence_length=1,
+                period=1,
+                min_length_time_axis=1,
+                max_length_time_axis=self.max_size,
+                priority_exponent=self.priority.alpha,
+                device=self.device.platform,
+            )
+        self._add_compiled = jax.jit(self._add, donate_argnums=(0, 1))
+        self._sample_compiled = jax.jit(self._sample, static_argnums=(2, 3))
+        self._update_compiled = jax.jit(self._update_priorities, donate_argnums=(0,))
+        self.clear()
+
+    def clear(self):
+        with jax.default_device(self.device):
+            example = {
+                "obses": {
+                    key: jnp.zeros(shape, dtype=jnp.uint8 if len(shape) >= 3 else jnp.float32)
+                    for key, shape in self.observation_space.items()
+                },
+                "actions": jnp.zeros(self.action_shape, dtype=jnp.float32),
+                "rewards": jnp.zeros((1,), dtype=jnp.float32),
+                "nxtobses": {
+                    key: jnp.zeros(shape, dtype=jnp.uint8 if len(shape) >= 3 else jnp.float32)
+                    for key, shape in self.observation_space.items()
+                },
+                "terminateds": jnp.zeros((1,), dtype=jnp.float32),
+            }
+            self.state = jax.jit(self.buffer.init)(example)
+            self._pending = (
+                jax.tree.map(
+                    lambda value: jnp.zeros(
+                        (self.worker_size, self.n_step, *value.shape), dtype=value.dtype
+                    ),
+                    {key: example[key] for key in ("obses", "actions", "rewards")},
+                ),
+                jnp.zeros(self.worker_size, dtype=jnp.int32),
+            )
+            self._key = jax.random.PRNGKey(self.seed)
+            self._all_active = jnp.ones(self.worker_size, dtype=bool)
+            self._not_truncated = jnp.zeros(self.worker_size, dtype=bool)
+        self._sample_ready = False
+
+    def __len__(self):
+        """Explicit host query; add/sample never poll the device's write pointer."""
+        return int(jnp.where(self.state.is_full, self.max_size, self.state.current_index))
+
+    def add(self, obs_t, action, reward, nxtobs_t, terminated, truncated=False, store_mask=None):
+        if (
+            not isinstance(obs_t, dict)
+            or not isinstance(nxtobs_t, dict)
+            or obs_t.keys() != self.observation_space.keys()
+            or nxtobs_t.keys() != obs_t.keys()
+        ):
+            raise ValueError("Observation keys must match observation_space")
+
+        # Placement happens at this boundary; JAX inputs already on this device stay there.
+        def array(value, shape, dtype):
+            result = (
+                value
+                if isinstance(value, jax.Array)
+                and value.dtype == dtype
+                and value.devices() == {self.device}
+                else jnp.asarray(value, dtype=dtype, device=self.device)
+            )
+            if result.size != prod(shape):
+                raise ValueError(f"Replay input shape {result.shape} does not match {shape}")
+            return result if result.shape == shape else result.reshape(shape)
+
+        batch = {
+            "obses": {
+                key: array(
+                    obs_t[key],
+                    (self.worker_size, *shape),
+                    jnp.uint8 if len(shape) >= 3 else jnp.float32,
+                )
+                for key, shape in self.observation_space.items()
+            },
+            "actions": array(action, (self.worker_size, *self.action_shape), jnp.float32),
+            "rewards": array(reward, (self.worker_size, 1), jnp.float32),
+            "nxtobses": {
+                key: array(
+                    nxtobs_t[key],
+                    (self.worker_size, *shape),
+                    jnp.uint8 if len(shape) >= 3 else jnp.float32,
+                )
+                for key, shape in self.observation_space.items()
+            },
+            "terminateds": array(terminated, (self.worker_size, 1), jnp.float32),
+        }
+        mask = (
+            self._all_active if store_mask is None else array(store_mask, (self.worker_size,), bool)
+        )
+        truncations = (
+            self._not_truncated
+            if truncated is False
+            else array(truncated, (self.worker_size,), bool)
+        )
+        self.state, self._pending = self._add_compiled(
+            self.state, self._pending, batch, truncations, mask
+        )
+
+    def _add(self, state, pending, batch, truncated, active):
+        if self.n_step == 1:
+            return self._append(state, batch, active), pending
+        staged, lengths = pending
+        workers = jnp.arange(self.worker_size)
+        staged = jax.tree.map(
+            lambda history, value: history.at[workers, lengths].set(value),
+            staged,
+            {key: batch[key] for key in ("obses", "actions", "rewards")},
+        )
+        lengths = lengths + active
+        boundary = (batch["terminateds"].reshape(-1).astype(bool) | truncated) & active
+        positions = jnp.arange(self.n_step)
+        ready = (
+            active[:, None]
+            & (positions < lengths[:, None])
+            & (boundary[:, None] | ((lengths == self.n_step)[:, None] & (positions == 0)))
+        )
+        distances = positions[None, :] - positions[:, None]
+        discounts = jnp.where(distances >= 0, self.gamma ** jnp.maximum(distances, 0), 0)
+        rewards = jnp.einsum(
+            "st,wtk->wsk",
+            discounts,
+            staged["rewards"] * (positions < lengths[:, None])[..., None],
+        )
+        items = {
+            **staged,
+            "rewards": rewards,
+            "nxtobses": jax.tree.map(
+                lambda value: jnp.broadcast_to(
+                    value[:, None], (self.worker_size, self.n_step, *value.shape[1:])
+                ),
+                batch["nxtobses"],
+            ),
+            "terminateds": jnp.broadcast_to(
+                batch["terminateds"][:, None], (self.worker_size, self.n_step, 1)
+            ),
+        }
+        state = self._append(
+            state,
+            jax.tree.map(lambda value: value.reshape((-1, *value.shape[2:])), items),
+            ready.reshape(-1),
+        )
+        shift = (lengths == self.n_step) & active & ~boundary
+        staged = jax.tree.map(
+            lambda value: jnp.where(
+                shift.reshape((self.worker_size,) + (1,) * (value.ndim - 1)),
+                jnp.roll(value, -1, axis=1),
+                value,
+            ),
+            staged,
+        )
+        return state, (staged, jnp.where(boundary, 0, lengths - shift))
+
+    def _append(self, state, batch, valid):
+        # Flashbax's native add has a static length. Compact masked workers and
+        # flushed episode tails without copying a variable item count to the CPU.
+        ranks = jnp.cumsum(valid, dtype=jnp.int32) - 1
+        count = jnp.sum(valid, dtype=jnp.int32)
+        keep = valid & (ranks >= count - self.max_size)
+        indexes = jnp.where(keep, (state.current_index + ranks) % self.max_size, self.max_size)
+        experience = jax.tree.map(
+            lambda storage, values: storage.at[0, indexes].set(values, mode="drop"),
+            state.experience,
+            batch,
+        )
+        if self.priority is not None:
+            tree = state.sum_tree_state
+            state = state.replace(
+                sum_tree_state=sum_tree.set_batch_bincount(
+                    tree,
+                    jnp.where(keep, indexes, tree.nodes.size + 1),
+                    jnp.where(keep, tree.max_recorded_priority, 0),
+                ),
+                running_index=state.running_index + count,
+            )
+        return state.replace(
+            experience=experience,
+            current_index=(state.current_index + count) % self.max_size,
+            is_full=state.is_full | (state.current_index + count >= self.max_size),
+        )
+
+    def sample(self, batch_size: int, beta=0.4):
+        if batch_size < 1 or not 0 <= beta <= 1:
+            raise ValueError("batch_size must be positive and beta must be in [0, 1]")
+        if not self._sample_ready:
+            if len(self) == 0:
+                raise ValueError("Cannot sample from empty replay")
+            self._sample_ready = True
+        self._key, batch = self._sample_compiled(self.state, self._key, batch_size, beta)
+        return batch
+
+    def _sample(self, state, key, batch_size, beta):
+        key, sample_key = jax.random.split(key)
+        if self.priority is None:
+            sample = trajectory_buffer.sample(state, sample_key, batch_size, 1, 1)
+            return key, jax.tree.map(lambda value: value[:, 0], sample.experience)
+        sample = prioritised_trajectory_buffer.prioritised_sample(
+            state, sample_key, batch_size, 1, 1
+        )
+        batch = jax.tree.map(lambda value: value[:, 0], sample.experience)
+        # ponytail: O(capacity) minimum preserves cpprb's global IS normalization;
+        # use a min tree if prioritized replay profiling makes this significant.
+        leaves = state.sum_tree_state.nodes[2**state.sum_tree_state.tree_depth - 1 :][
+            : self.max_size
+        ]
+        minimum = jnp.min(jnp.where(leaves > 0, leaves, jnp.inf))
+        sampled_priorities = sum_tree.get_batch(state.sum_tree_state, sample.indices)
+        return key, {
+            **batch,
+            "weights": (minimum / sampled_priorities) ** beta,
+            "indexes": sample.indices,
+        }
+
+    def update_priorities(self, indexes, priorities):
+        if self.priority is None:
+            raise ValueError("Priority updates require prioritized replay")
+        indexes = jnp.asarray(indexes, dtype=jnp.int32, device=self.device).reshape(-1)
+        priorities = jnp.asarray(priorities, dtype=jnp.float32, device=self.device).reshape(-1)
+        if indexes.shape != priorities.shape or not indexes.size:
+            raise ValueError("Priority indexes and values must have matching non-empty shapes")
+        self.state = self._update_compiled(self.state, indexes, priorities)
+
+    def _update_priorities(self, state, indexes, priorities):
+        assert self.priority is not None
+        return prioritised_trajectory_buffer.set_priorities(
+            state,
+            indexes,
+            jnp.abs(priorities) + self.priority.eps,
+            self.priority.alpha,
+            self.device.platform,
+        )

--- a/replay_memory/replay_factory.py
+++ b/replay_memory/replay_factory.py
@@ -70,6 +70,19 @@ def make_replay_buffer(need: LocalReplayNeed):
     - For n_step only -> NstepReplayBuffer
     - Otherwise -> ReplayBuffer
     """
+    if need.memory_backend not in ("cpu", "gpu"):
+        raise ValueError("Replay memory_backend must be resolved to 'cpu' or 'gpu'")
+    if need.memory_backend == "gpu":
+        if isinstance(need, SelfPredictionReplayNeed):
+            raise ValueError("GPU replay does not support self-prediction sequences")
+        if need.compress_observations:
+            raise ValueError("GPU replay does not support frame-stack compression")
+        if need.device is not None and need.device.platform != "gpu":
+            raise ValueError("GPU replay requires a GPU storage device")
+        from replay_memory.flashbax_buffer import FlashbaxReplayBuffer
+
+        return FlashbaxReplayBuffer(need)
+
     buffer_size = need.buffer_size
     observation_space = need.observation_space
     action_shape_or_n = need.action_shape_or_n

--- a/tests/test_checkpoint_state.py
+++ b/tests/test_checkpoint_state.py
@@ -150,6 +150,8 @@ def test_checkpoint_round_trip(cls):
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = cls.__new__(cls)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.simba = False
         dst.reward_normalizer = None
@@ -194,6 +196,8 @@ def test_simba_obs_rms_round_trip():
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = DDPG.__new__(DDPG)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.simba = True
         dst.reward_normalizer = None
@@ -227,6 +231,8 @@ def test_dpg_reward_normalizer_statistics_round_trip_without_partial_returns():
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = DDPG.__new__(DDPG)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.ckpt = _scaffold()
         dst.simba = False
@@ -296,6 +302,8 @@ def test_dpg_checkpoint_without_reward_stats_clears_partial_discounted_returns()
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = DDPG.__new__(DDPG)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.ckpt = _scaffold()
         dst.simba = False

--- a/tests/test_dpg_training.py
+++ b/tests/test_dpg_training.py
@@ -204,10 +204,10 @@ def test_dpg_training_lifecycle_logs_reward_scale():
     assert ("rollout/reward_scale", 2.0, 10) in agent.logger_run.metrics
 
 
-def test_dpg_priority_update_materializes_jax_values_on_host():
+def test_dpg_priority_update_materializes_device_priorities_for_host_indexes():
     agent = FakeAgent()
     lifecycle = DPGTrainingLifecycle(agent)
-    data = {"indexes": jnp.arange(4).reshape(2, 2)}
+    data = {"indexes": np.arange(4).reshape(2, 2)}
     report = DPGTrainReport(
         loss=1.0,
         new_priorities=jnp.arange(4, dtype=jnp.float32).reshape(2, 2),

--- a/tests/test_replay_factory_injection.py
+++ b/tests/test_replay_factory_injection.py
@@ -85,6 +85,9 @@ def test_q_network_family_uses_injected_replay_factory():
 
 def test_dpg_family_uses_injected_replay_factory():
     agent = Deteministic_Policy_Gradient_Family.__new__(Deteministic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
+    agent.memory_device = None
+    agent.seed = 42
     fake_buffer = object()
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
@@ -111,6 +114,7 @@ def test_dpg_family_uses_injected_replay_factory():
             n_step=2,
             gamma=0.95,
             priority=None,
+            seed=42,
         )
     ]
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -939,6 +939,7 @@ class _ShapeCheckingEvalEnv:
 
 def _dpg_action_agent():
     agent = Deteministic_Policy_Gradient_Family.__new__(Deteministic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
     agent.simba = True
     agent.use_checkpointing = True
     agent.ckpt = type("Ckpt", (), {"enabled": True})()
@@ -978,6 +979,7 @@ def test_dpg_eval_actions_use_checkpoint_normalizer():
 
 def test_dpg_eval_skips_random_warmup_and_uses_policy_action():
     agent = Deteministic_Policy_Gradient_Family.__new__(Deteministic_Policy_Gradient_Family)
+    agent.memory_backend = "cpu"
     agent.simba = False
     agent.learning_starts = 100
     agent.worker_size = 32
@@ -995,6 +997,7 @@ def test_dpg_eval_skips_random_warmup_and_uses_policy_action():
 
 def test_td3_test_action_uses_eval_action_shape_with_many_workers():
     agent = TD3.__new__(TD3)
+    agent.memory_backend = "cpu"
     agent.simba = False
     agent.learning_starts = 0
     agent.worker_size = 32

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -30,6 +30,7 @@ def test_action_sampling_and_mode_are_explicitly_separate():
 
 def test_dpg_eval_path_uses_sac_mode_without_sampling():
     agent = object.__new__(SAC)
+    agent.memory_backend = "cpu"
     agent.simba = False
     agent.learning_starts = 100
     agent.use_checkpointing = False

--- a/uv.lock
+++ b/uv.lock
@@ -802,7 +802,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
@@ -840,43 +840,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -902,7 +902,7 @@ name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
@@ -1082,10 +1082,10 @@ name = "fabric"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator" },
-    { name = "deprecated" },
-    { name = "invoke" },
-    { name = "paramiko" },
+    { name = "decorator", marker = "python_full_version < '3.14'" },
+    { name = "deprecated", marker = "python_full_version < '3.14'" },
+    { name = "invoke", marker = "python_full_version < '3.14'" },
+    { name = "paramiko", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/7e/29cd6237c3b7ce79c3ca945eb99ab5affd101db54b2f7a78dde0cfa19fd4/fabric-3.2.3.tar.gz", hash = "sha256:dcbd2c47ad87688facaef5cc11aab6d1ec9ed05645fed97a5de7204d5d17cc44", size = 183497, upload-time = "2026-04-06T00:00:11.481Z" }
 wheels = [
@@ -1127,6 +1127,24 @@ wheels = [
 ]
 
 [[package]]
+name = "flashbax"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chex" },
+    { name = "flax" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+    { name = "tensorstore" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/a2/fddfe1f119b964b45d1e9ac557d3e921f393e4369417d0a98803163c705b/flashbax-0.1.3.tar.gz", hash = "sha256:3792972973169d455188451dd3f93a0ab37004bb122bb256a323927daaca9a3e", size = 56444, upload-time = "2025-03-27T09:50:45.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/f2/3ec1ebf403bd1593c44a0e42dbd0935a03bffb090259a3e88699d210a9f0/flashbax-0.1.3-py3-none-any.whl", hash = "sha256:798b0056dd0f525269ad9689a402dd0a515db7cb6976c761aa95004ff37e9697", size = 82386, upload-time = "2025-03-27T09:50:44.004Z" },
+]
+
+[[package]]
 name = "flax"
 version = "0.12.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1137,8 +1155,8 @@ dependencies = [
     { name = "optax" },
     { name = "orbax-checkpoint" },
     { name = "pyyaml" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-13-jax-baselines-mjlab'" },
-    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
     { name = "tensorstore" },
     { name = "treescope" },
     { name = "typing-extensions" },
@@ -1495,7 +1513,7 @@ name = "importlib-metadata"
 version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
 wheels = [
@@ -1525,17 +1543,17 @@ name = "ipython"
 version = "9.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.14'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.14'" },
+    { name = "jedi", marker = "python_full_version < '3.14'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.14'" },
+    { name = "pexpect", marker = "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.14'" },
+    { name = "psutil", marker = "python_full_version < '3.14' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version < '3.14'" },
+    { name = "stack-data", marker = "python_full_version < '3.14'" },
+    { name = "traitlets", marker = "python_full_version < '3.14'" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
@@ -1548,7 +1566,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1585,6 +1603,7 @@ dependencies = [
     { name = "chex" },
     { name = "cpprb" },
     { name = "dm-pix" },
+    { name = "flashbax" },
     { name = "flax" },
     { name = "gymnasium" },
     { name = "jax" },
@@ -1677,6 +1696,7 @@ requires-dist = [
     { name = "dm-pix" },
     { name = "envpool", marker = "extra == 'all'" },
     { name = "envpool", marker = "extra == 'envpool'" },
+    { name = "flashbax", specifier = ">=0.1.3,<0.2" },
     { name = "flax" },
     { name = "gymnasium" },
     { name = "gymnasium", extras = ["atari"], marker = "extra == 'atari'" },
@@ -1799,7 +1819,7 @@ name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -2149,7 +2169,7 @@ name = "matplotlib-inline"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "traitlets" },
+    { name = "traitlets", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
@@ -2170,10 +2190,10 @@ name = "mediapy"
 version = "1.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipython" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "ipython", marker = "python_full_version < '3.14'" },
+    { name = "matplotlib", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/99/8b59dbcebf7e84b35e86c893f52fdc2953299d66ef1fcbacca26162818b0/mediapy-1.2.7.tar.gz", hash = "sha256:fd3826ca156f9165cd369f44d4d345d5609df1da3caf867df7ce304e19dd7fde", size = 28660, upload-time = "2026-07-01T13:14:43.448Z" }
 wheels = [
@@ -2185,26 +2205,26 @@ name = "mjlab"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "imageio-ffmpeg" },
-    { name = "mediapy" },
-    { name = "mjviser" },
-    { name = "mujoco" },
-    { name = "mujoco-warp" },
-    { name = "numpy" },
-    { name = "onnxscript" },
-    { name = "prettytable" },
-    { name = "rsl-rl-lib" },
-    { name = "scipy" },
-    { name = "tensorboard" },
-    { name = "tensordict" },
-    { name = "torch" },
-    { name = "torchrunx" },
-    { name = "tqdm" },
-    { name = "trimesh" },
-    { name = "tyro" },
-    { name = "viser" },
-    { name = "wandb" },
-    { name = "warp-lang" },
+    { name = "imageio-ffmpeg", marker = "python_full_version < '3.14'" },
+    { name = "mediapy", marker = "python_full_version < '3.14'" },
+    { name = "mjviser", marker = "python_full_version < '3.14'" },
+    { name = "mujoco", marker = "python_full_version < '3.14'" },
+    { name = "mujoco-warp", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "onnxscript", marker = "python_full_version < '3.14'" },
+    { name = "prettytable", marker = "python_full_version < '3.14'" },
+    { name = "rsl-rl-lib", marker = "python_full_version < '3.14'" },
+    { name = "scipy", marker = "python_full_version < '3.14'" },
+    { name = "tensorboard", marker = "python_full_version < '3.14'" },
+    { name = "tensordict", marker = "python_full_version < '3.14'" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
+    { name = "torchrunx", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "trimesh", marker = "python_full_version < '3.14'" },
+    { name = "tyro", marker = "python_full_version < '3.14'" },
+    { name = "viser", marker = "python_full_version < '3.14'" },
+    { name = "wandb", marker = "python_full_version < '3.14'" },
+    { name = "warp-lang", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/0a/6679b04d90f66a714b1da45b7d9e1fbc9926b15708df237a043db109375e/mjlab-1.6.0.tar.gz", hash = "sha256:d2938936037a591f26f2fc16ba0ba32c579ab1077abda0bf1eed9b0d2a415703", size = 14116570, upload-time = "2026-08-09T00:23:43.159Z" }
 wheels = [
@@ -2216,11 +2236,11 @@ name = "mjviser"
 version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mujoco" },
-    { name = "numpy" },
-    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "trimesh" },
-    { name = "viser" },
+    { name = "mujoco", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "trimesh", marker = "python_full_version < '3.14'" },
+    { name = "viser", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/eef89b279fb1811b5f120a99ac9284c32ff2ca4fad5e6f5c93035f72ba9a/mjviser-0.0.14.tar.gz", hash = "sha256:ebde2203dab89959a13ae549b4d3e5e5cf9eb69de11a1a2fd759cbe8f8c641f3", size = 29576, upload-time = "2026-05-07T03:35:13.128Z" }
 wheels = [
@@ -2436,11 +2456,11 @@ name = "mujoco-warp"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py" },
-    { name = "etils", extra = ["epath"], marker = "extra == 'extra-13-jax-baselines-mjlab'" },
-    { name = "mujoco" },
-    { name = "numpy" },
-    { name = "warp-lang" },
+    { name = "absl-py", marker = "python_full_version < '3.14'" },
+    { name = "etils", extra = ["epath"], marker = "(python_full_version < '3.14' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "mujoco", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "warp-lang", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/02/da883029b3661619651d0e2469ec17df92dd64ca5de25119886d516ee1de/mujoco_warp-3.11.0.tar.gz", hash = "sha256:e9e521a3809b95baa98c44bd4fcaccb035b5c700e2616efc52ebc33d29ae2eef", size = 2075418, upload-time = "2026-07-28T01:21:41.987Z" }
 wheels = [
@@ -2558,7 +2578,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2571,7 +2591,7 @@ name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
@@ -2664,7 +2684,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.22.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/ff/c6a098c1e0bccc68aac5f1684526cf8936abb7024dcc46dca315b8a6f47f/nvidia_cudnn_cu12-9.22.0.52-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:cd9011812498376f866b9826331cc965ac922eb2df8549c9f2989f10255e5001", size = 774536507, upload-time = "2026-05-08T15:36:09.067Z" },
@@ -2677,7 +2697,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.24.0.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/30/7c257e3d5cb4fecb147b93895c66e29c93f8e76d74b45bb418ff0587c4ec/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a6812a554a1ff0413e9c52b84c26c050380649ab9615f9c16bded368ce9f421f", size = 650976863, upload-time = "2026-07-02T16:23:39.248Z" },
@@ -2690,7 +2710,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2703,7 +2723,7 @@ name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
@@ -2735,9 +2755,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2750,9 +2770,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
@@ -2765,7 +2785,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2778,7 +2798,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
@@ -2839,7 +2859,7 @@ name = "nvidia-nvshmem-cu12"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-cccl-cu12" },
+    { name = "nvidia-cuda-cccl-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'win32' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform == 'emscripten' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other') or (sys_platform == 'win32' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-other')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/da/bd8ae5201f8c5751ece31fe4fe489ece10fbcf5fcc1a595855b6459b6d6e/nvidia_nvshmem_cu12-3.6.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7b38521ff84cdfc68da3360fe249cfbabfe05ee9aa271458857476124b03a420", size = 153109548, upload-time = "2026-03-24T19:19:19.523Z" },
@@ -2870,10 +2890,10 @@ name = "onnx"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", hash = "sha256:aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473", size = 11949859, upload-time = "2025-08-27T02:34:27.107Z" }
 wheels = [
@@ -2907,11 +2927,11 @@ name = "onnx-ir"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy" },
-    { name = "onnx" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "onnx", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/c2/61194cec0dbc5622273c0ebd592d37cc1dca0d7f1a744f02edd45ac905a3/onnx_ir-1.0.0.tar.gz", hash = "sha256:9e261f25fde8da9612ae5cb43b3b374d5ff469c04af0363cad588b2bb000b812", size = 163121, upload-time = "2026-08-11T14:49:46.895Z" }
 wheels = [
@@ -2923,12 +2943,12 @@ name = "onnxscript"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy" },
-    { name = "onnx" },
-    { name = "onnx-ir" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "onnx", marker = "python_full_version < '3.14'" },
+    { name = "onnx-ir", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/3a/4d79bce3f460e0df7fed54a92ce80827f25da66511da368bb00783ad8d20/onnxscript-0.7.1.tar.gz", hash = "sha256:309fb86484b11fa4ded90dba580e0d63f1a0827588e521cecaf2eeddb46d6e86", size = 618160, upload-time = "2026-06-29T23:33:21.526Z" }
 wheels = [
@@ -3229,10 +3249,10 @@ name = "paramiko"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bcrypt" },
-    { name = "cryptography" },
-    { name = "invoke" },
-    { name = "pynacl" },
+    { name = "bcrypt", marker = "python_full_version < '3.14'" },
+    { name = "cryptography", marker = "python_full_version < '3.14'" },
+    { name = "invoke", marker = "python_full_version < '3.14'" },
+    { name = "pynacl", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
 wheels = [
@@ -3253,7 +3273,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3488,7 +3508,7 @@ name = "prettytable"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/88/ef38a6e4bc375600d3031e405a8d3b3dc4a154fccffd21d5d06e66c96230/prettytable-3.3.0.tar.gz", hash = "sha256:118eb54fd2794049b810893653b20952349df6d3bc1764e7facd8a18064fa9b0", size = 54305, upload-time = "2022-05-05T15:21:40.5Z" }
 wheels = [
@@ -3521,7 +3541,7 @@ name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
@@ -3769,7 +3789,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -4014,14 +4034,13 @@ name = "rich"
 version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "extra == 'extra-13-jax-baselines-mjlab'" },
-    { name = "pygments", marker = "extra == 'extra-13-jax-baselines-mjlab'" },
+    { name = "markdown-it-py", marker = "(python_full_version < '3.14' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "pygments", marker = "(python_full_version < '3.14' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
@@ -4033,6 +4052,7 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.14' and extra != 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab' and extra != 'extra-13-jax-baselines-other'",
     "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other'",
@@ -4075,8 +4095,8 @@ resolution-markers = [
     "python_full_version < '3.12' and extra != 'extra-13-jax-baselines-all' and extra != 'extra-13-jax-baselines-mjlab' and extra != 'extra-13-jax-baselines-other'",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
-    { name = "pygments", marker = "extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "markdown-it-py", marker = "python_full_version >= '3.14' or extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "pygments", marker = "python_full_version >= '3.14' or extra == 'extra-13-jax-baselines-all' or extra != 'extra-13-jax-baselines-mjlab' or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -4196,14 +4216,14 @@ name = "rsl-rl-lib"
 version = "5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gitpython" },
-    { name = "numpy" },
-    { name = "onnx" },
-    { name = "onnxscript" },
-    { name = "tensorboard" },
-    { name = "tensordict" },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "gitpython", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "onnx", marker = "python_full_version < '3.14'" },
+    { name = "onnxscript", marker = "python_full_version < '3.14'" },
+    { name = "tensorboard", marker = "python_full_version < '3.14'" },
+    { name = "tensordict", marker = "python_full_version < '3.14'" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
+    { name = "torchvision", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/a6/11460213f75318253ae20d792802faa0c3cfe2b49e29ec785e590cd81eaa/rsl_rl_lib-5.4.2.tar.gz", hash = "sha256:688e881db7f7af06d12e5498fd6f0c41b0e2f858dc0667f5fd68219c86b9667d", size = 66011, upload-time = "2026-07-15T09:45:34.847Z" }
 wheels = [
@@ -4464,9 +4484,9 @@ name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
+    { name = "asttokens", marker = "python_full_version < '3.14'" },
+    { name = "executing", marker = "python_full_version < '3.14'" },
+    { name = "pure-eval", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
@@ -4516,7 +4536,7 @@ name = "sympy"
 version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/8a/5a7fd6284fa8caac23a26c9ddf9c30485a48169344b4bd3b0f02fef1890f/sympy-1.13.3.tar.gz", hash = "sha256:b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9", size = 7533196, upload-time = "2024-09-18T21:54:25.591Z" }
 wheels = [
@@ -4582,13 +4602,13 @@ name = "tensordict"
 version = "0.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle" },
-    { name = "importlib-metadata" },
-    { name = "numpy" },
+    { name = "cloudpickle", marker = "python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
     { name = "orjson", marker = "python_full_version < '3.13'" },
-    { name = "packaging" },
-    { name = "pyvers" },
-    { name = "torch" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyvers", marker = "python_full_version < '3.14'" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/5867ad5e9587e8d240d50cc4d9f1fb53aeb125800b2fc872f7b120fa2419/tensordict-0.14.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10304477b61ca7a977871ba2eb431911db57c1184ec2e9aaa4aba0d596077306", size = 945209, upload-time = "2026-09-05T11:54:28.318Z" },
@@ -4663,20 +4683,20 @@ name = "torch"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-13-jax-baselines-mjlab') or (python_full_version >= '3.14' and extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (python_full_version >= '3.14' and extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other') or (sys_platform != 'linux' and extra == 'extra-13-jax-baselines-all' and extra == 'extra-13-jax-baselines-mjlab') or (sys_platform != 'linux' and extra == 'extra-13-jax-baselines-mjlab' and extra == 'extra-13-jax-baselines-other')" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "networkx", marker = "python_full_version < '3.14'" },
+    { name = "nvidia-cudnn-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "triton", marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/2c/0c9757a1ea1fff8ccc4faff1d1c87e98a69542b5d4b606e50f7518f72e58/torch-2.14.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ae530ddd3f3b94248b77f1fd3313c4f3405bd0d17283d505b81574816767133a", size = 127277244, upload-time = "2026-09-02T13:42:57.855Z" },
@@ -4706,10 +4726,10 @@ name = "torchrunx"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle" },
-    { name = "fabric" },
-    { name = "numpy" },
-    { name = "torch" },
+    { name = "cloudpickle", marker = "python_full_version < '3.14'" },
+    { name = "fabric", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/80/b760a13db3e41fc2645911c30717cef05f1b200367d98f979226802ab10e/torchrunx-0.4.0.tar.gz", hash = "sha256:adcdbfd82ef633e549ba6e7694bc6eb258f55a6a64c8c59776794b922ae7b3ff", size = 41553, upload-time = "2026-08-04T07:55:09.264Z" }
 wheels = [
@@ -4721,9 +4741,9 @@ name = "torchvision"
 version = "0.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "pillow", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "torch", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/47/6b32740f7ae0ecf8772297f7e61e842b127b11de5c2c07efd9aeeaed0690/torchvision-0.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:bbe15455b59a6c9d822584fd3faaaac50ee972101d7bb7e2887da456e148a3ea", size = 1813735, upload-time = "2026-09-02T13:46:58.108Z" },
@@ -4786,7 +4806,7 @@ name = "trimesh"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
 wheels = [
@@ -4815,7 +4835,7 @@ name = "typeguard"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/de/4420db493fa8fc0856d5e5c1b159c63a323d2de2317babe36b01568928e8/typeguard-4.6.0.tar.gz", hash = "sha256:e7414f09111317de3e335de92cd397c5c0ca00b1cc1676de12e1d444a79b3f21", size = 82330, upload-time = "2026-07-26T08:40:23.207Z" }
 wheels = [
@@ -4857,9 +4877,9 @@ name = "tyro"
 version = "1.0.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docstring-parser" },
-    { name = "typeguard" },
-    { name = "typing-extensions" },
+    { name = "docstring-parser", marker = "python_full_version < '3.14'" },
+    { name = "typeguard", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/83/4008dff806dc894fc0422017316982d3f14709046bcb0dfa720cb64501aa/tyro-1.0.16.tar.gz", hash = "sha256:edf23c9c3eecba5a2b5af152df8f34a723b689a001ff5b7311f93eff1893a636", size = 603382, upload-time = "2026-08-23T01:19:26.643Z" }
 wheels = [
@@ -4955,16 +4975,16 @@ name = "viser"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "imageio" },
-    { name = "msgspec" },
-    { name = "numpy" },
-    { name = "requests" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
-    { name = "trimesh" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-    { name = "zstandard" },
+    { name = "imageio", marker = "python_full_version < '3.14'" },
+    { name = "msgspec", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "trimesh", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/4d/e3d9bb3cb71a3f5de21b9f35fb4db09c6f873885c02e9d9ace20d221aae1/viser-1.1.0.tar.gz", hash = "sha256:28c27da73f391fdc7a1ffc3e3d122fd8eede9d15508128bc53c7e02904169412", size = 5310056, upload-time = "2026-08-16T21:15:10.628Z" }
 wheels = [
@@ -5005,7 +5025,7 @@ name = "warp-lang"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/a2/712bcea055b80135e20a7a142f5dc1fa617bf3b5557dd4cc3afcc1048ab4/warp_lang-1.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ee06e2e76bff84088a09e64315e71ed0e55e94c936ec664d7b05ebd56f66a363", size = 25048790, upload-time = "2026-07-07T22:26:18.532Z" },


### PR DESCRIPTION
mjlab의 JAX GPU 관측을 처리하면서 DPG의 행동 선택·리플레이·통계 계산에서 발생하던 호스트 변환을 줄입니다. `--memory_backend auto|cpu|gpu`를 추가하고, `auto`는 GPU 관측에 Flashbax 리플레이를 선택합니다. CPU 저장은 기존 cpprb 경로를 사용합니다.

- Flashbax 어댑터에 일반·우선순위 리플레이, n-step 전이, 워커 마스크 및 에피소드 종료 처리를 추가합니다. 코어는 주입된 리플레이 프로토콜을 사용합니다.
- 같은 스텝에서 자동 초기화하는 mjlab 롤아웃에 디바이스 처리 경로를 추가하고, DPG 탐색 노이즈·정규화·우선순위 갱신·체크포인트 복원에서 GPU 배열을 유지합니다.
- Go1 실험 기본값을 TQC, 워커 1,024개, 벡터 스텝당 업데이트 2회, 3-step 리플레이로 조정하고 GPU 관측과 학습 환경 재사용 평가를 활성화합니다. SAC·CrossQ의 엔트로피 계수 학습률은 3e-4로 변경합니다.

검증: 관련 CPU 테스트 112개 통과, 최종 수정 후 rollout 테스트 35개 재확인 통과. Go1 설정 CLI dry-run과 커밋 훅도 통과했습니다.

남은 진단: 변경 파일 대상 Ruff 검사 12건과 ty 타입 진단 86건이 남아 있습니다. GPU 실제 학습·수렴·성능은 검증하지 않았습니다.
