### PR TITLE
perf: 학습 경로의 CPU↔GPU 전환 최소화

### DIFF
--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -242,13 +242,15 @@ class MjlabSingleEnv(SingleEnv):
         action = (jnp if self._vector.jax_arrays else np).asarray(action)
         self._vector.step(action[None])
         observation, reward, terminated, truncated, info = self._vector.get_result()
-        if terminated[0] or truncated[0]:
+        reward, terminated, truncated = jax.device_get((reward[0], terminated[0], truncated[0]))
+        terminated, truncated = bool(terminated), bool(truncated)
+        if terminated or truncated:
             self._cached_reset = self._current()
         return (
             {key: value[0] for key, value in observation.items()},
-            float(reward[0]),
-            bool(terminated[0]),
-            bool(truncated[0]),
+            float(reward),
+            terminated,
+            truncated,
             info,
         )
 

--- a/experiments/checkpoint_store.py
+++ b/experiments/checkpoint_store.py
@@ -9,7 +9,7 @@ class FileCheckpointStore:
     def save(self, path, state):
         os.makedirs(path, exist_ok=True)
         with open(os.path.join(path, "arrays.npy"), "wb") as handle:
-            for leaf in jax.tree_util.tree_leaves(state):
+            for leaf in jax.tree_util.tree_leaves(jax.device_get(state)):
                 np.save(handle, leaf, allow_pickle=False)
 
         structure = jax.tree_util.tree_map(lambda _leaf: 0, state)

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -29,6 +29,7 @@ from jax_baselines.core.eval import (
     extract_vector_original_rewards,
     record_and_test,
 )
+from jax_baselines.core.replay_protocol import select_replay_device
 from jax_baselines.core.rollout_stats import EpisodeTracker, device_episode_step
 from jax_baselines.core.seeding import key_gen, set_global_seeds
 from jax_baselines.core.training_session import TrainingSession
@@ -120,37 +121,35 @@ class Actor_Critic_Policy_Gradient_Family:
 
         self.get_env_setup()
         self._initial_reset: tuple[dict, dict] | None = None
-        self.memory_backend: Literal["cpu", "gpu"] = "cpu"
-        if memory_backend == "gpu":
-            self.memory_backend = "gpu"
-        elif memory_backend == "auto":
+        self.memory_device = None
+        if memory_backend != "cpu":
             if self.env_type == "SingleEnv":
                 self._initial_reset = self.env.reset()
                 initial_obs = self._initial_reset[0]
             else:
                 initial_obs = self.env.current_obs()
-            if all(
-                isinstance(value, jax.Array)
-                and all(device.platform == "gpu" for device in value.devices())
-                for value in initial_obs.values()
-            ):
-                self.memory_backend = "gpu"
+            self.memory_device = select_replay_device(initial_obs, required=memory_backend == "gpu")
+        self.memory_backend: Literal["cpu", "gpu"] = (
+            "gpu" if self.memory_device is not None else "cpu"
+        )
         print("memory backend : ", self.memory_backend)
         self.obs_normalization = obs_normalization
-        self.obs_rms = (
-            RunningMeanStd(
-                epsilon=0.0,
-                shapes=self.observation_space,
-                dtype=np.float32,
-                on_device=self.memory_backend == "gpu",
+        with jax.default_device(self.memory_device):
+            self.obs_rms = (
+                RunningMeanStd(
+                    epsilon=0.0,
+                    shapes=self.observation_space,
+                    dtype=np.float32,
+                    on_device=self.memory_backend == "gpu",
+                )
+                if obs_normalization
+                else None
             )
-            if obs_normalization
-            else None
-        )
         # Control model initialization timing across children
         self._init_setup_model = _init_setup_model
         if self._init_setup_model:
-            self.setup_model()
+            with jax.default_device(self.memory_device):
+                self.setup_model()
 
     def save_params(self, path):
         self.checkpoint_store.save(
@@ -165,11 +164,14 @@ class Actor_Critic_Policy_Gradient_Family:
         state = self.checkpoint_store.restore(path)
         if not isinstance(state, ACCheckpointState):
             raise TypeError("Expected ACCheckpointState with observation-normalization state")
-        obs_rms = (
-            RunningMeanStd.from_state(state.obs_rms_state, on_device=self.memory_backend == "gpu")
-            if state.obs_rms_state is not None
-            else None
-        )
+        with jax.default_device(self.memory_device):
+            obs_rms = (
+                RunningMeanStd.from_state(
+                    state.obs_rms_state, on_device=self.memory_backend == "gpu"
+                )
+                if state.obs_rms_state is not None
+                else None
+            )
         if obs_rms is not None and (
             obs_rms.means.keys() != self.observation_space.keys()
             or any(
@@ -178,7 +180,7 @@ class Actor_Critic_Policy_Gradient_Family:
             )
         ):
             raise ValueError("Checkpoint observation statistics do not match the environment")
-        self.params = state.params
+        self.params = jax.device_put(state.params, self.memory_device)
         self.obs_rms = obs_rms
         self.obs_normalization = obs_rms is not None
 
@@ -206,6 +208,7 @@ class Actor_Critic_Policy_Gradient_Family:
             self.worker_size,
             [1] if self.action_type == "discrete" else self.action_size,
             memory_backend=self.memory_backend,
+            memory_device=self.memory_device,
         )
 
     def get_env_setup(self):
@@ -282,7 +285,8 @@ class Actor_Critic_Policy_Gradient_Family:
         if self.memory_backend == "cpu":
             if eval:
                 return np.asarray(mu)
-            return np.random.normal(np.asarray(mu), np.asarray(std)).astype(np.float32)
+            mu, std = jax.device_get((mu, std))
+            return np.random.normal(mu, std).astype(np.float32)
         if eval:
             return mu
         return _sample_continuous(mu, std, next(self.key_seq))
@@ -325,7 +329,8 @@ class Actor_Critic_Policy_Gradient_Family:
             for k, v in eval_result.items():
                 description += f"{k} : {v:8.2f}, "
 
-        description += f"loss : {np.mean(self.lossque):.3f}"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        description += f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f}"
 
         description += self._rollout_pbar_suffix()
 
