### PR TITLE
feat: DQN·SPR 계열에 memory_backend 지원

### DIFF
--- a/experiments/cli/qnet.py
+++ b/experiments/cli/qnet.py
@@ -33,6 +33,12 @@ def add_args(parser):
     parser.add_argument("--target_update", type=int, default=2000, help="target update intervals")
     parser.add_argument("--batch", type=int, default=64, help="batch size")
     parser.add_argument("--buffer_size", type=float, default=200000, help="buffer_size")
+    parser.add_argument(
+        "--memory_backend",
+        choices=("auto", "cpu", "gpu"),
+        default="auto",
+        help="replay storage device; auto follows environment observations",
+    )
     parser.add_argument("--double", action="store_true")
     parser.add_argument("--dueling", action="store_true")
     parser.add_argument("--per", action="store_true")
@@ -111,6 +117,7 @@ def _common(a):
         "learning_rate": a.learning_rate,
         "batch_size": a.batch,
         "buffer_size": int(a.buffer_size),
+        "memory_backend": a.memory_backend,
         "target_network_update_freq": a.target_update,
         "prioritized_replay": a.per,
         "double_q": a.double,
@@ -191,6 +198,7 @@ ALGOS = {
             "learning_rate": a.learning_rate,
             "batch_size": a.batch,
             "buffer_size": int(a.buffer_size),
+            "memory_backend": a.memory_backend,
             "off_policy_fix": a.off_policy_fix,
             "scaled_by_reset": a.scaled_by_reset,
             "munchausen": a.munchausen,
@@ -219,6 +227,7 @@ ALGOS = {
             "learning_rate": a.learning_rate,
             "batch_size": a.batch,
             "buffer_size": int(a.buffer_size),
+            "memory_backend": a.memory_backend,
             "exploration_final_eps": a.final_eps,
             "param_noise": a.noisynet,
             "off_policy_fix": a.off_policy_fix,

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Literal
 
@@ -19,6 +20,7 @@ from jax_baselines.core.replay_protocol import (
     PriorityNeed,
     ReplayBufferFactory,
     require_replay_factory,
+    select_replay_device,
 )
 from jax_baselines.core.rollout import (
     ActionSelection,
@@ -40,7 +42,7 @@ class Deteministic_Policy_Gradient_Family:
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         num_workers=1,
         eval_eps=20,
@@ -129,15 +131,7 @@ class Deteministic_Policy_Gradient_Family:
                 initial_obs = self._initial_reset[0]
             else:
                 initial_obs = self.env.current_obs()
-            if all(isinstance(value, jax.Array) for value in initial_obs.values()):
-                devices = set().union(*(value.devices() for value in initial_obs.values()))
-                if len(devices) == 1 and next(iter(devices)).platform == "gpu":
-                    self.memory_device = next(iter(devices))
-            if memory_backend == "gpu" and self.memory_device is None:
-                try:
-                    self.memory_device = jax.devices("gpu")[0]
-                except RuntimeError as error:
-                    raise ValueError("memory_backend='gpu' requires a JAX GPU device") from error
+            self.memory_device = select_replay_device(initial_obs, required=memory_backend == "gpu")
             if self.memory_device is not None:
                 self.memory_backend = "gpu"
         print("memory backend : ", self.memory_backend)

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -16,6 +19,7 @@ from jax_baselines.core.replay_protocol import (
     PriorityNeed,
     ReplayBufferFactory,
     require_replay_factory,
+    select_replay_device,
 )
 from jax_baselines.core.rollout import (
     ActionSelection,
@@ -36,12 +40,13 @@ from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 class Q_Network_Family:
     _run_name = "Q_network"
+    _get_actions: Callable[..., jax.Array]
 
     supports_bulk_training = False
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         num_workers=1,
         eval_eps=20,
@@ -83,7 +88,10 @@ class Q_Network_Family:
         ckpt_baseline_q=None,
         checkpoint_store: CheckpointStore | None = None,
         reward_normalization=False,
+        memory_backend: Literal["auto", "cpu", "gpu"] = "auto",
     ):
+        if memory_backend not in ("auto", "cpu", "gpu"):
+            raise ValueError("memory_backend must be 'auto', 'cpu', or 'gpu'")
         self.env_builder = env_builder
         self.model_builder_maker = model_builder_maker
         self.num_workers = num_workers
@@ -135,9 +143,27 @@ class Q_Network_Family:
         self.reward_normalization = bool(reward_normalization)
 
         self.get_env_setup()
-        self.reward_normalizer = (
-            RewardNormalizer(self.worker_size, self.gamma) if self.reward_normalization else None
-        )
+        self._initial_reset = None
+        self.memory_backend: Literal["cpu", "gpu"] = "cpu"
+        self.memory_device = None
+        if memory_backend != "cpu":
+            if self.env_type == "SingleEnv":
+                self._initial_reset = self.env.reset()
+                initial_obs = self._initial_reset[0]
+            else:
+                initial_obs = self.env.current_obs()
+            self.memory_device = select_replay_device(initial_obs, required=memory_backend == "gpu")
+            if self.memory_device is not None:
+                self.memory_backend = "gpu"
+        print("memory backend : ", self.memory_backend)
+        with jax.default_device(self.memory_device):
+            self.reward_normalizer = (
+                RewardNormalizer(
+                    self.worker_size, self.gamma, on_device=self.memory_backend == "gpu"
+                )
+                if self.reward_normalization
+                else None
+            )
         self.get_memory_setup()
 
         # Generic checkpointing scaffolding (used by algorithms that opt-in)
@@ -168,7 +194,8 @@ class Q_Network_Family:
         self._init_setup_model = _init_setup_model
         if self._init_setup_model:
             # Calls overridden setup_model in children
-            self.setup_model()
+            with jax.default_device(self.memory_device):
+                self.setup_model()
 
     def save_params(self, path):
         if self.reward_normalizer is None:
@@ -184,14 +211,16 @@ class Q_Network_Family:
 
     def load_params(self, path):
         state = self.checkpoint_store.restore(path)
-        if self.reward_normalizer is not None:
-            self.reward_normalizer.reset()
-        if isinstance(state, QNetCheckpointState):
-            self.params = self.target_params = state.params
-            if self.reward_normalizer is not None and state.reward_rms_state is not None:
-                self.reward_normalizer.restore(state.reward_rms_state)
-            return
-        self.params = self.target_params = state
+        with jax.default_device(self.memory_device):
+            if self.reward_normalizer is not None:
+                self.reward_normalizer.reset()
+            if isinstance(state, QNetCheckpointState):
+                if self.reward_normalizer is not None and state.reward_rms_state is not None:
+                    self.reward_normalizer.restore(state.reward_rms_state)
+                state = state.params
+            self.params = self.target_params = (
+                jax.device_put(state, self.memory_device) if self.memory_backend == "gpu" else state
+            )
 
     def get_env_setup(self):
         (
@@ -202,6 +231,13 @@ class Q_Network_Family:
             self.worker_size,
             self.env_type,
         ) = get_local_env_info(self.env_builder, self.num_workers, seed=self.seed)
+        self.autoreset_steps = True
+        if self.env_type == "VectorizedEnv":
+            env_info = self.env.get_info()
+            if "autoreset_steps" in env_info:
+                self.autoreset_steps = env_info["autoreset_steps"]
+                if not isinstance(self.autoreset_steps, bool):
+                    raise TypeError("Environment autoreset_steps must be a bool")
         print("observation size : ", self.observation_space)
         print("action size : ", self.action_size)
         print("worker_size : ", self.worker_size)
@@ -224,6 +260,9 @@ class Q_Network_Family:
                 gamma=self.gamma,
                 priority=priority,
                 compress_observations=self.compress_memory,
+                memory_backend=self.memory_backend,
+                device=self.memory_device,
+                seed=self.seed,
             )
         )
 
@@ -298,7 +337,7 @@ class Q_Network_Family:
         if len(reports) == 1:
             return reports[-1]
         counts = jnp.array([report.update_count for report in reports])
-        total = jnp.sum(counts)
+        total = sum(report.update_count for report in reports)
         metrics = {
             name: jnp.sum(jnp.array([report.metrics[name] for report in reports]) * counts) / total
             for name in reports[-1].metrics
@@ -322,11 +361,8 @@ class Q_Network_Family:
             target=target,
             metrics=metrics,
             histograms=histograms,
-            update_count=int(total),
+            update_count=total,
         )
-
-    def _get_actions(self, params, obses) -> np.ndarray:
-        raise NotImplementedError
 
     def _compile_common_functions(self):
         """Common JIT compilation for Q-Network family algorithms."""
@@ -356,17 +392,27 @@ class Q_Network_Family:
     def _random_actions(self, shape=None):
         if shape is None:
             shape = (self.worker_size, 1)
+        if self.memory_backend == "gpu":
+            with jax.default_device(self.memory_device):
+                return jax.random.randint(next(self.key_seq), shape, 0, self.action_size[0])
         return np.random.choice(self.action_size[0], shape)
 
     def _epsilon_greedy_actions(self, greedy_actions, epsilon):
-        greedy_actions = np.asarray(greedy_actions)
+        if self.memory_backend == "cpu":
+            greedy_actions = np.asarray(greedy_actions)
         if epsilon <= 0:
             return greedy_actions
         random_actions = self._random_actions(greedy_actions.shape)
         if epsilon >= 1:
             return random_actions
-        random_mask = np.random.uniform(size=greedy_actions.shape) < epsilon
-        return np.where(random_mask, random_actions, greedy_actions)
+        random_mask = (
+            jax.random.uniform(next(self.key_seq), greedy_actions.shape)
+            if self.memory_backend == "gpu"
+            else np.random.uniform(size=greedy_actions.shape)
+        ) < epsilon
+        return (jnp if self.memory_backend == "gpu" else np).where(
+            random_mask, random_actions, greedy_actions
+        )
 
     def actions(self, obs, epsilon, eval_mode=False):
         # Select params: during eval with checkpointing prefer snapshot
@@ -427,7 +473,7 @@ class Q_Network_Family:
             if self.double_q:
                 run_name = "Double_" + run_name
             if self.n_step_method:
-                run_name = "{}Step_".format(self.n_step) + run_name
+                run_name = f"{self.n_step}Step_" + run_name
             if self.prioritized_replay:
                 run_name = run_name + "+PER"
         return run_name
@@ -483,7 +529,7 @@ class Q_Network_Family:
 
     def _single_action_selection(self, obs, steps):
         actions = self.actions(obs, self.update_eps)
-        return ActionSelection(env_action=actions[0][0], store_action=actions[0])
+        return ActionSelection(env_action=actions[0][0].item(), store_action=actions[0])
 
     def _vector_action_selection(self, obs, steps):
         actions = self.actions(obs, self.update_eps)
@@ -492,20 +538,24 @@ class Q_Network_Family:
     def _refresh_exploration(self, steps):
         self.update_eps = float(self.exploration(steps))
 
+    def _write_ckpt_residual(self, value):
+        self._ckpt_update_residual = value
+
     def make_rollout_spec(self, ctx):
         self.rollout_tracker = EpisodeTracker(ctx.logger_run.log_metric, ctx.log_interval)
-        train = lambda steps, gradient_steps: self.train_step(  # noqa: E731
-            steps, gradient_steps, ctx.logger_run, ctx.log_interval
-        )
+
+        def train(steps, gradient_steps):
+            return self.train_step(steps, gradient_steps, ctx.logger_run, ctx.log_interval)
+
         pulse = CheckpointTrainPulse(
             train_freq=self.train_freq,
             gradient_steps=self.gradient_steps,
             train=train,
             record_loss=lambda loss: self.lossque.append(loss),
             read_residual=lambda: self._ckpt_update_residual,
-            write_residual=lambda value: setattr(self, "_ckpt_update_residual", value),
+            write_residual=self._write_ckpt_residual,
         )
-        return RolloutSpec(
+        spec = RolloutSpec(
             env=self.env,
             replay_buffer=self.replay_buffer,
             learning_starts=self.learning_starts,
@@ -530,7 +580,12 @@ class Q_Network_Family:
             record_transition=(
                 self.reward_normalizer.record if self.reward_normalizer is not None else None
             ),
+            memory_device=self.memory_device,
+            autoreset_steps=self.autoreset_steps,
+            initial_reset=self._initial_reset,
         )
+        self._initial_reset = None
+        return spec
 
     def eval(self, ctx, steps):
         return evaluate_policy(

--- a/jax_baselines/DQN/training.py
+++ b/jax_baselines/DQN/training.py
@@ -9,9 +9,12 @@ tuple returns and translate them into a lifecycle result on the Python side via
 
 from dataclasses import dataclass, field
 
+import jax
+
 from jax_baselines.core.bulk_training import (
     bulk_chunk_schedule,
     bulk_train_hook,
+    flatten_priority_values,
     host_priority_values,
     make_train_contexts,
     normalize_bulk_weights,
@@ -184,8 +187,13 @@ class QNetTrainingLifecycle:
                 "when prioritized_replay is enabled"
             )
 
-        indexes = host_priority_values(data["indexes"])
-        priorities = host_priority_values(result.replay_priorities)
+        convert = (
+            flatten_priority_values
+            if isinstance(data["indexes"], jax.Array)
+            else host_priority_values
+        )
+        indexes = convert(data["indexes"])
+        priorities = convert(result.replay_priorities)
         self.agent.replay_buffer.update_priorities(indexes, priorities)
 
     def _log_report(self, report, steps, logger_run, log_interval):

--- a/jax_baselines/SPR/spr.py
+++ b/jax_baselines/SPR/spr.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
@@ -35,7 +38,7 @@ class SPR(Q_Network_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         off_policy_fix=False,
         spr_weight=5.0,
@@ -57,7 +60,7 @@ class SPR(Q_Network_Family):
         self.categorial_min = float(categorial_min)
 
         # Set SPR-specific defaults
-        spr_kwargs = {
+        spr_kwargs: dict[str, Any] = {
             "exploration_fraction": 0,
             "exploration_final_eps": 0,
             "exploration_initial_eps": 0,
@@ -93,6 +96,9 @@ class SPR(Q_Network_Family):
                 priority=priority,
                 compress_observations=self.compress_memory,
                 prediction_depth=max(self.prediction_depth, self.n_step),
+                memory_backend=self.memory_backend,
+                device=self.memory_device,
+                seed=self.seed,
             )
         )
 

--- a/jax_baselines/core/replay_protocol.py
+++ b/jax_baselines/core/replay_protocol.py
@@ -10,6 +10,28 @@ from typing import Any, Literal, Protocol
 
 import jax
 
+from jax_baselines.core.env_protocols import Observation
+
+
+def select_replay_device(observations: Observation, *, required: bool) -> jax.Device | None:
+    """Follow a single GPU observation device, or require an available GPU."""
+    devices: set[jax.Device] = set()
+    for value in observations.values():
+        if not isinstance(value, jax.Array):
+            devices.clear()
+            break
+        devices.update(value.devices())
+    if len(devices) == 1:
+        device = devices.pop()
+        if device.platform == "gpu":
+            return device
+    if not required:
+        return None
+    try:
+        return jax.devices("gpu")[0]
+    except (RuntimeError, IndexError) as error:
+        raise ValueError("memory_backend='gpu' requires a JAX GPU device") from error
+
 
 @dataclass(frozen=True)
 class PriorityNeed:

--- a/replay_memory/flashbax_buffer.py
+++ b/replay_memory/flashbax_buffer.py
@@ -7,7 +7,7 @@ import jax
 import jax.numpy as jnp
 from flashbax.buffers import prioritised_trajectory_buffer, sum_tree, trajectory_buffer
 
-from jax_baselines.core.replay_protocol import LocalReplayNeed
+from jax_baselines.core.replay_protocol import LocalReplayNeed, SelfPredictionReplayNeed
 
 
 class FlashbaxReplayBuffer:
@@ -31,7 +31,10 @@ class FlashbaxReplayBuffer:
             self.device = need.device
         self.max_size = need.buffer_size
         self.worker_size = need.worker_size
-        self.n_step = need.n_step
+        self.prediction_depth = (
+            need.prediction_depth if isinstance(need, SelfPredictionReplayNeed) else None
+        )
+        self.n_step = need.n_step if self.prediction_depth is None else 1
         self.gamma = need.gamma
         self.priority = need.priority
         self.observation_space = need.observation_space
@@ -76,6 +79,9 @@ class FlashbaxReplayBuffer:
                 },
                 "terminateds": jnp.zeros((1,), dtype=jnp.float32),
             }
+            if self.prediction_depth is not None:
+                example["sequence_index"] = jnp.zeros((), dtype=jnp.int32)
+                example["episode_ends"] = jnp.zeros((), dtype=bool)
             self.state = jax.jit(self.buffer.init)(example)
             self._pending = (
                 jax.tree.map(
@@ -151,6 +157,12 @@ class FlashbaxReplayBuffer:
         )
 
     def _add(self, state, pending, batch, truncated, active):
+        if self.prediction_depth is not None:
+            batch = {
+                **batch,
+                "sequence_index": state.current_index.reshape((1,)),
+                "episode_ends": batch["terminateds"].reshape(-1).astype(bool) | truncated,
+            }
         if self.n_step == 1:
             return self._append(state, batch, active), pending
         staged, lengths = pending
@@ -246,22 +258,61 @@ class FlashbaxReplayBuffer:
         key, sample_key = jax.random.split(key)
         if self.priority is None:
             sample = trajectory_buffer.sample(state, sample_key, batch_size, 1, 1)
-            return key, jax.tree.map(lambda value: value[:, 0], sample.experience)
+            batch = jax.tree.map(lambda value: value[:, 0], sample.experience)
+            if self.prediction_depth is not None:
+                batch = self._sample_sequence(state, batch)
+            return key, batch
         sample = prioritised_trajectory_buffer.prioritised_sample(
             state, sample_key, batch_size, 1, 1
         )
         batch = jax.tree.map(lambda value: value[:, 0], sample.experience)
-        # ponytail: O(capacity) minimum preserves cpprb's global IS normalization;
-        # use a min tree if prioritized replay profiling makes this significant.
-        leaves = state.sum_tree_state.nodes[2**state.sum_tree_state.tree_depth - 1 :][
-            : self.max_size
-        ]
-        minimum = jnp.min(jnp.where(leaves > 0, leaves, jnp.inf))
         sampled_priorities = sum_tree.get_batch(state.sum_tree_state, sample.indices)
+        if self.prediction_depth is not None:
+            batch = self._sample_sequence(state, batch)
+            minimum = jnp.min(sampled_priorities)
+        else:
+            # ponytail: O(capacity) minimum preserves cpprb's global IS normalization;
+            # use a min tree if prioritized replay profiling makes this significant.
+            leaves = state.sum_tree_state.nodes[2**state.sum_tree_state.tree_depth - 1 :][
+                : self.max_size
+            ]
+            minimum = jnp.min(jnp.where(leaves > 0, leaves, jnp.inf))
         return key, {
             **batch,
             "weights": (minimum / sampled_priorities) ** beta,
             "indexes": sample.indices,
+        }
+
+    def _sample_sequence(self, state, starts):
+        assert self.prediction_depth is not None
+        offsets = jnp.arange(self.prediction_depth)
+        indexes = (starts["sequence_index"][:, None] + offsets) % self.max_size
+        episode_ends = state.experience["episode_ends"][0, indexes]
+        available = jnp.where(
+            state.is_full,
+            (state.current_index - starts["sequence_index"] - 1) % self.max_size + 1,
+            state.current_index - starts["sequence_index"],
+        )
+        filled = (offsets < available[:, None]) & (
+            jnp.cumsum(episode_ends, axis=1) - episode_ends == 0
+        )
+        # Repeat the final valid transition for padding; never expose a reset or
+        # overwritten row as a future observation, including truncation bootstrap.
+        indexes = (
+            starts["sequence_index"][:, None]
+            + jnp.minimum(offsets, jnp.sum(filled, axis=1)[:, None] - 1)
+        ) % self.max_size
+        batch = jax.tree.map(lambda value: value[0, indexes], state.experience)
+        return {
+            "obses": jax.tree.map(
+                lambda obs, next_obs: jnp.concatenate((obs[:, :1], next_obs), axis=1),
+                batch["obses"],
+                batch["nxtobses"],
+            ),
+            "actions": batch["actions"],
+            "rewards": batch["rewards"][..., 0],
+            "terminateds": batch["terminateds"][..., 0].astype(bool),
+            "filled": filled,
         }
 
     def update_priorities(self, indexes, priorities):

--- a/replay_memory/replay_factory.py
+++ b/replay_memory/replay_factory.py
@@ -43,6 +43,8 @@ def _frame_compress_applicable(observation_space, worker_size, n_step, n_frames)
 
 
 def _validate_self_prediction_replay_need(need: SelfPredictionReplayNeed) -> None:
+    if need.prediction_depth < 1:
+        raise ValueError("SelfPredictionReplayNeed prediction_depth must be positive")
     unsupported = []
     if need.compress_observations:
         unsupported.append("compress_observations=True")
@@ -72,9 +74,9 @@ def make_replay_buffer(need: LocalReplayNeed):
     """
     if need.memory_backend not in ("cpu", "gpu"):
         raise ValueError("Replay memory_backend must be resolved to 'cpu' or 'gpu'")
+    if isinstance(need, SelfPredictionReplayNeed):
+        _validate_self_prediction_replay_need(need)
     if need.memory_backend == "gpu":
-        if isinstance(need, SelfPredictionReplayNeed):
-            raise ValueError("GPU replay does not support self-prediction sequences")
         if need.compress_observations:
             raise ValueError("GPU replay does not support frame-stack compression")
         if need.device is not None and need.device.platform != "gpu":
@@ -96,7 +98,6 @@ def make_replay_buffer(need: LocalReplayNeed):
     n_frames = need.n_frames
 
     if isinstance(need, SelfPredictionReplayNeed):
-        _validate_self_prediction_replay_need(need)
         if prioritized:
             return PrioritizedTransitionReplayBuffer(
                 buffer_size,

--- a/tests/test_checkpoint_state.py
+++ b/tests/test_checkpoint_state.py
@@ -256,6 +256,8 @@ def test_qnet_reward_normalizer_statistics_round_trip_without_partial_returns():
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = Q_Network_Family.__new__(Q_Network_Family)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.reward_normalizer = RewardNormalizer(worker_size=3, gamma=0.99)
         dst.load_params(d)
@@ -275,6 +277,8 @@ def test_qnet_legacy_checkpoint_clears_partial_discounted_returns():
     with tempfile.TemporaryDirectory() as d:
         src.save_params(d)
         dst = Q_Network_Family.__new__(Q_Network_Family)
+        dst.memory_backend = "cpu"
+        dst.memory_device = None
         dst.checkpoint_store = FileCheckpointStore()
         dst.reward_normalizer = RewardNormalizer(worker_size=2, gamma=0.99)
         dst.reward_normalizer.record(

--- a/tests/test_optimizer_factory_injection.py
+++ b/tests/test_optimizer_factory_injection.py
@@ -84,6 +84,7 @@ def test_q_network_constructor_uses_injected_optimizer_factory(monkeypatch):
         optimizer_factory=factory,
         learning_rate=0.125,
         _init_setup_model=False,
+        memory_backend="cpu",
     )
 
     assert agent.optimizer is optimizer

--- a/tests/test_qnet_eval_mode.py
+++ b/tests/test_qnet_eval_mode.py
@@ -41,6 +41,7 @@ class _ActorStub:
         self.key_seq = iter(range(1000))
         self.action_size = [3]
         self.worker_size = 1
+        self.memory_backend = "cpu"
         self.used_params = []
 
     def get_behavior_params(self):

--- a/tests/test_qnet_training.py
+++ b/tests/test_qnet_training.py
@@ -168,10 +168,10 @@ def test_qnet_training_lifecycle_logs_reward_scale():
     assert ("rollout/reward_scale", 2.0, 10) in agent.logger_run.metrics
 
 
-def test_qnet_priority_update_materializes_jax_values_on_host():
+def test_qnet_priority_update_materializes_device_priorities_for_host_indexes():
     agent = FakeAgent()
     lifecycle = QNetTrainingLifecycle(agent)
-    data = {"indexes": jnp.arange(4).reshape(2, 2)}
+    data = {"indexes": np.arange(4).reshape(2, 2)}
     result = QNetTrainResult.from_values(
         loss=1.0,
         replay_priorities=jnp.arange(4, dtype=jnp.float32).reshape(2, 2),

--- a/tests/test_replay_factory_injection.py
+++ b/tests/test_replay_factory_injection.py
@@ -52,6 +52,9 @@ class FakeWorkerReplayFactory:
 
 def test_q_network_family_uses_injected_replay_factory():
     agent = Q_Network_Family.__new__(Q_Network_Family)
+    agent.memory_backend = "cpu"
+    agent.memory_device = None
+    agent.seed = 42
     fake_buffer = object()
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
@@ -79,6 +82,7 @@ def test_q_network_family_uses_injected_replay_factory():
             gamma=0.9,
             priority=PriorityNeed(alpha=0.7, eps=0.01),
             compress_observations=True,
+            seed=42,
         )
     ]
 
@@ -292,6 +296,9 @@ def test_spr_uses_injected_transition_replay_factory():
     from jax_baselines.SPR.spr import SPR
 
     agent = SPR.__new__(SPR)
+    agent.memory_backend = "cpu"
+    agent.memory_device = None
+    agent.seed = 42
     fake_buffer = object()
     factory = FakeLocalReplayFactory(fake_buffer)
     agent.replay_factory = factory
@@ -321,6 +328,7 @@ def test_spr_uses_injected_transition_replay_factory():
             priority=PriorityNeed(alpha=0.6, eps=0.01),
             compress_observations=False,
             prediction_depth=5,
+            seed=42,
         )
     ]
 


### PR DESCRIPTION
DQN·SPR·BBF를 포함한 QNet 계열에서 `--memory_backend auto|cpu|gpu`로 replay 저장 장치를 선택할 수 있습니다. 기존 DPG GPU replay를 재사용하고 SPR 시퀀스 샘플링·PER를 GPU 경로에 연결했습니다.

`auto`는 관측이 단일 GPU에 있을 때 GPU replay를 선택하며, 명시적 `gpu`는 GPU가 없으면 오류를 냅니다. GPU replay의 프레임 압축 미지원과 SPR의 단일 worker 제약은 유지합니다. DPG와 QNet이 같은 장치 선택 함수를 사용하도록 공통 계약도 정리했습니다.

검증: 실제 GPU DQN·SPR 업데이트에서 파라미터 변화와 PER 갱신 확인, GPU 통합 검사 13개·CPU 검사 12개·관련 테스트 237개 통과. 저장소 훅 통과, 신규 타입 진단 없음.

스택 1/2: 기준 브랜치는 `main`입니다. 후속 PR #33은 이 브랜치를 기준으로 공통 CPU↔GPU 전환 최적화만 포함합니다. 이 PR을 먼저 검토·병합합니다.
