### PR TITLE
refactor: 중첩 분기와 중복 계산 단순화

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -93,12 +93,12 @@ def _single_env_info(env, env_id: str) -> EnvInfo:
 
 
 def _prepared_env_info(env, env_id: str) -> EnvInfo:
-    if isinstance(env, VectorizedEnv):
-        env_info = env.env_info
-        if env_info is None:
-            raise ValueError("Vectorized env must expose env_info")
-        return env_info
-    return _single_env_info(env, env_id)
+    if not isinstance(env, VectorizedEnv):
+        return _single_env_info(env, env_id)
+    env_info = env.env_info
+    if env_info is None:
+        raise ValueError("Vectorized env must expose env_info")
+    return env_info
 
 
 _ENV_BACKENDS = ("gymnasium", "envpool", "mjlab")
@@ -150,21 +150,21 @@ def get_env_builder(
                 jax_arrays=jax_arrays,
                 reuse_for_eval=reuse_for_eval and render_mode is None,
             )
-        if worker > 1:
-            # Vectorized backend is an explicit choice: gymnasium AsyncVectorEnv
-            # (default, portable) or EnvPool (faster, only for envs it ships).
-            if env_backend == "envpool":
-                if not _is_envpool_supported(env_name):
-                    raise ValueError(
-                        f"env_backend='envpool' requested but EnvPool has no spec for "
-                        f"{env_name!r}; use env_backend='gymnasium' or a supported env id."
-                    )
-                return EnvPoolVectorizedEnv(
-                    env_name,
-                    worker_num=worker,
-                    seed=seed,
-                    observation_key=observation_key,
+        # Vectorized backend is an explicit choice: gymnasium AsyncVectorEnv
+        # (default, portable) or EnvPool (faster, only for envs it ships).
+        if worker > 1 and env_backend == "envpool":
+            if not _is_envpool_supported(env_name):
+                raise ValueError(
+                    f"env_backend='envpool' requested but EnvPool has no spec for "
+                    f"{env_name!r}; use env_backend='gymnasium' or a supported env id."
                 )
+            return EnvPoolVectorizedEnv(
+                env_name,
+                worker_num=worker,
+                seed=seed,
+                observation_key=observation_key,
+            )
+        if worker > 1:
             return GymVectorizedEnv(
                 env_name,
                 worker_num=worker,
@@ -172,32 +172,31 @@ def get_env_builder(
                 observation_key=observation_key,
                 reuse_for_eval=reuse_for_eval and render_mode is None,
             )
+        from env_builder.atari_wrappers import get_env_type, make_wrap_atari
+
+        env_type, _ = get_env_type(env_name)
+        if env_type == "atari_env":
+            env = make_wrap_atari(env_name, clip_rewards=True)
         else:
-            from env_builder.atari_wrappers import get_env_type, make_wrap_atari
+            env = gym.make(env_name, render_mode=render_mode)
+        env = gym.wrappers.TransformObservation(
+            env,
+            lambda observation: normalize_observation(observation, observation_key),
+            spaces.Dict(flatten_observation_space(env.observation_space, observation_key)),
+        )
+        env = _normalize_action_space(env)
+        if reuse_for_eval and render_mode is None:
+            from env_builder.gym_state import GymStateWrapper
 
-            env_type, _ = get_env_type(env_name)
-            if env_type == "atari_env":
-                env = make_wrap_atari(env_name, clip_rewards=True)
-            else:
-                env = gym.make(env_name, render_mode=render_mode)
-            env = gym.wrappers.TransformObservation(
-                env,
-                lambda observation: normalize_observation(observation, observation_key),
-                spaces.Dict(flatten_observation_space(env.observation_space, observation_key)),
-            )
-            env = _normalize_action_space(env)
-            if reuse_for_eval and render_mode is None:
-                from env_builder.gym_state import GymStateWrapper
-
-                try:
-                    env = GymStateWrapper(env)
-                except (TypeError, ValueError):
-                    env.close()
-                    raise
-                if seed is None:
-                    env.reset()
-            seed_env(env, seed)
-            return env
+            try:
+                env = GymStateWrapper(env)
+            except (TypeError, ValueError):
+                env.close()
+                raise
+            if seed is None:
+                env.reset()
+        seed_env(env, seed)
+        return env
 
     def prepare_envs(num_workers=1, seed=None):
         eval_seed = None if seed is None else seed + 1

--- a/experiments/cli/dpg.py
+++ b/experiments/cli/dpg.py
@@ -107,7 +107,11 @@ def build_env(args):
 
 
 def _variant(args):
-    return "simbav2_" if args.simbav2 else "simba_" if args.simba else ""
+    if args.simbav2:
+        return "simbav2_"
+    if args.simba:
+        return "simba_"
+    return ""
 
 
 def _simba(args):

--- a/experiments/cli/exp.py
+++ b/experiments/cli/exp.py
@@ -47,12 +47,11 @@ FAMILY_SCRIPTS = {
 def _build_args(merged):
     argv = []
     for key, value in merged.items():
-        flag = f"--{key}"
-        if isinstance(value, bool):
-            if value:
-                argv.append(flag)
+        if value is False:
             continue
-        argv.extend([flag, str(value)])
+        argv.append(f"--{key}")
+        if value is not True:
+            argv.append(str(value))
     return argv
 
 

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -513,7 +513,7 @@ class Actor_Critic_Policy_Gradient_Family:
         # terminal so it contributes a zero-value target and never bridges the
         # two episodes in the return. prev_done chains off the *real* env dones,
         # and the same mask keeps the dummy out of the rollout episode stats.
-        prev_done = None
+        prev_done = np.zeros(self.worker_size, dtype=bool)
         convert_action = self.conv_action if self.action_type == "continuous" else None
 
         def send(actions):
@@ -599,7 +599,7 @@ class Actor_Critic_Policy_Gradient_Family:
                 done = np.logical_or(terminateds, truncateds)
                 real_reset = vector_real_reset_mask(self.env, terminateds, truncateds, infos)
                 autoreset = vector_autoreset_mask(self.env, terminateds, truncateds, infos)
-                active = np.ones(self.worker_size, dtype=bool) if prev_done is None else ~prev_done
+                active = ~prev_done
                 scores[active] += rewards[active]
                 eplens[active] += 1
                 step_original, step_original_present = extract_vector_original_rewards(
@@ -609,7 +609,7 @@ class Actor_Critic_Policy_Gradient_Family:
                 originals[active_original] += step_original[active_original]
                 original_present[active_original] = True
 
-                if prev_done is not None and prev_done.any():
+                if prev_done.any():
                     # Flag the dummy step terminal AND zero its reward so it is fully
                     # inert (zero-value target, no episode bridge), independent of
                     # whatever the env reports on the discarded autoreset step.

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -88,11 +88,12 @@ class Actor_Critic_Policy_Gradient_Family:
     ):
         if memory_backend not in ("auto", "cpu", "gpu"):
             raise ValueError("memory_backend must be 'auto', 'cpu', or 'gpu'")
-        if use_entropy_adv_shaping:
-            if not np.isfinite(ent_coef) or ent_coef < 0:
-                raise ValueError("entropy shaping requires finite ent_coef >= 0")
-            if not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1:
-                raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
+        if use_entropy_adv_shaping and (not np.isfinite(ent_coef) or ent_coef < 0):
+            raise ValueError("entropy shaping requires finite ent_coef >= 0")
+        if use_entropy_adv_shaping and (
+            not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1
+        ):
+            raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
         self.env_builder = env_builder
         self.model_builder_maker = model_builder_maker
         self.num_workers = num_workers

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -297,26 +297,18 @@ class Actor_Critic_Policy_Gradient_Family:
         prob = jnp.clip(prob, 1e-8, 1.0)
         prob = prob / jnp.sum(prob, axis=-1, keepdims=True)
         action = action.astype(jnp.int32)
-        if out_prob:
-            return prob, jnp.log(jnp.take_along_axis(prob, action, axis=1))
-        else:
-            return jnp.log(jnp.take_along_axis(prob, action, axis=1))
+        log_prob = jnp.log(jnp.take_along_axis(prob, action, axis=1))
+        return (prob, log_prob) if out_prob else log_prob
 
     def get_logprob_continuous(self, prob, action, key, out_prob=False):
         mu, log_std = prob
         std = jnp.exp(log_std)
-        if out_prob:
-            return prob, -(
-                0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
-                + jnp.sum(log_std, axis=-1, keepdims=True)
-                + 0.5 * jnp.log(2 * np.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
-            )
-        else:
-            return -(
-                0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
-                + jnp.sum(log_std, axis=-1, keepdims=True)
-                + 0.5 * jnp.log(2 * np.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
-            )
+        log_prob = -(
+            0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
+            + jnp.sum(log_std, axis=-1, keepdims=True)
+            + 0.5 * jnp.log(2 * np.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
+        )
+        return (prob, log_prob) if out_prob else log_prob
 
     def _loss_continuous(self):
         pass

--- a/jax_baselines/APE_X/worker.py
+++ b/jax_baselines/APE_X/worker.py
@@ -105,14 +105,9 @@ class Ape_X_Worker(object):
                             len_label: eplen,
                             to_label: float(truncated),
                         }
-                        if have_original_reward:
-                            if have_lives:
-                                if info["lives"] == 0:
-                                    log_dict[original_rw_label] = original_score
-                                    original_score = 0
-                            else:
-                                log_dict[original_rw_label] = original_score
-                                original_score = 0
+                        if have_original_reward and (not have_lives or info["lives"] == 0):
+                            log_dict[original_rw_label] = original_score
+                            original_score = 0
                         logger_server.log_worker(log_dict, episode)
                     score = 0
                     eplen = 0

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -463,21 +463,21 @@ class Deteministic_Policy_Gradient_Family:
         return run_name
 
     def _apply_simba_normalization(self, obs, eval, steps):
-        if self.simba:
-            rms = (
-                self.checkpoint_obs_rms
-                if (
-                    eval
-                    and self.use_checkpointing
-                    and self.ckpt.enabled
-                    and self.checkpoint_obs_rms is not None
-                )
-                else self._policy_update_obs_rms()
+        if not self.simba:
+            return obs
+        rms = (
+            self.checkpoint_obs_rms
+            if (
+                eval
+                and self.use_checkpointing
+                and self.ckpt.enabled
+                and self.checkpoint_obs_rms is not None
             )
-            if (not eval) and steps != np.inf:
-                self.obs_rms.update(obs)
-            obs = rms.normalize(obs)
-        return obs
+            else self._policy_update_obs_rms()
+        )
+        if (not eval) and steps != np.inf:
+            self.obs_rms.update(obs)
+        return rms.normalize(obs)
 
     def _policy_update_obs_rms(self):
         return self.action_obs_rms if self.action_obs_rms is not None else self.obs_rms

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -286,8 +286,8 @@ class Deteministic_Policy_Gradient_Family:
             env_info = self.env.get_info()
             if "autoreset_steps" in env_info:
                 self.autoreset_steps = env_info["autoreset_steps"]
-                if not isinstance(self.autoreset_steps, bool):
-                    raise TypeError("Environment autoreset_steps must be a bool")
+        if not isinstance(self.autoreset_steps, bool):
+            raise TypeError("Environment autoreset_steps must be a bool")
         print("observation size : ", self.observation_space)
         print("action size : ", self.action_size)
         print("worker_size : ", self.worker_size)

--- a/jax_baselines/DDPG/training.py
+++ b/jax_baselines/DDPG/training.py
@@ -138,22 +138,24 @@ class DPGTrainingLifecycle:
             data["rewards"] = self.agent.reward_normalizer.normalize(data["rewards"])
 
     def _update_priorities(self, data, report):
-        if self.agent.prioritized_replay:
-            convert = (
-                flatten_priority_values
-                if isinstance(data["indexes"], jax.Array)
-                else host_priority_values
-            )
-            indexes = convert(data["indexes"])
-            priorities = convert(report.new_priorities)
-            self.agent.replay_buffer.update_priorities(indexes, priorities)
+        if not self.agent.prioritized_replay:
+            return
+        convert = (
+            flatten_priority_values
+            if isinstance(data["indexes"], jax.Array)
+            else host_priority_values
+        )
+        indexes = convert(data["indexes"])
+        priorities = convert(report.new_priorities)
+        self.agent.replay_buffer.update_priorities(indexes, priorities)
 
     def _log_report(self, report, steps, logger_run, log_interval):
         interval = self.agent.log_interval if log_interval is None else log_interval
-        if logger_run and (steps - self.agent._last_log_step >= interval):
-            self.agent._last_log_step = steps
-            metrics = report.metrics
-            if self.agent.reward_normalizer is not None:
-                metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
-            for metric_name, metric_value in jax.device_get(metrics).items():
-                logger_run.log_metric(metric_name, metric_value, steps)
+        if not (logger_run and steps - self.agent._last_log_step >= interval):
+            return
+        self.agent._last_log_step = steps
+        metrics = report.metrics
+        if self.agent.reward_normalizer is not None:
+            metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
+        for metric_name, metric_value in jax.device_get(metrics).items():
+            logger_run.log_metric(metric_name, metric_value, steps)

--- a/jax_baselines/DQN/apex_dqn.py
+++ b/jax_baselines/DQN/apex_dqn.py
@@ -204,29 +204,20 @@ class APE_X_DQN(Ape_X_Family):
         key,
     ):
         next_q = self.get_q(target_params, nxtobses, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = self.get_q(action_params, nxtobses, key) if self.double_q else next_q
 
         if self.munchausen:
-            if self.double_q:
-                next_sub_q, tau_log_pi_next = q_log_pi(
-                    self.get_q(params, nxtobses, key), self.munchausen_entropy_tau
-                )
-            else:
-                next_sub_q, tau_log_pi_next = q_log_pi(next_q, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(next_action_q, self.munchausen_entropy_tau)
             pi_next = jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau)
             next_vals = jnp.sum(pi_next * (next_q - tau_log_pi_next), axis=1, keepdims=True)
 
-            if self.double_q:
-                q_k_targets = self.get_q(params, obses, key)
-            else:
-                q_k_targets = self.get_q(target_params, obses, key)
+            q_k_targets = self.get_q(action_params, obses, key)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, actions, axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.argmax(self.get_q(params, nxtobses, key), axis=1, keepdims=True)
-            else:
-                next_actions = jnp.argmax(next_q, axis=1, keepdims=True)
+            next_actions = jnp.argmax(next_action_q, axis=1, keepdims=True)
             next_vals = jnp.take_along_axis(next_q, next_actions, axis=1)
         return (not_terminateds * next_vals * self._gamma) + rewards

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -462,18 +462,17 @@ class Q_Network_Family:
             and self.n_step_method
             and self.prioritized_replay
         ):
-            run_name = f"Rainbow({self.n_step} step)_" + run_name
-        else:
-            if self.param_noise:
-                run_name = "Noisy_" + run_name
-            if self.dueling_model:
-                run_name = "Dueling_" + run_name
-            if self.double_q:
-                run_name = "Double_" + run_name
-            if self.n_step_method:
-                run_name = f"{self.n_step}Step_" + run_name
-            if self.prioritized_replay:
-                run_name = run_name + "+PER"
+            return f"Rainbow({self.n_step} step)_" + run_name
+        if self.param_noise:
+            run_name = "Noisy_" + run_name
+        if self.dueling_model:
+            run_name = "Dueling_" + run_name
+        if self.double_q:
+            run_name = "Double_" + run_name
+        if self.n_step_method:
+            run_name = f"{self.n_step}Step_" + run_name
+        if self.prioritized_replay:
+            run_name = run_name + "+PER"
         return run_name
 
     def learn(

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -233,8 +233,8 @@ class Q_Network_Family:
             env_info = self.env.get_info()
             if "autoreset_steps" in env_info:
                 self.autoreset_steps = env_info["autoreset_steps"]
-                if not isinstance(self.autoreset_steps, bool):
-                    raise TypeError("Environment autoreset_steps must be a bool")
+        if not isinstance(self.autoreset_steps, bool):
+            raise TypeError("Environment autoreset_steps must be a bool")
         print("observation size : ", self.observation_space)
         print("action size : ", self.action_size)
         print("worker_size : ", self.worker_size)

--- a/jax_baselines/DQN/dqn.py
+++ b/jax_baselines/DQN/dqn.py
@@ -102,29 +102,20 @@ class DQN(Q_Network_Family):
         key,
     ):
         next_q = self.get_q(target_params, nxtobses, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = self.get_q(action_params, nxtobses, key) if self.double_q else next_q
 
         if self.munchausen:
-            if self.double_q:
-                next_sub_q, tau_log_pi_next = q_log_pi(
-                    self.get_q(params, nxtobses, key), self.munchausen_entropy_tau
-                )
-            else:
-                next_sub_q, tau_log_pi_next = q_log_pi(next_q, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(next_action_q, self.munchausen_entropy_tau)
             pi_next = jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau)
             next_vals = jnp.sum(pi_next * (next_q - tau_log_pi_next), axis=1, keepdims=True)
 
-            if self.double_q:
-                q_k_targets = self.get_q(params, obses, key)
-            else:
-                q_k_targets = self.get_q(target_params, obses, key)
+            q_k_targets = self.get_q(action_params, obses, key)
             _, clipped_tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(clipped_tau_log_pi, actions, axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.argmax(self.get_q(params, nxtobses, key), axis=1, keepdims=True)
-            else:
-                next_actions = jnp.argmax(next_q, axis=1, keepdims=True)
+            next_actions = jnp.argmax(next_action_q, axis=1, keepdims=True)
             next_vals = jnp.take_along_axis(next_q, next_actions, axis=1)
         return (not_terminateds * next_vals * self._gamma) + rewards

--- a/jax_baselines/DQN/training.py
+++ b/jax_baselines/DQN/training.py
@@ -198,13 +198,14 @@ class QNetTrainingLifecycle:
 
     def _log_report(self, report, steps, logger_run, log_interval):
         interval = self.agent.log_interval if log_interval is None else log_interval
-        if logger_run and (steps - self.agent._last_log_step >= interval):
-            self.agent._last_log_step = steps
-            metrics = report.metrics
-            if self.agent.reward_normalizer is not None:
-                metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
-            metrics, histograms = jax.device_get((metrics, report.histograms))
-            for metric_name, metric_value in metrics.items():
-                logger_run.log_metric(metric_name, metric_value, steps)
-            for histogram_name, histogram_value in histograms.items():
-                logger_run.log_histogram(histogram_name, histogram_value, steps)
+        if not (logger_run and steps - self.agent._last_log_step >= interval):
+            return
+        self.agent._last_log_step = steps
+        metrics = report.metrics
+        if self.agent.reward_normalizer is not None:
+            metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
+        metrics, histograms = jax.device_get((metrics, report.histograms))
+        for metric_name, metric_value in metrics.items():
+            logger_run.log_metric(metric_name, metric_value, steps)
+        for histogram_name, histogram_value in histograms.items():
+            logger_run.log_histogram(histogram_name, histogram_value, steps)

--- a/jax_baselines/FQF/fqf.py
+++ b/jax_baselines/FQF/fqf.py
@@ -368,10 +368,11 @@ class FQF(Q_Network_Family):
             _tau_hats,
             key,
         )
+        action_params = params if self.double_q else target_params
 
         if self.double_q:
             next_q = self.get_q(
-                params,
+                action_params,
                 online_feature,
                 _tau,
                 _tau_hats,
@@ -390,12 +391,8 @@ class FQF(Q_Network_Family):
             )  # batch x actions x support
             next_vals = jnp.sum(pi_next * next_vals, axis=1)
 
-            if self.double_q:
-                feature = self.preproc(params, key, obses)
-                q_k_targets = self.get_q(params, feature, taus, tau_hats, key)
-            else:
-                feature = self.preproc(target_params, key, obses)
-                q_k_targets = self.get_q(target_params, feature, taus, tau_hats, key)
+            feature = self.preproc(action_params, key, obses)
+            q_k_targets = self.get_q(action_params, feature, taus, tau_hats, key)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, jnp.squeeze(actions, axis=2), axis=1)
 

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -130,26 +130,18 @@ class IMPALA_Family:
     def get_logprob_discrete(self, prob, action, key, out_prob=False):
         prob = jnp.clip(jax.nn.softmax(prob), 1e-5, 1.0)
         action = action.astype(jnp.int32)
-        if out_prob:
-            return prob, jnp.log(jnp.take_along_axis(prob, action, axis=1))
-        else:
-            return jnp.log(jnp.take_along_axis(prob, action, axis=1))
+        log_prob = jnp.log(jnp.take_along_axis(prob, action, axis=1))
+        return (prob, log_prob) if out_prob else log_prob
 
     def get_logprob_continuous(self, prob, action, key, out_prob=False):
         mu, log_std = prob
         std = jnp.exp(log_std)
-        if out_prob:
-            return prob, -(
-                0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
-                + jnp.sum(log_std, axis=-1, keepdims=True)
-                + 0.5 * jnp.log(2 * jnp.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
-            )
-        else:
-            return -(
-                0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
-                + jnp.sum(log_std, axis=-1, keepdims=True)
-                + 0.5 * jnp.log(2 * jnp.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
-            )
+        log_prob = -(
+            0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
+            + jnp.sum(log_std, axis=-1, keepdims=True)
+            + 0.5 * jnp.log(2 * jnp.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
+        )
+        return (prob, log_prob) if out_prob else log_prob
 
     def _compute_vtrace(
         self, pi_prob, mu_log_prob, rewards, terminateds, truncateds, value, next_value

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -52,11 +52,12 @@ class IMPALA_Family:
         worker_replay_factory: WorkerReplayBufferFactory | None = None,
         checkpoint_store: CheckpointStore | None = None,
     ):
-        if use_entropy_adv_shaping:
-            if not np.isfinite(ent_coef) or ent_coef < 0:
-                raise ValueError("entropy shaping requires finite ent_coef >= 0")
-            if not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1:
-                raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
+        if use_entropy_adv_shaping and (not np.isfinite(ent_coef) or ent_coef < 0):
+            raise ValueError("entropy shaping requires finite ent_coef >= 0")
+        if use_entropy_adv_shaping and (
+            not np.isfinite(entropy_adv_shaping_kappa) or entropy_adv_shaping_kappa <= 1
+        ):
+            raise ValueError("entropy shaping requires finite entropy_adv_shaping_kappa > 1")
         self.workers = workers
         self.model_builder_maker = model_builder_maker
         self.worker_replay_factory = worker_replay_factory

--- a/jax_baselines/IMPALA/worker.py
+++ b/jax_baselines/IMPALA/worker.py
@@ -99,14 +99,9 @@ class Impala_Worker(object):
                                 len_label: eplen,
                                 to_label: float(truncated),
                             }
-                            if have_original_reward:
-                                if have_lives:
-                                    if info["lives"] == 0:
-                                        log_dict[original_rw_label] = original_score
-                                        original_score = 0
-                                else:
-                                    log_dict[original_rw_label] = original_score
-                                    original_score = 0
+                            if have_original_reward and (not have_lives or info["lives"] == 0):
+                                log_dict[original_rw_label] = original_score
+                                original_score = 0
                             logger_server.log_worker(log_dict, episode)
                         score = 0
                         eplen = 0

--- a/jax_baselines/IQN/apex_iqn.py
+++ b/jax_baselines/IQN/apex_iqn.py
@@ -265,13 +265,15 @@ class APE_X_IQN(Ape_X_Family):
     ):
         target_tau = jax.random.uniform(key, (self.batch_size, self.n_support))
         next_q = self.get_q(target_params, nxtobses, target_tau, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = (
+            self.get_q(action_params, nxtobses, target_tau, key) if self.double_q else next_q
+        )
 
         if self.munchausen:
-            if self.double_q:
-                next_q_mean = jnp.mean(self.get_q(params, nxtobses, target_tau, key), axis=2)
-            else:
-                next_q_mean = jnp.mean(next_q, axis=2)
-            next_sub_q, tau_log_pi_next = q_log_pi(next_q_mean, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(
+                jnp.mean(next_action_q, axis=2), self.munchausen_entropy_tau
+            )
             pi_next = jnp.expand_dims(
                 jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau), axis=2
             )
@@ -280,29 +282,15 @@ class APE_X_IQN(Ape_X_Family):
             )  # batch x actions x support
             next_vals = jnp.sum(pi_next * next_vals, axis=1)
 
-            if self.double_q:
-                q_k_targets = jnp.mean(self.get_q(params, obses, target_tau, key), axis=2)
-            else:
-                q_k_targets = jnp.mean(self.get_q(target_params, obses, target_tau, key), axis=2)
+            q_k_targets = jnp.mean(self.get_q(action_params, obses, target_tau, key), axis=2)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, jnp.squeeze(actions, axis=2), axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.argmax(
-                    jnp.mean(
-                        self.get_q(params, nxtobses, target_tau, key),
-                        axis=2,
-                        keepdims=True,
-                    ),
-                    axis=1,
-                    keepdims=True,
-                )
-            else:
-                next_actions = jnp.argmax(
-                    jnp.mean(next_q, axis=2, keepdims=True), axis=1, keepdims=True
-                )
+            next_actions = jnp.argmax(
+                jnp.mean(next_action_q, axis=2, keepdims=True), axis=1, keepdims=True
+            )
             next_vals = jnp.squeeze(
                 jnp.take_along_axis(next_q, next_actions, axis=1)
             )  # batch x support

--- a/jax_baselines/IQN/iqn.py
+++ b/jax_baselines/IQN/iqn.py
@@ -207,13 +207,15 @@ class IQN(Q_Network_Family):
     ):
         target_tau = jax.random.uniform(key, (self.batch_size, self.n_support))
         next_q = self.get_q(target_params, nxtobses, target_tau, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = (
+            self.get_q(action_params, nxtobses, target_tau, key) if self.double_q else next_q
+        )
 
         if self.munchausen:
-            if self.double_q:
-                next_q_mean = jnp.mean(self.get_q(params, nxtobses, target_tau, key), axis=2)
-            else:
-                next_q_mean = jnp.mean(next_q, axis=2)
-            next_sub_q, tau_log_pi_next = q_log_pi(next_q_mean, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(
+                jnp.mean(next_action_q, axis=2), self.munchausen_entropy_tau
+            )
             pi_next = jnp.expand_dims(
                 jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau), axis=2
             )  # batch x actions x 1
@@ -222,29 +224,15 @@ class IQN(Q_Network_Family):
             )  # batch x actions x support
             next_vals = jnp.sum(pi_next * next_vals, axis=1)
 
-            if self.double_q:
-                q_k_targets = jnp.mean(self.get_q(params, obses, target_tau, key), axis=2)
-            else:
-                q_k_targets = jnp.mean(self.get_q(target_params, obses, target_tau, key), axis=2)
+            q_k_targets = jnp.mean(self.get_q(action_params, obses, target_tau, key), axis=2)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, jnp.squeeze(actions, axis=2), axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.argmax(
-                    jnp.mean(
-                        self.get_q(params, nxtobses, target_tau, key),
-                        axis=2,
-                        keepdims=True,
-                    ),
-                    axis=1,
-                    keepdims=True,
-                )
-            else:
-                next_actions = jnp.argmax(
-                    jnp.mean(next_q, axis=2, keepdims=True), axis=1, keepdims=True
-                )
+            next_actions = jnp.argmax(
+                jnp.mean(next_action_q, axis=2, keepdims=True), axis=1, keepdims=True
+            )
             next_vals = jnp.squeeze(
                 jnp.take_along_axis(next_q, next_actions, axis=1)
             )  # batch x support

--- a/jax_baselines/QRDQN/apex_qrdqn.py
+++ b/jax_baselines/QRDQN/apex_qrdqn.py
@@ -294,13 +294,13 @@ class APE_X_QRDQN(Ape_X_Family):
         key,
     ):
         next_q = self.get_q(target_params, nxtobses, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = self.get_q(action_params, nxtobses, key) if self.double_q else next_q
 
         if self.munchausen:
-            if self.double_q:
-                next_q_mean = jnp.mean(self.get_q(params, nxtobses, key), axis=2)
-            else:
-                next_q_mean = jnp.mean(next_q, axis=2)
-            next_sub_q, tau_log_pi_next = q_log_pi(next_q_mean, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(
+                jnp.mean(next_action_q, axis=2), self.munchausen_entropy_tau
+            )
             pi_next = jnp.expand_dims(
                 jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau), axis=2
             )  # batch x actions x 1
@@ -309,24 +309,15 @@ class APE_X_QRDQN(Ape_X_Family):
             )  # batch x actions x support
             next_vals = jnp.sum(pi_next * next_vals, axis=1)
 
-            if self.double_q:
-                q_k_targets = jnp.mean(self.get_q(params, obses, key), axis=2)
-            else:
-                q_k_targets = jnp.mean(self.get_q(target_params, obses, key), axis=2)
+            q_k_targets = jnp.mean(self.get_q(action_params, obses, key), axis=2)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, jnp.squeeze(actions, axis=2), axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.expand_dims(
-                    jnp.argmax(jnp.mean(self.get_q(params, nxtobses, key), axis=2), axis=1),
-                    axis=(1, 2),
-                )
-            else:
-                next_actions = jnp.expand_dims(
-                    jnp.argmax(jnp.mean(next_q, axis=2), axis=1), axis=(1, 2)
-                )
+            next_actions = jnp.expand_dims(
+                jnp.argmax(jnp.mean(next_action_q, axis=2), axis=1), axis=(1, 2)
+            )
             next_vals = jnp.squeeze(
                 jnp.take_along_axis(next_q, next_actions, axis=1)
             )  # batch x support

--- a/jax_baselines/QRDQN/qrdqn.py
+++ b/jax_baselines/QRDQN/qrdqn.py
@@ -202,13 +202,13 @@ class QRDQN(Q_Network_Family):
         key,
     ):
         next_q = self.get_q(target_params, nxtobses, key)
+        action_params = params if self.double_q else target_params
+        next_action_q = self.get_q(action_params, nxtobses, key) if self.double_q else next_q
 
         if self.munchausen:
-            if self.double_q:
-                next_q_mean = jnp.mean(self.get_q(params, nxtobses, key), axis=2)
-            else:
-                next_q_mean = jnp.mean(next_q, axis=2)
-            next_sub_q, tau_log_pi_next = q_log_pi(next_q_mean, self.munchausen_entropy_tau)
+            next_sub_q, tau_log_pi_next = q_log_pi(
+                jnp.mean(next_action_q, axis=2), self.munchausen_entropy_tau
+            )
             pi_next = jnp.expand_dims(
                 jax.nn.softmax(next_sub_q / self.munchausen_entropy_tau), axis=2
             )  # batch x actions x 1
@@ -217,25 +217,15 @@ class QRDQN(Q_Network_Family):
             )  # batch x actions x support
             next_vals = jnp.sum(pi_next * next_vals, axis=1)
 
-            if self.double_q:
-                q_k_targets = jnp.mean(self.get_q(params, obses, key), axis=2)
-            else:
-                q_k_targets = jnp.mean(self.get_q(target_params, obses, key), axis=2)
+            q_k_targets = jnp.mean(self.get_q(action_params, obses, key), axis=2)
             _, tau_log_pi = q_log_pi(q_k_targets, self.munchausen_entropy_tau, clip=True)
             munchausen_addon = jnp.take_along_axis(tau_log_pi, jnp.squeeze(actions, axis=2), axis=1)
 
             rewards = rewards + self.munchausen_alpha * munchausen_addon
         else:
-            if self.double_q:
-                next_actions = jnp.argmax(
-                    jnp.mean(self.get_q(params, nxtobses, key), axis=2, keepdims=True),
-                    axis=1,
-                    keepdims=True,
-                )
-            else:
-                next_actions = jnp.argmax(
-                    jnp.mean(next_q, axis=2, keepdims=True), axis=1, keepdims=True
-                )
+            next_actions = jnp.argmax(
+                jnp.mean(next_action_q, axis=2, keepdims=True), axis=1, keepdims=True
+            )
             next_vals = jnp.squeeze(
                 jnp.take_along_axis(next_q, next_actions, axis=1)
             )  # batch x support

--- a/jax_baselines/core/bulk_training.py
+++ b/jax_baselines/core/bulk_training.py
@@ -48,20 +48,22 @@ def bulk_chunk_plan(gradient_steps, buckets):
         scalar_counts[steps] = scalar_counts[steps - 1] + 1
 
         for bucket in buckets:
-            if bucket <= steps:
-                candidate_calls = calls[steps - bucket] + 1
-                candidate_scalars = scalar_counts[steps - bucket]
-                if _is_better_chunk_plan(
-                    candidate_calls,
-                    candidate_scalars,
-                    bucket,
-                    calls[steps],
-                    scalar_counts[steps],
-                    first_chunks[steps],
-                ):
-                    calls[steps] = candidate_calls
-                    scalar_counts[steps] = candidate_scalars
-                    first_chunks[steps] = bucket
+            if bucket > steps:
+                continue
+            candidate_calls = calls[steps - bucket] + 1
+            candidate_scalars = scalar_counts[steps - bucket]
+            if not _is_better_chunk_plan(
+                candidate_calls,
+                candidate_scalars,
+                bucket,
+                calls[steps],
+                scalar_counts[steps],
+                first_chunks[steps],
+            ):
+                continue
+            calls[steps] = candidate_calls
+            scalar_counts[steps] = candidate_scalars
+            first_chunks[steps] = bucket
 
     chunks = []
     remaining = gradient_steps

--- a/jax_baselines/core/env_info.py
+++ b/jax_baselines/core/env_info.py
@@ -155,20 +155,17 @@ def get_worker_env_info(workers, worker_info, include_action_type=False):
     Returns:
         observation_space, action_size, env_type [, action_type]
     """
-    if isinstance(workers, list):
-        env_dict = worker_info(workers[0])
-        env_info = _require_env_info(env_dict)
-        observation_space = env_info["observation_space"]
-        action_size = env_info["action_size"]
-        action_type = env_info["action_type"]
-        env_type = _validate_core_env_type(env_info)
-
-        if include_action_type:
-            return observation_space, action_size, env_type, action_type
-        else:
-            return observation_space, action_size, env_type
-    else:
+    if not isinstance(workers, list):
         raise ValueError("Invalid workers type")
+    env_info = _require_env_info(worker_info(workers[0]))
+    observation_space = env_info["observation_space"]
+    action_size = env_info["action_size"]
+    action_type = env_info["action_type"]
+    env_type = _validate_core_env_type(env_info)
+
+    if include_action_type:
+        return observation_space, action_size, env_type, action_type
+    return observation_space, action_size, env_type
 
 
 def infer_action_meta(action_type):

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -22,37 +22,6 @@ def extract_original_reward(info):
     return None
 
 
-def _extract_vector_info_values(infos, worker_size, key, dtype):
-    values = np.zeros(worker_size, dtype=np.float64)
-    present = np.zeros(worker_size, dtype=bool)
-
-    if isinstance(infos, dict):
-        if key not in infos:
-            return values, present
-        raw = np.asarray(infos[key], dtype=dtype)
-        if raw.shape == ():
-            raw = np.full(worker_size, raw.item(), dtype=dtype)
-        else:
-            raw = raw.reshape(-1)
-        count = min(worker_size, raw.shape[0])
-        values[:count] = raw[:count]
-        mask = infos.get(f"_{key}")
-        if mask is None:
-            present[:count] = True
-        else:
-            present[:count] = np.asarray(mask, dtype=bool).reshape(-1)[:count]
-        return values, present
-
-    if isinstance(infos, (list, tuple)):
-        for idx, info in enumerate(infos[:worker_size]):
-            if isinstance(info, dict) and key in info:
-                values[idx] = info[key]
-                present[idx] = True
-        return values, present
-
-    return values, present
-
-
 def extract_vector_original_rewards(infos, worker_size):
     """Return per-worker original rewards and a presence mask from vector infos.
 
@@ -60,7 +29,29 @@ def extract_vector_original_rewards(infos, worker_size):
     expose one info dict per worker. Supporting both shapes keeps rollout
     logging independent from the vector backend.
     """
-    return _extract_vector_info_values(infos, worker_size, "original_reward", np.float64)
+    values = np.zeros(worker_size, dtype=np.float64)
+    present = np.zeros(worker_size, dtype=bool)
+    if isinstance(infos, (list, tuple)):
+        for idx, info in enumerate(infos[:worker_size]):
+            if not isinstance(info, dict) or "original_reward" not in info:
+                continue
+            values[idx] = info["original_reward"]
+            present[idx] = True
+        return values, present
+    if not isinstance(infos, dict) or "original_reward" not in infos:
+        return values, present
+    raw = np.asarray(infos["original_reward"], dtype=np.float64)
+    if raw.shape == ():
+        raw = np.full(worker_size, raw.item(), dtype=np.float64)
+    else:
+        raw = raw.reshape(-1)
+    count = min(worker_size, raw.shape[0])
+    values[:count] = raw[:count]
+    if "_original_reward" not in infos or infos["_original_reward"] is None:
+        present[:count] = True
+        return values, present
+    present[:count] = np.asarray(infos["_original_reward"], dtype=bool).reshape(-1)[:count]
+    return values, present
 
 
 def log_measurement(

--- a/jax_baselines/core/rollout.py
+++ b/jax_baselines/core/rollout.py
@@ -447,17 +447,16 @@ class RolloutEngine:
                     if advance and not ckpt_success:
                         monitor_failed = True
                     emit_original = original_present[idx] and real_reset[idx]
-                    if active[idx]:
-                        spec.record_rollout_episode(
-                            steps,
-                            episode_reward=float(scores[idx]),
-                            episode_length=int(eplens[idx]),
-                            timeout=float(truncateds[idx]),
-                            original_reward=(float(originals[idx]) if emit_original else None),
-                        )
+                    spec.record_rollout_episode(
+                        steps,
+                        episode_reward=float(scores[idx]),
+                        episode_length=int(eplens[idx]),
+                        timeout=float(truncateds[idx]),
+                        original_reward=(float(originals[idx]) if emit_original else None),
+                    )
                     scores[idx] = 0.0
                     eplens[idx] = 0
-                    if active[idx] and emit_original:
+                    if emit_original:
                         originals[idx] = 0.0
                         original_present[idx] = False
 

--- a/model_builder/flax/Module.py
+++ b/model_builder/flax/Module.py
@@ -256,34 +256,33 @@ class BatchReNorm(Module):
             "batch_stats", "var", lambda s: jnp.ones(s, jnp.float32), feature_shape
         )
 
+        initializing = self.is_initializing()
         if use_running_average:
             mean, var = ra_mean.value, ra_var.value
-            custom_mean = mean
-            custom_var = var
         else:
             mean, var = _compute_stats(
                 x,
                 reduction_axes,
                 dtype=self.dtype,
-                axis_name=self.axis_name if not self.is_initializing() else None,
+                axis_name=self.axis_name if not initializing else None,
                 axis_index_groups=self.axis_index_groups,
                 use_fast_variance=self.use_fast_variance,
             )
-            custom_mean = mean
-            custom_var = var
-            if not self.is_initializing():
-                # The code below is implemented following the Batch Renormalization paper
-                std = jnp.sqrt(var + self.epsilon)
-                ra_std = jnp.sqrt(ra_var.value + self.epsilon)
-                r = jnp.clip(std / ra_std, 1 / self.r_max, self.r_max)
-                r = lax.stop_gradient(r)
-                d = jnp.clip((mean - ra_mean.value) / ra_std, -self.d_max, self.d_max)
-                d = lax.stop_gradient(d)
-                custom_mean = mean - (std * d / r)
-                custom_var = (var + self.epsilon) / (r * r) - self.epsilon
+        custom_mean = mean
+        custom_var = var
+        if not use_running_average and not initializing:
+            # The code below is implemented following the Batch Renormalization paper
+            std = jnp.sqrt(var + self.epsilon)
+            ra_std = jnp.sqrt(ra_var.value + self.epsilon)
+            r = jnp.clip(std / ra_std, 1 / self.r_max, self.r_max)
+            r = lax.stop_gradient(r)
+            d = jnp.clip((mean - ra_mean.value) / ra_std, -self.d_max, self.d_max)
+            d = lax.stop_gradient(d)
+            custom_mean = mean - (std * d / r)
+            custom_var = (var + self.epsilon) / (r * r) - self.epsilon
 
-                ra_mean.value = self.momentum * ra_mean.value + (1 - self.momentum) * mean
-                ra_var.value = self.momentum * ra_var.value + (1 - self.momentum) * var
+            ra_mean.value = self.momentum * ra_mean.value + (1 - self.momentum) * mean
+            ra_var.value = self.momentum * ra_var.value + (1 - self.momentum) * var
 
         return _normalize(
             self,

--- a/model_builder/flax/qnet/c51_builder.py
+++ b/model_builder/flax/qnet/c51_builder.py
@@ -42,34 +42,25 @@ class Model(nn.Module):
                 ]
             )(feature)
             return jax.nn.softmax(q_net, axis=2)
-        else:
-            v = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(self.categorial_bar_n, kernel_init=clip_factorized_uniform(0.01)),
-                    lambda x: jnp.reshape(x, (x.shape[0], 1, self.categorial_bar_n)),
-                ]
-            )(feature)
-            a = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(
-                        self.action_size[0] * self.categorial_bar_n,
-                        kernel_init=clip_factorized_uniform(0.01),
-                    ),
-                    lambda x: jnp.reshape(
-                        x, (x.shape[0], self.action_size[0], self.categorial_bar_n)
-                    ),
-                ]
-            )(feature)
-            q = v + a - jnp.mean(a, axis=1, keepdims=True)
-            return jax.nn.softmax(q, axis=2)
+        v = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(self.categorial_bar_n, kernel_init=clip_factorized_uniform(0.01)),
+                lambda x: jnp.reshape(x, (x.shape[0], 1, self.categorial_bar_n)),
+            ]
+        )(feature)
+        a = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(
+                    self.action_size[0] * self.categorial_bar_n,
+                    kernel_init=clip_factorized_uniform(0.01),
+                ),
+                lambda x: jnp.reshape(x, (x.shape[0], self.action_size[0], self.categorial_bar_n)),
+            ]
+        )(feature)
+        q = v + a - jnp.mean(a, axis=1, keepdims=True)
+        return jax.nn.softmax(q, axis=2)
 
 
 def model_builder_maker(
@@ -107,7 +98,6 @@ def model_builder_maker(
             params = model.init(key, observation)
             print_flax_model_summary(print_model, key, (model, observation))
             return preproc_fn, model_fn, params
-        else:
-            return preproc_fn, model_fn
+        return preproc_fn, model_fn
 
     return model_builder

--- a/model_builder/flax/qnet/dqn_builder.py
+++ b/model_builder/flax/qnet/dqn_builder.py
@@ -33,22 +33,15 @@ class Model(nn.Module):
                 + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(0.01))]
             )(feature)
             return q_net
-        else:
-            v = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [self.layer(1, kernel_init=clip_factorized_uniform(0.01))]
-            )(feature)
-            a = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(0.01))]
-            )(feature)
-            return v + a - jnp.mean(a, axis=1, keepdims=True)
+        v = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [self.layer(1, kernel_init=clip_factorized_uniform(0.01))]
+        )(feature)
+        a = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(0.01))]
+        )(feature)
+        return v + a - jnp.mean(a, axis=1, keepdims=True)
 
 
 def model_builder_maker(observation_space, action_space, dueling_model, param_noise, policy_kwargs):
@@ -80,7 +73,6 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
             params = model.init(key, observation)
             print_flax_model_summary(print_model, key, (model, observation))
             return preproc_fn, model_fn, params
-        else:
-            return preproc_fn, model_fn
+        return preproc_fn, model_fn
 
     return model_builder

--- a/model_builder/flax/qnet/iqn_builder.py
+++ b/model_builder/flax/qnet/iqn_builder.py
@@ -48,23 +48,22 @@ class Model(nn.Module):
                     + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))]
                 )(mul_embedding)
                 return q_net
-            else:
-                v = nn.Sequential(
-                    [
-                        self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                        for i in range(2 * self.hidden_n)
-                    ]
-                    + [self.layer(1, kernel_init=clip_factorized_uniform(3))]
-                )(mul_embedding)
-                a = nn.Sequential(
-                    [
-                        self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                        for i in range(2 * self.hidden_n)
-                    ]
-                    + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))]
-                )(mul_embedding)
-                q = v + a - jnp.mean(a, axis=1, keepdims=True)
-                return q
+            v = nn.Sequential(
+                [
+                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
+                    for i in range(2 * self.hidden_n)
+                ]
+                + [self.layer(1, kernel_init=clip_factorized_uniform(3))]
+            )(mul_embedding)
+            a = nn.Sequential(
+                [
+                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
+                    for i in range(2 * self.hidden_n)
+                ]
+                + [self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))]
+            )(mul_embedding)
+            q = v + a - jnp.mean(a, axis=1, keepdims=True)
+            return q
 
         out = jax.vmap(qnet, in_axes=(None, 2), out_axes=2)(
             feature, costau
@@ -104,7 +103,6 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
             params = model.init(key, observation, tau)
             print_flax_model_summary(print_model, key, (model, observation, tau))
             return preproc_fn, model_fn, params
-        else:
-            return preproc_fn, model_fn
+        return preproc_fn, model_fn
 
     return model_builder

--- a/model_builder/flax/qnet/qrdqn_builder.py
+++ b/model_builder/flax/qnet/qrdqn_builder.py
@@ -40,35 +40,28 @@ class Model(nn.Module):
                 ]
             )(feature)
             return q_net
-        else:
-            v = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(
-                        self.support_n,
-                        kernel_init=clip_factorized_uniform(3 / self.support_n),
-                    ),
-                    lambda x: jnp.reshape(x, (x.shape[0], 1, self.support_n)),
-                ]
-            )(feature)
-            a = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(
-                        self.action_size[0] * self.support_n,
-                        kernel_init=clip_factorized_uniform(3 / self.support_n),
-                    ),
-                    lambda x: jnp.reshape(x, (x.shape[0], self.action_size[0], self.support_n)),
-                ]
-            )(feature)
-            q = v + a - jnp.mean(a, axis=1, keepdims=True)
-            return q
+        v = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(
+                    self.support_n,
+                    kernel_init=clip_factorized_uniform(3 / self.support_n),
+                ),
+                lambda x: jnp.reshape(x, (x.shape[0], 1, self.support_n)),
+            ]
+        )(feature)
+        a = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(
+                    self.action_size[0] * self.support_n,
+                    kernel_init=clip_factorized_uniform(3 / self.support_n),
+                ),
+                lambda x: jnp.reshape(x, (x.shape[0], self.action_size[0], self.support_n)),
+            ]
+        )(feature)
+        q = v + a - jnp.mean(a, axis=1, keepdims=True)
+        return q
 
 
 def model_builder_maker(
@@ -106,7 +99,6 @@ def model_builder_maker(
             params = model.init(key, observation)
             print_flax_model_summary(print_model, key, (model, observation))
             return preproc_fn, model_fn, params
-        else:
-            return preproc_fn, model_fn
+        return preproc_fn, model_fn
 
     return model_builder

--- a/model_builder/flax/qnet/spr_modules.py
+++ b/model_builder/flax/qnet/spr_modules.py
@@ -111,32 +111,25 @@ class Model(nn.Module):
                 ]
             )(feature)
             return jax.nn.softmax(q_net, axis=2)
-        else:
-            v = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(self.categorial_bar_n, kernel_init=clip_factorized_uniform(0.01)),
-                    lambda x: jnp.reshape(x, (-1, 1, self.categorial_bar_n)),
-                ]
-            )(feature)
-            a = nn.Sequential(
-                [
-                    self.layer(self.node) if i % 2 == 0 else jax.nn.relu
-                    for i in range(2 * self.hidden_n)
-                ]
-                + [
-                    self.layer(
-                        self.action_size[0] * self.categorial_bar_n,
-                        kernel_init=clip_factorized_uniform(0.01),
-                    ),
-                    lambda x: jnp.reshape(x, (-1, self.action_size[0], self.categorial_bar_n)),
-                ]
-            )(feature)
-            q = v + a - jnp.mean(a, axis=1, keepdims=True)
-            return jax.nn.softmax(q, axis=-1)
+        v = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(self.categorial_bar_n, kernel_init=clip_factorized_uniform(0.01)),
+                lambda x: jnp.reshape(x, (-1, 1, self.categorial_bar_n)),
+            ]
+        )(feature)
+        a = nn.Sequential(
+            [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
+            + [
+                self.layer(
+                    self.action_size[0] * self.categorial_bar_n,
+                    kernel_init=clip_factorized_uniform(0.01),
+                ),
+                lambda x: jnp.reshape(x, (-1, self.action_size[0], self.categorial_bar_n)),
+            ]
+        )(feature)
+        q = v + a - jnp.mean(a, axis=1, keepdims=True)
+        return jax.nn.softmax(q, axis=-1)
 
 
 def make_spr_style_builder_maker(
@@ -213,7 +206,6 @@ def make_spr_style_builder_maker(
             params = model.init(key, observation, action)
             print_flax_model_summary(print_model, key, (model, observation, action))
             return preproc_fn, model_fn, transition_fn, projection_fn, prediction_fn, params
-        else:
-            return preproc_fn, model_fn, transition_fn, projection_fn, prediction_fn
+        return preproc_fn, model_fn, transition_fn, projection_fn, prediction_fn
 
     return model_builder

--- a/replay_memory/cpprb_buffers.py
+++ b/replay_memory/cpprb_buffers.py
@@ -227,22 +227,24 @@ class NstepReplayBuffer(ReplayBuffer):
             self.obsdict, self.nextobsdict, env_nextobsdict, action_space, n_step, gamma
         )
 
-        if worker_size > 1:
-            self.buffer = self._create_central_buffer(size, central_env_dict, comp_kw)
-            # ponytail: row isolation preserves immediate sampling;
-            # per-worker central buffers if compression ratio matters.
-            self._isolate_multiworker_steps = bool(comp_kw)
-            if n_step == 1:
-                self.add = self.multiworker_single_step_add
-            else:
-                self._local_capacity = n_step + 1
-                self.local_buffers = [
-                    cpprb.ReplayBuffer(self._local_capacity, env_dict=local_env_dict, Nstep=n_s)
-                    for _ in range(worker_size)
-                ]
-                self.add = self.multiworker_add
-        else:
+        if worker_size <= 1:
             self.buffer = self._create_central_buffer(size, central_env_dict, comp_kw, n_s=n_s)
+            return
+
+        self.buffer = self._create_central_buffer(size, central_env_dict, comp_kw)
+        # ponytail: row isolation preserves immediate sampling;
+        # per-worker central buffers if compression ratio matters.
+        self._isolate_multiworker_steps = bool(comp_kw)
+        if n_step == 1:
+            self.add = self.multiworker_single_step_add
+            return
+
+        self._local_capacity = n_step + 1
+        self.local_buffers = [
+            cpprb.ReplayBuffer(self._local_capacity, env_dict=local_env_dict, Nstep=n_s)
+            for _ in range(worker_size)
+        ]
+        self.add = self.multiworker_add
 
     def _create_central_buffer(self, size, env_dict, comp_kw, n_s=None):
         if n_s is not None:

--- a/replay_memory/replay_factory.py
+++ b/replay_memory/replay_factory.py
@@ -132,7 +132,7 @@ def make_replay_buffer(need: LocalReplayNeed):
             buffer_size, observation_space, action_shape_or_n, n_step, gamma, n_frames
         )
 
-    if (
+    if n_step > 1 or (
         compress_memory
         and worker_size > 1
         and n_step == 1
@@ -161,40 +161,15 @@ def make_replay_buffer(need: LocalReplayNeed):
         )
 
     if prioritized:
-        if n_step > 1:
-            return PrioritizedNstepReplayBuffer(
-                buffer_size,
-                observation_space,
-                action_shape_or_n,
-                worker_size,
-                n_step,
-                gamma,
-                alpha,
-                compress_memory,
-                eps,
-            )
-        else:
-            return PrioritizedReplayBuffer(
-                buffer_size,
-                observation_space,
-                alpha,
-                action_shape_or_n,
-                compress_memory,
-                eps,
-            )
-    else:
-        if n_step > 1:
-            return NstepReplayBuffer(
-                buffer_size,
-                observation_space,
-                action_shape_or_n,
-                worker_size,
-                n_step,
-                gamma,
-                compress_memory,
-            )
-        else:
-            return ReplayBuffer(buffer_size, observation_space, action_shape_or_n, compress_memory)
+        return PrioritizedReplayBuffer(
+            buffer_size,
+            observation_space,
+            alpha,
+            action_shape_or_n,
+            compress_memory,
+            eps,
+        )
+    return ReplayBuffer(buffer_size, observation_space, action_shape_or_n, compress_memory)
 
 
 def make_multi_prioritized_buffer(need: SharedPrioritizedReplayNeed):

--- a/tests/test_experiment_env_configs.py
+++ b/tests/test_experiment_env_configs.py
@@ -17,7 +17,7 @@ def test_simulator_extra_is_optional_and_old_stacks_are_removed():
 
 @pytest.mark.parametrize(
     ("filename", "family", "algorithms"),
-    [("pg_mjlab_go1.yaml", "pg", ["PPO", "SPO"]), ("dpg_mjlab_go1.yaml", "dpg", ["SAC"])],
+    [("pg_mjlab_go1.yaml", "pg", ["PPO", "SPO"]), ("dpg_mjlab_go1.yaml", "dpg", ["TQC"])],
 )
 def test_adapter_configs_preserve_actor_and_critic_observations(filename, family, algorithms):
     path = Path("experiments/configs") / filename

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -271,9 +271,16 @@ def test_rollout_reward_normalization_flag_controls_transition_recording(enabled
     assert transitions == expected
 
 
-@pytest.mark.parametrize("vectorized", [False, True])
-@pytest.mark.parametrize("checkpointing", [False, True])
-def test_every_rollout_path_records_reward_normalization_transitions(vectorized, checkpointing):
+@pytest.mark.parametrize(
+    ("vectorized", "learn"),
+    [
+        (False, RolloutEngine.learn_single_env),
+        (False, RolloutEngine.learn_single_env_checkpointing),
+        (True, RolloutEngine.learn_vectorized_env),
+        (True, RolloutEngine.learn_vectorized_env_checkpointing),
+    ],
+)
+def test_every_rollout_path_records_reward_normalization_transitions(vectorized, learn):
     rec = []
     if vectorized:
         env = FakeVecEnv(
@@ -293,17 +300,7 @@ def test_every_rollout_path_records_reward_normalization_transitions(vectorized,
     transitions = []
     runner.spec.reward_normalization = True
     runner.spec.record_transition = lambda *args: transitions.append(args)
-    method = (
-        runner.learn_vectorized_env_checkpointing
-        if vectorized and checkpointing
-        else runner.learn_vectorized_env
-        if vectorized
-        else runner.learn_single_env_checkpointing
-        if checkpointing
-        else runner.learn_single_env
-    )
-
-    method(FakePbar([0]))
+    learn(runner, FakePbar([0]))
 
     assert len(transitions) == 1
 


### PR DESCRIPTION
학습 루프·환경 생성·리플레이·분산 워커에 중첩된 조건과 반복 계산이 있어 정상 실행 경로와 상태 갱신 순서를 파악하기 어려웠습니다. 가드 절과 조기 반환을 적용하고 중복 계산을 정리해 프로덕션 중첩 함수를 **86→67개**, 최대 조건 깊이를 **5→3**으로 줄입니다. 32개 파일에서 순 158행을 줄였으며 독립 작업별로 24개 커밋으로 나눴습니다.

- 환경 메타데이터 검증, replay 선택·초기화, 로깅·우선순위 갱신, SIMBA 정규화와 실행 이름 구성을 평탄화합니다.
- DQN·QRDQN·IQN의 local/APEX 및 FQF에서 double-Q의 action 선택과 Munchausen 타깃 집계를 분리하고, 정책 로그 확률의 중복 계산을 제거합니다.
- CPU rollout의 마스크를 일관된 배열로 유지하고 중복 검사를 제거합니다. CPU 원본 보상 parser의 단일 사용 helper를 인라인하고 bulk 계획의 불가능한 후보를 일찍 제외합니다.
- APE-X·IMPALA의 원본 점수 기록 조건, BatchReNorm의 통계 선택·갱신, 선택한 Flax Q 모델과 실험 CLI의 분기를 정리합니다.
- 기존 rollout 테스트는 실제 실행 메서드를 파라미터로 받도록 정리하고, Go1 YAML의 현재 알고리즘인 TQC에 맞춰 낡은 SAC 기대값을 수정합니다.

정적 알고리즘 선택, CPU/GPU 전송 경계, RNG 소비, 모델 파라미터 경로와 reset·flush·로그 순서를 보존하는 범위입니다. CPU/GPU 보상 스키마 통합이나 reset/checkpoint 상태 전이 재설계는 포함하지 않습니다.

검증 결과:

- 영향 범위의 기존 테스트 **447개 통과**. import 경계 검사 포함.
- DQN·QRDQN·IQN·FQF·CrossQ·TPPO 각각 **1,024 step** 실제 CPU 학습 정상 종료, 유한 loss·평가 결과·저장 파라미터 확인.
- 타깃 112개 경우의 출력·JIT gradient·모델 호출 순서, 코어 4,783개 경우의 결과, 정책·모델 526개 수치 leaf가 변경 전후 정확히 일치.
- 실제 GPU에서 core·off-policy·on-policy 전송 검사 통과. 로깅 시 묶음 host 변환 1회, 로깅 생략 시 0회 유지.
- 저장소 pre-commit 검사 통과. 변경 파일의 Ruff **40→40**, ty **111→111**로 기존 진단은 남아 있으나 새로운 진단이나 억제 규칙은 없습니다.

짧은 학습 및 동등성 검증이며, 장기 학습 성능이나 처리량 향상을 측정한 변경은 아닙니다.