@@ -372,13 +377,15 @@ class Actor_Critic_Policy_Gradient_Family:
             transition_steps=self._lr_annealing_transition_steps(total_timesteps),
         )
         self.optimizer = self._make_optimizer(schedule)
-        self.opt_state = self.optimizer.init(self.params)
+        with jax.default_device(self.memory_device):
+            self.opt_state = self.optimizer.init(self.params)
 
     def run_training_loop(self, ctx):
-        if self.env_type == "SingleEnv":
-            self.learn_SingleEnv(ctx)
-        if self.env_type == "VectorizedEnv":
-            self.learn_VectorizedEnv(ctx)
+        with jax.default_device(self.memory_device):
+            if self.env_type == "SingleEnv":
+                self.learn_SingleEnv(ctx)
+            if self.env_type == "VectorizedEnv":
+                self.learn_VectorizedEnv(ctx)
 
     def learn(
         self,

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -55,14 +55,16 @@ class IMPALA(IMPALA_Family):
 
         if steps % self.log_interval == 0:
             log_dict = {
-                "loss/critic_loss": float(critic_loss),
-                "loss/actor_loss": float(actor_loss),
-                "loss/entropy_loss": float(entropy_loss),
-                "loss/mean_rho": float(rho),
-                "loss/mean_target": float(targets),
+                "loss/critic_loss": critic_loss,
+                "loss/actor_loss": actor_loss,
+                "loss/entropy_loss": entropy_loss,
+                "loss/mean_rho": rho,
+                "loss/mean_target": targets,
             }
-            self.logger_server.log_trainer(steps, log_dict)
-        return critic_loss, float(rho)
+            self.logger_server.log_trainer(
+                steps, {key: float(value) for key, value in jax.device_get(log_dict).items()}
+            )
+        return critic_loss, rho
 
     def preprocess(
         self,

--- a/jax_baselines/APE_X/base_class.py
+++ b/jax_baselines/APE_X/base_class.py
@@ -2,6 +2,7 @@ import time
 from collections import deque
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 
 from jax_baselines.APE_X.exploration import worker_epsilons
@@ -117,7 +118,7 @@ class Ape_X_Family(object):
         self.checkpoint_store.save(path, self.params)
 
     def load_params(self, path):
-        self.params = self.target_params = self.checkpoint_store.restore(path)
+        self.params = self.target_params = jax.device_put(self.checkpoint_store.restore(path))
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
@@ -157,8 +158,10 @@ class Ape_X_Family(object):
         pass
 
     def description(self):
-        return "buffer len : {} loss : {:.3f} |".format(
-            len(self.replay_buffer), np.mean(self.lossque)
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        return (
+            f"buffer len : {len(self.replay_buffer)} "
+            f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f} |"
         )
 
     def train_step(self, steps, gradient_steps):
@@ -178,8 +181,15 @@ class Ape_X_Family(object):
             self.replay_buffer.update_priorities(data["indexes"], new_priorities)
 
         if steps % self.log_interval == 0:
-            log_dict = {"loss/qloss": float(loss), "loss/targets": float(t_mean)}
-            self.logger_server.log_trainer(steps, log_dict)
+            self.logger_server.log_trainer(
+                steps,
+                {
+                    key: float(value)
+                    for key, value in jax.device_get(
+                        {"loss/qloss": loss, "loss/targets": t_mean}
+                    ).items()
+                },
+            )
 
         return loss
 

--- a/jax_baselines/APE_X/dpg_base_class.py
+++ b/jax_baselines/APE_X/dpg_base_class.py
@@ -2,6 +2,7 @@ import time
 from collections import deque
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 
 from jax_baselines.APE_X.exploration import worker_epsilons
@@ -112,7 +113,7 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
         self.checkpoint_store.save(path, self.params)
 
     def load_params(self, path):
-        self.params = self.target_params = self.checkpoint_store.restore(path)
+        self.params = self.target_params = jax.device_put(self.checkpoint_store.restore(path))
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
@@ -155,8 +156,10 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
         return self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
 
     def description(self):
-        return "buffer len : {} loss : {:.3f} |".format(
-            len(self.replay_buffer), np.mean(self.lossque)
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        return (
+            f"buffer len : {len(self.replay_buffer)} "
+            f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f} |"
         )
 
     def train_step(self, steps, gradient_steps):
@@ -176,8 +179,15 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
             self.replay_buffer.update_priorities(data["indexes"], new_priorities)
 
         if steps % self.log_interval == 0:
-            log_dict = {"loss/qloss": float(loss), "loss/targets": float(t_mean)}
-            self.logger_server.log_trainer(steps, log_dict)
+            self.logger_server.log_trainer(
+                steps,
+                {
+                    key: float(value)
+                    for key, value in jax.device_get(
+                        {"loss/qloss": loss, "loss/targets": t_mean}
+                    ).items()
+                },
+            )
 
         return loss
 

--- a/jax_baselines/APE_X/dpg_worker.py
+++ b/jax_baselines/APE_X/dpg_worker.py
@@ -64,7 +64,7 @@ class Ape_X_Worker(object):
             else:
                 obs, info = self.env.reset()
             obs = batch_observation(obs)
-            params = param_server.get_params()
+            params = jax.device_put(param_server.get_params())
             eplen = 0
             episode = 0
             if eps is None:
@@ -78,7 +78,7 @@ class Ape_X_Worker(object):
 
             while not stop.is_set():
                 if update.is_set():
-                    params = param_server.get_params()
+                    params = jax.device_put(param_server.get_params())
                     update.clear()
                     get_action = _get_action
 

--- a/jax_baselines/APE_X/worker.py
+++ b/jax_baselines/APE_X/worker.py
@@ -65,7 +65,7 @@ class Ape_X_Worker(object):
                 original_score = 0
             score = 0
             obs = batch_observation(obs)
-            params = param_server.get_params()
+            params = jax.device_put(param_server.get_params())
             eplen = 0
             episode = 0
             if eps is None:
@@ -83,7 +83,7 @@ class Ape_X_Worker(object):
 
             while not stop.is_set():
                 if update.is_set():
-                    params = param_server.get_params()
+                    params = jax.device_put(param_server.get_params())
                     update.clear()
                     get_action = _get_action
 

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -136,7 +136,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": np.exp(self.log_ent_coef)},
+            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
         )
 
     def _train_on_bulk(self, data, contexts):

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -239,19 +239,11 @@ class Deteministic_Policy_Gradient_Family:
         )
 
     def _restore_checkpoint_state(self, state: CheckpointState):
-        self.load_checkpoint_params(
-            jax.device_put(state.params, self.memory_device)
-            if self.memory_backend == "gpu"
-            else state.params
-        )
+        self.load_checkpoint_params(jax.device_put(state.params, self.memory_device))
         self.train_steps_count = int(np.asarray(state.train_steps_count).item())
         self._ckpt_update_residual = float(np.asarray(state.ckpt_residual).item())
         self.ckpt.from_state(state.controller_state)
-        self.eval_snapshot = (
-            jax.device_put(state.eval_snapshot, self.memory_device)
-            if self.memory_backend == "gpu"
-            else state.eval_snapshot
-        )
+        self.eval_snapshot = jax.device_put(state.eval_snapshot, self.memory_device)
 
         with jax.default_device(self.memory_device):
             if self.simba:
@@ -444,7 +436,8 @@ class Deteministic_Policy_Gradient_Family:
             for k, v in eval_result.items():
                 description += f"{k} : {v:8.2f}, "
 
-        description += f"loss : {np.mean(self.lossque):.3f}"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        description += f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f}"
         if self.use_checkpointing and (self.ckpt.last_update_step is not None):
             description += f", ckpt_upd_step : {int(self.ckpt.last_update_step)}"
         description += self._rollout_pbar_suffix()

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -95,7 +95,8 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             for k, v in eval_result.items():
                 description += f"{k} : {v:8.2f}, "
 
-        description += f"loss : {np.mean(self.lossque):.3f}"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        description += f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f}"
         description += f", epsilon : {self.epsilon:.3f}"
         description += self._rollout_pbar_suffix()
         return description
@@ -106,20 +107,17 @@ class DDPG(Deteministic_Policy_Gradient_Family):
     def _apply_action_noise(self, actions, steps, eval):
         if eval:
             return actions
-        self.epsilon = self.exploration(steps)
-        if self.memory_backend == "cpu":
-            self.epsilon = float(self.epsilon)
+        self.epsilon = self.exploration_initial_eps
+        if self._exploration_steps > 0:
+            self.epsilon += min(max(steps / self._exploration_steps, 0.0), 1.0) * (
+                self.exploration_final_eps - self.exploration_initial_eps
+            )
         return (jnp if self.memory_backend == "gpu" else np).clip(
             actions + self.noise() * self.epsilon, -1, 1
         )
 
     def prepare_run(self, total_timesteps):
-        self.exploration = optax.linear_schedule(
-            init_value=self.exploration_initial_eps,
-            end_value=self.exploration_final_eps,
-            transition_steps=int(self.exploration_fraction * total_timesteps),
-        )
-        self.exploration.value = self.exploration
+        self._exploration_steps = int(self.exploration_fraction * total_timesteps)
         self.epsilon = 1.0
 
     def test_action(self, obs):

--- a/jax_baselines/DDPG/training.py
+++ b/jax_baselines/DDPG/training.py
@@ -152,9 +152,8 @@ class DPGTrainingLifecycle:
         interval = self.agent.log_interval if log_interval is None else log_interval
         if logger_run and (steps - self.agent._last_log_step >= interval):
             self.agent._last_log_step = steps
-            for metric_name, metric_value in report.metrics.items():
-                logger_run.log_metric(metric_name, metric_value, steps)
+            metrics = report.metrics
             if self.agent.reward_normalizer is not None:
-                logger_run.log_metric(
-                    "rollout/reward_scale", self.agent.reward_normalizer.scale, steps
-                )
+                metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
+            for metric_name, metric_value in jax.device_get(metrics).items():
+                logger_run.log_metric(metric_name, metric_value, steps)

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -4,7 +4,6 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
 
 from jax_baselines.core.checkpoint import make_checkpoint_scaffold, snapshot_pytree
 from jax_baselines.core.checkpoint_state import QNetCheckpointState
@@ -218,9 +217,7 @@ class Q_Network_Family:
                 if self.reward_normalizer is not None and state.reward_rms_state is not None:
                     self.reward_normalizer.restore(state.reward_rms_state)
                 state = state.params
-            self.params = self.target_params = (
-                jax.device_put(state, self.memory_device) if self.memory_backend == "gpu" else state
-            )
+            self.params = self.target_params = jax.device_put(state, self.memory_device)
 
     def get_env_setup(self):
         (
@@ -434,7 +431,8 @@ class Q_Network_Family:
             for k, v in eval_result.items():
                 description += f"{k} : {v:8.2f}, "
 
-        description += f"loss : {np.mean(self.lossque):.3f}"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        description += f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f}"
 
         if not self.param_noise:
             description += f", epsilon : {self.update_eps:.3f}"
@@ -508,14 +506,7 @@ class Q_Network_Family:
         )
 
     def prepare_run(self, total_timesteps):
-        if self.param_noise:
-            self.exploration = optax.constant_schedule(0)
-        else:
-            self.exploration = optax.linear_schedule(
-                init_value=self.exploration_initial_eps,
-                end_value=self.exploration_final_eps,
-                transition_steps=int(self.exploration_fraction * total_timesteps),
-            )
+        self._exploration_steps = int(self.exploration_fraction * total_timesteps)
         self.update_eps = 1.0
 
     def run_training_loop(self, ctx):
@@ -536,7 +527,14 @@ class Q_Network_Family:
         return ActionSelection(env_action=actions, store_action=actions)
 
     def _refresh_exploration(self, steps):
-        self.update_eps = float(self.exploration(steps))
+        if self.param_noise:
+            self.update_eps = 0.0
+            return
+        self.update_eps = self.exploration_initial_eps
+        if self._exploration_steps > 0:
+            self.update_eps += min(max(steps / self._exploration_steps, 0.0), 1.0) * (
+                self.exploration_final_eps - self.exploration_initial_eps
+            )
 
     def _write_ckpt_residual(self, value):
         self._ckpt_update_residual = value

--- a/jax_baselines/DQN/training.py
+++ b/jax_baselines/DQN/training.py
@@ -200,11 +200,11 @@ class QNetTrainingLifecycle:
         interval = self.agent.log_interval if log_interval is None else log_interval
         if logger_run and (steps - self.agent._last_log_step >= interval):
             self.agent._last_log_step = steps
-            for metric_name, metric_value in report.metrics.items():
-                logger_run.log_metric(metric_name, metric_value, steps)
-            for histogram_name, histogram_value in report.histograms.items():
-                logger_run.log_histogram(histogram_name, histogram_value, steps)
+            metrics = report.metrics
             if self.agent.reward_normalizer is not None:
-                logger_run.log_metric(
-                    "rollout/reward_scale", self.agent.reward_normalizer.scale, steps
-                )
+                metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
+            metrics, histograms = jax.device_get((metrics, report.histograms))
+            for metric_name, metric_value in metrics.items():
+                logger_run.log_metric(metric_name, metric_value, steps)
+            for histogram_name, histogram_value in histograms.items():
+                logger_run.log_histogram(histogram_name, histogram_value, steps)

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -102,7 +102,7 @@ class IMPALA_Family:
         self.checkpoint_store.save(path, self.params)
 
     def load_params(self, path):
-        self.params = self.target_params = self.checkpoint_store.restore(path)
+        self.params = self.target_params = jax.device_put(self.checkpoint_store.restore(path))
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
@@ -221,7 +221,7 @@ class IMPALA_Family:
                     return mean, log_std
 
                 def get_action_prob(actor, params, obses):
-                    mean, log_std = actor(params, obses)
+                    mean, log_std = jax.device_get(actor(params, obses))
                     std = np.exp(log_std)
                     action = np.random.normal(mean, std)
                     return action, -(
@@ -243,7 +243,8 @@ class IMPALA_Family:
         return builder
 
     def description(self):
-        return f"loss : {np.mean(self.lossque):.3f} |"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        return f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f} |"
 
     def run_name_update(self, run_name):
         return run_name

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -118,14 +118,16 @@ class SurrogateIMPALA(IMPALA_Family):
 
         if steps % self.log_interval == 0:
             log_dict = {
-                "loss/critic_loss": float(critic_loss),
-                "loss/actor_loss": float(actor_loss),
-                "loss/entropy_loss": float(entropy_loss),
-                "loss/mean_rho": float(rho),
-                "loss/mean_target": float(targets),
+                "loss/critic_loss": critic_loss,
+                "loss/actor_loss": actor_loss,
+                "loss/entropy_loss": entropy_loss,
+                "loss/mean_rho": rho,
+                "loss/mean_target": targets,
             }
-            self.logger_server.log_trainer(steps, log_dict)
-        return critic_loss, float(rho)
+            self.logger_server.log_trainer(
+                steps, {key: float(value) for key, value in jax.device_get(log_dict).items()}
+            )
+        return critic_loss, rho
 
     def preprocess(
         self,

--- a/jax_baselines/IMPALA/worker.py
+++ b/jax_baselines/IMPALA/worker.py
@@ -66,10 +66,10 @@ class Impala_Worker(object):
 
             # Eager initial fetch so `params` is always bound before first use,
             # mirroring the APE-X workers (avoids reliance on update being pre-set).
-            params = param_server.get_params()
+            params = jax.device_put(param_server.get_params())
             while not stop.is_set():
                 if update.is_set():
-                    params = param_server.get_params()
+                    params = jax.device_put(param_server.get_params())
                     update.clear()
                 for _ in range(local_size):
                     eplen += 1

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -147,7 +147,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": np.exp(self.log_ent_coef)},
+            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
         )
 
     def _train_on_bulk(self, data, contexts):

--- a/jax_baselines/SPR/spr.py
+++ b/jax_baselines/SPR/spr.py
@@ -198,8 +198,10 @@ class SPR(Q_Network_Family):
         return result
 
     def _aggregate_train_reports(self, reports):
+        if len(reports) == 1:
+            return reports[0]
         counts = jnp.array([report.update_count for report in reports])
-        total = jnp.sum(counts)
+        total = sum(report.update_count for report in reports)
         mean_loss = jnp.sum(jnp.array([report.loss for report in reports]) * counts) / total
         mean_target = jnp.sum(jnp.array([report.target for report in reports]) * counts) / total
         mean_rprloss = (
@@ -210,7 +212,7 @@ class SPR(Q_Network_Family):
             loss=mean_loss,
             target=mean_target,
             metrics={"loss/rprloss": mean_rprloss},
-            update_count=int(total),
+            update_count=total,
         )
 
     def _image_augmentation(self, obs, key):

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -513,7 +513,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
             for k, v in eval_result.items():
                 description += f"{k} : {v:8.2f}, "
 
-        description += f"loss : {np.mean(self.lossque):.3f}"
+        array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
+        description += f"loss : {array_module.mean(array_module.asarray(tuple(self.lossque))):.3f}"
         description += self._rollout_pbar_suffix()
         return description
 

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -121,14 +121,16 @@ class IMPALA_TPPO(IMPALA_Family):
 
         if steps % self.log_interval == 0:
             log_dict = {
-                "loss/critic_loss": float(critic_loss),
-                "loss/actor_loss": float(actor_loss),
-                "loss/entropy_loss": float(entropy_loss),
-                "loss/mean_rho": float(rho),
-                "loss/mean_target": float(targets),
+                "loss/critic_loss": critic_loss,
+                "loss/actor_loss": actor_loss,
+                "loss/entropy_loss": entropy_loss,
+                "loss/mean_rho": rho,
+                "loss/mean_target": targets,
             }
-            self.logger_server.log_trainer(steps, log_dict)
-        return critic_loss, float(rho)
+            self.logger_server.log_trainer(
+                steps, {key: float(value) for key, value in jax.device_get(log_dict).items()}
+            )
+        return critic_loss, rho
 
     def preprocess(
         self,

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -173,7 +173,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": np.exp(self.log_ent_coef)},
+            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
         )
 
     def _train_on_bulk(self, data, contexts):

--- a/jax_baselines/core/epoch_buffer.py
+++ b/jax_baselines/core/epoch_buffer.py
@@ -31,6 +31,7 @@ class EpochBuffer:
         worker_size=1,
         action_space=1,
         memory_backend: Literal["cpu", "gpu"] = "cpu",
+        memory_device: jax.Device | None = None,
     ):
         if epoch_size < 1 or worker_size < 1:
             raise ValueError("epoch_size and worker_size must be positive")
@@ -38,9 +39,11 @@ class EpochBuffer:
             raise ValueError("observation_space must be a non-empty dict")
         if memory_backend not in ("cpu", "gpu"):
             raise ValueError("memory_backend must be 'cpu' or 'gpu'")
+        if memory_device is not None and memory_device.platform != memory_backend:
+            raise ValueError("memory_device must match memory_backend")
         self.memory_backend = memory_backend
-        self._device: jax.Device | None = None
-        if memory_backend == "gpu":
+        self._device = memory_device
+        if memory_backend == "gpu" and self._device is None:
             try:
                 devices = jax.devices("gpu")
             except RuntimeError as error:

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -174,16 +174,35 @@ def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn
         actions = act_eval_fn(eval_env.current_obs())
         eval_env.step(conv_action(actions) if conv_action is not None else actions)
         _, rewards, terminateds, truncateds, infos = eval_env.get_result()
-        rewards, terminateds, truncateds = jax.device_get((rewards, terminateds, truncateds))
+        reward_infos = {}
+        if isinstance(infos, dict):
+            reward_infos = {
+                key: infos[key] for key in ("original_reward", "_original_reward") if key in infos
+            }
+        elif isinstance(infos, (list, tuple)):
+            reward_infos = [
+                {"original_reward": info["original_reward"]}
+                if isinstance(info, dict) and "original_reward" in info
+                else {}
+                for info in infos
+            ]
+        rewards, terminateds, truncateds, real_reset, autoreset, reward_infos = jax.device_get(
+            (
+                rewards,
+                terminateds,
+                truncateds,
+                vector_real_reset_mask(eval_env, terminateds, truncateds, infos),
+                vector_autoreset_mask(eval_env, terminateds, truncateds, infos),
+                reward_infos,
+            )
+        )
         done = np.logical_or(terminateds, truncateds)
         active = ~prev_done & (counts < targets)
         rewards_sum[active] += rewards[active]
         lengths[active] += 1
-        original, present = extract_vector_original_rewards(infos, workers)
+        original, present = extract_vector_original_rewards(reward_infos, workers)
         originals[active & present] += original[active & present]
         original_present[active & present] = True
-        real_reset = np.asarray(vector_real_reset_mask(eval_env, terminateds, truncateds, infos))
-        autoreset = np.asarray(vector_autoreset_mask(eval_env, terminateds, truncateds, infos))
         finished = done & active
         emit_original = finished & real_reset & original_present
         original_rewards.extend(originals[emit_original].tolist())
@@ -252,7 +271,7 @@ def run_test_episodes(test_env, actions_eval_fn, episode, conv_action=None):
 
     total_rewards = []
     for _ in range(episode):
-        obs, info = test_env.reset()
+        obs, _ = test_env.reset()
         obs = batch_observation(obs)
         terminated = False
         truncated = False
@@ -263,7 +282,7 @@ def run_test_episodes(test_env, actions_eval_fn, episode, conv_action=None):
             step_action = conv_action(actions) if conv_action is not None else actions
             action_to_step = _normalize_action_for_step(step_action)
 
-            observation, reward, terminated, truncated, info = test_env.step(action_to_step)
+            observation, reward, terminated, truncated, _ = test_env.step(action_to_step)
             obs = batch_observation(observation)
             episode_rew += reward
             eplen += 1

--- a/jax_baselines/math/statistics.py
+++ b/jax_baselines/math/statistics.py
@@ -156,29 +156,32 @@ class RunningMeanStd:
 
     def to_state(self):
         """Serialize running statistics to a numpy-friendly state."""
+        means, variances, count = jax.device_get((self.means, self.vars, self.count))
         return {
-            "means": {key: np.asarray(arr) for key, arr in self.means.items()},
-            "vars": {key: np.asarray(arr) for key, arr in self.vars.items()},
-            "count": np.asarray(self.count, dtype=np.float64),
+            "means": {key: np.asarray(arr) for key, arr in means.items()},
+            "vars": {key: np.asarray(arr) for key, arr in variances.items()},
+            "count": np.asarray(count, dtype=np.float64),
         }
 
     @classmethod
     def from_state(cls, state, *, on_device: bool = False):
         """Deserialize running statistics from a saved state."""
+        if not on_device:
+            state = jax.device_get(state)
         means = state["means"]
         vars_ = state["vars"]
         if not isinstance(means, dict) or not isinstance(vars_, dict):
             raise TypeError("Running statistics means and vars must be dictionaries")
         if means.keys() != vars_.keys():
             raise ValueError("Running statistics means and vars must have matching keys")
-        means = {key: np.asarray(arr) for key, arr in means.items()}
-        vars_ = {key: np.asarray(arr) for key, arr in vars_.items()}
+        array_module = jnp if on_device else np
+        means = {key: array_module.asarray(arr) for key, arr in means.items()}
+        vars_ = {key: array_module.asarray(arr) for key, arr in vars_.items()}
         if any(means[key].shape != vars_[key].shape for key in means):
             raise ValueError("Running statistics means and vars must have matching shapes")
         dtype = next(iter(means.values())).dtype if means else np.float64
         shapes = {key: arr.shape for key, arr in means.items()}
         instance = cls(shapes=shapes, dtype=dtype, on_device=on_device)
-        array_module = jnp if on_device else np
         instance.means = {
             key: array_module.asarray(arr, dtype=instance.dtype) for key, arr in means.items()
         }

--- a/replay_memory/cpprb_buffers.py
+++ b/replay_memory/cpprb_buffers.py
@@ -2,6 +2,7 @@ import warnings
 from collections.abc import Mapping
 
 import cpprb
+import jax
 import numpy as np
 
 
@@ -263,7 +264,13 @@ class NstepReplayBuffer(ReplayBuffer):
         truncated=False,
         store_mask=None,
     ):
-        for w in _active_worker_indices(self.worker_size, store_mask):
+        workers = _active_worker_indices(self.worker_size, store_mask)
+        if not len(workers):
+            return
+        obs_t, action, reward, nxtobs_t, terminated, truncated = jax.device_get(
+            (obs_t, action, reward, nxtobs_t, terminated, truncated)
+        )
+        for w in workers:
             obsdict = _storage_observation(
                 self.obsdict, {key: value[w] for key, value in obs_t.items()}, "obs"
             )
@@ -309,7 +316,13 @@ class NstepReplayBuffer(ReplayBuffer):
         truncated=False,
         store_mask=None,
     ):
-        for w in _active_worker_indices(self.worker_size, store_mask):
+        workers = _active_worker_indices(self.worker_size, store_mask)
+        if not len(workers):
+            return
+        obs_t, action, reward, nxtobs_t, terminated, truncated = jax.device_get(
+            (obs_t, action, reward, nxtobs_t, terminated, truncated)
+        )
+        for w in workers:
             obsdict = _storage_observation(
                 self.obsdict, {key: value[w] for key, value in obs_t.items()}, "obs"
             )

--- a/replay_memory/frame_buffers.py
+++ b/replay_memory/frame_buffers.py
@@ -88,7 +88,7 @@ class FrameStackReplayBuffer:
     def add(self, obs_t, action, reward, nxtobs_t, terminated, truncated=False):
         r = self._count % self.max_size
         self._boundary_next.pop(r, None)
-        self._frame[r] = np.asarray(obs_t[self.observation_key])[0, :, :, -self.cf :]
+        self._frame[r] = np.asarray(obs_t[self.observation_key][0, :, :, -self.cf :])
         self._action[r] = np.asarray(action, dtype=np.float32).reshape(self.action_shape)
         self._reward[r] = reward
         self._terminated[r] = bool(terminated)
@@ -96,9 +96,9 @@ class FrameStackReplayBuffer:
         self._ep_id[r] = self._ep
         self._ep_step[r] = self._cur_step
         if terminated or truncated:
-            self._boundary_next[r] = np.asarray(nxtobs_t[self.observation_key])[
-                0, :, :, -self.cf :
-            ].copy()
+            self._boundary_next[r] = np.asarray(
+                nxtobs_t[self.observation_key][0, :, :, -self.cf :]
+            ).copy()
         self._count += 1
         if terminated or truncated:
             self._ep += 1

--- a/tests/test_ac_memory_backend.py
+++ b/tests/test_ac_memory_backend.py
@@ -100,7 +100,7 @@ def test_gpu_environment_selects_device_memory_unless_cpu_requested(backend):
 def test_forced_gpu_fails_without_gpu():
     if any(device.platform == "gpu" for device in jax.devices()):
         pytest.skip("Requires a CPU-only JAX runtime")
-    with pytest.raises(RuntimeError, match="GPU|gpu"):
+    with pytest.raises(ValueError, match="GPU|gpu"):
         agent = Actor_Critic_Policy_Gradient_Family(
             _Env(np.ones(2, np.float32)),
             None,

--- a/tests/test_ac_observation_normalization.py
+++ b/tests/test_ac_observation_normalization.py
@@ -11,6 +11,7 @@ from jax_baselines.math.statistics import RunningMeanStd
 def _agent(enabled=True):
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.memory_backend = "cpu"
+    agent.memory_device = None
     agent.action_type = "continuous"
     agent._initial_reset = None
     agent.observation_space = {"unified_obs": [1]}

--- a/tests/test_checkpoint_store_adapter.py
+++ b/tests/test_checkpoint_store_adapter.py
@@ -8,6 +8,7 @@ from experiments.checkpoint_store import FileCheckpointStore
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.APE_X.base_class import Ape_X_Family
 from jax_baselines.APE_X.dpg_base_class import Ape_X_Deteministic_Policy_Gradient_Family
+from jax_baselines.core.checkpoint_state import ACCheckpointState
 from jax_baselines.core.checkpoint_store import NoOpCheckpointStore
 from jax_baselines.IMPALA.base_class import IMPALA_Family
 
@@ -42,7 +43,8 @@ def test_noop_checkpoint_store_does_not_write_and_cannot_restore(tmp_path):
 )
 def test_remaining_families_delegate_checkpoint_io(family, sets_target):
     class MemoryStore:
-        restored = {"weights": 2}
+        def __init__(self, restored):
+            self.restored = restored
 
         def save(self, path, state):
             self.saved = (path, state)
@@ -53,12 +55,21 @@ def test_remaining_families_delegate_checkpoint_io(family, sets_target):
 
     agent = family.__new__(family)
     agent.params = {"weights": 1}
-    agent.checkpoint_store = MemoryStore()
+    if isinstance(agent, Actor_Critic_Policy_Gradient_Family):
+        agent.obs_rms = None
+        agent.memory_backend = "cpu"
+        agent.memory_device = None
+        saved = ACCheckpointState(params=agent.params, obs_rms_state=None)
+        restored = ACCheckpointState(params={"weights": 2}, obs_rms_state=None)
+    else:
+        saved = agent.params
+        restored = {"weights": 2}
+    agent.checkpoint_store = MemoryStore(restored)
 
     agent.save_params("checkpoint")
     agent.load_params("checkpoint")
 
-    assert agent.checkpoint_store.saved == ("checkpoint", {"weights": 1})
+    assert agent.checkpoint_store.saved == ("checkpoint", saved)
     assert agent.checkpoint_store.restored_path == "checkpoint"
     assert agent.params == {"weights": 2}
     if sets_target:

--- a/tests/test_leaf_learn_defaults.py
+++ b/tests/test_leaf_learn_defaults.py
@@ -186,12 +186,16 @@ def test_ddpg_prepare_run_keeps_exploration_initialization():
     agent.exploration_fraction = 0.5
     agent.exploration_initial_eps = 1.0
     agent.exploration_final_eps = 0.1
+    agent.memory_backend = "cpu"
+    agent.noise = lambda: 0.0
 
     agent.prepare_run(100)
 
     assert agent.epsilon == 1.0
-    assert agent.exploration.value(0) == pytest.approx(1.0)
-    assert agent.exploration.value(50) == pytest.approx(0.1)
+    agent._apply_action_noise(0.0, steps=0, eval=False)
+    assert agent.epsilon == pytest.approx(1.0)
+    agent._apply_action_noise(0.0, steps=50, eval=False)
+    assert agent.epsilon == pytest.approx(0.1)
 
 
 def _set_q_run_name_flags(agent):

--- a/tests/test_optimizer_factory_injection.py
+++ b/tests/test_optimizer_factory_injection.py
@@ -47,6 +47,7 @@ def test_a2c_prepare_run_rebuilds_optimizer_with_linear_lr_schedule_through_fact
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.optimizer_factory = factory
     agent.learning_rate = 0.00025
+    agent.memory_device = None
     agent.lr_annealing = True
     agent.batch_size = 10
     agent.worker_size = 2

--- a/tests/test_pg_ppo2_fidelity_cli.py
+++ b/tests/test_pg_ppo2_fidelity_cli.py
@@ -120,6 +120,7 @@ def test_prepare_run_rebuilds_optimizer_with_linear_lr_schedule():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.optimizer_factory = fake_optimizer_factory
     agent.learning_rate = 0.00025
+    agent.memory_device = None
     agent.lr_annealing = True
     agent.batch_size = 10
     agent.worker_size = 2

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -869,11 +869,15 @@ def test_qnet_vector_action_passes_array_through():
 
 def test_qnet_refresh_exploration_updates_epsilon():
     agent = Q_Network_Family.__new__(Q_Network_Family)
-    agent.exploration = lambda steps: 0.42
+    agent.param_noise = False
+    agent.exploration_fraction = 0.5
+    agent.exploration_initial_eps = 1.0
+    agent.exploration_final_eps = 0.0
+    agent.prepare_run(100)
 
     agent._refresh_exploration(steps=10)
 
-    assert agent.update_eps == 0.42
+    assert agent.update_eps == 0.8
 
 
 def test_dpg_single_action_single_indexes_continuous_action():

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -30,7 +30,7 @@ class FakeLoggerRun:
         return ("local_path", name)
 
 
-def test_off_policy_prepare_run_builds_callable_exploration_schedules():
+def test_off_policy_prepare_run_updates_exploration_at_environment_steps():
     qnet = Q_Network_Family.__new__(Q_Network_Family)
     qnet.param_noise = False
     qnet.exploration_fraction = 0.5
@@ -42,11 +42,16 @@ def test_off_policy_prepare_run_builds_callable_exploration_schedules():
     ddpg.exploration_fraction = 0.5
     ddpg.exploration_initial_eps = 1.0
     ddpg.exploration_final_eps = 0.1
+    ddpg.memory_backend = "cpu"
+    ddpg.noise = lambda: np.zeros((1, 1))
     ddpg.prepare_run(100)
 
-    expected = pytest.approx([1.0, 0.55, 0.1])
-    assert [float(qnet.exploration(step)) for step in (0, 25, 50)] == expected
-    assert [float(ddpg.exploration(step)) for step in (0, 25, 50)] == expected
+    observed = []
+    for step in (0, 25, 50):
+        qnet._refresh_exploration(step)
+        ddpg._apply_action_noise(np.zeros((1, 1)), step, eval=False)
+        observed.append((qnet.update_eps, ddpg.epsilon))
+    np.testing.assert_allclose(observed, [(1.0, 1.0), (0.55, 0.55), (0.1, 0.1)])
 
 
 class FakeLogger:
@@ -320,6 +325,7 @@ class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
         self.params = None
         self.obs_rms = None
         self.memory_backend = "cpu"
+        self.memory_device = None
 
     def learn_SingleEnv(self, ctx):
         self.calls.append(("single", ctx))


### PR DESCRIPTION
학습 지표·체크포인트 복원·분산 워커의 파라미터 수신에서 반복되던 CPU↔GPU 전환을 줄였습니다. 복원·수신한 모델 파라미터는 해당 경계에서 한 번 장치에 배치하고 이후 추론에서 재사용합니다.

탐색률은 호스트에서 계산하고 GPU 손실은 장치에서 집계하며, 로그·평가·체크포인트의 필요한 호스트 전송을 묶었습니다. Actor-Critic의 선택 장치를 모델·정규화·EpochBuffer까지 유지하고, IMPALA 연속 행동의 불필요한 왕복과 SPR 보고서 집계의 스칼라 동기화를 제거했습니다. CPU 프레임 replay는 저장할 마지막 프레임만 가져옵니다.

검증: 실제 GPU 전송 경계 25/25, QNet·DPG 복원 후 추론 2/2 통과. DQN·SPR·SAC·A2C 실제 업데이트와 분산 워커 3종의 실행 루프를 확인했고, 영향 모듈 테스트 및 저장소 훅을 통과했습니다. 신규 Ruff·타입 진단은 없으며 기존 진단은 남아 있습니다. 전송 경계와 payload를 확인한 변경이며 처리량 개선율은 측정하지 않았습니다.

스택 2/2: #32 위에 쌓인 PR이며 기준 브랜치는 `feat/qnet-memory-backend`입니다. #32를 먼저 검토·병합한 뒤 이 PR을 병합합니다. 이 PR의 diff에는 공통 전송 최적화 커밋만 포함됩니다.
