### PR TITLE
[2/4] FlashSAC 및 MJLab Go1 실행 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python -m pip install -e '.[all]'
 | TD7[^TD7]       | :white_check_mark:(LAP[^LaP]) | :x:                        | :x:                | :heavy_check_mark: | :heavy_check_mark:   |
 | CrossQ[^CrossQ] | :heavy_check_mark:            | :heavy_check_mark:         | :x:                | :heavy_check_mark: | :heavy_check_mark:   |
 | XQC[^XQC]       | :heavy_check_mark:            | :heavy_check_mark:         | :x:                | :x:                | :x:                  |
+| FlashSAC[^FlashSAC] | :x:                       | :heavy_check_mark:         | :x:                | :x:                | :x:                  |
 | BRO[^BRO]:x:    | :x:                           | :x:                        | :x:                | :x:                | :x:                  |
 
 ## Performance Compariton
@@ -169,6 +170,8 @@ score : 9.600, epsilon : 0.010, loss : 0.181 |: 100%|███████| 5000
 [^TD3]: [TD3](https://arxiv.org/abs/1802.09477)
 
 [^SAC]: [SAC](https://arxiv.org/abs/1812.05905)
+
+[^FlashSAC]: [FlashSAC](https://github.com/Holiday-Robot/FlashSAC/tree/87edc9061150ae9e962dd84e6544e27a1554b3ab)
 
 [^DAC]: [DAC](https://arxiv.org/abs/2310.19527)
 

--- a/experiments/cli/dpg.py
+++ b/experiments/cli/dpg.py
@@ -5,9 +5,13 @@ from env_builder.env_builder import get_env_builder
 # isort: on
 from experiments.cli._env import add_env_args, env_builder_kwargs
 from experiments.cli._run import AlgoSpec, FamilyRunner, run_family
-from experiments.optimizers import make_batch_scaled_optimizer_factory
+from experiments.optimizers import (
+    make_batch_scaled_optimizer_factory,
+    make_optimizer_factory,
+)
 from jax_baselines.CrossQ.crossq import CrossQ
 from jax_baselines.DDPG.ddpg import DDPG
+from jax_baselines.FlashSAC.flashsac import FlashSAC
 from jax_baselines.SAC.sac import SAC
 from jax_baselines.TD3.td3 import TD3
 from jax_baselines.TD7.td7 import TD7
@@ -19,6 +23,12 @@ from replay_memory.replay_factory import make_replay_buffer
 def add_args(parser):
     parser.add_argument("--experiment_name", type=str, default="DPG", help="experiment name")
     parser.add_argument("--learning_rate", type=float, default=0.0000625, help="learning rate")
+    parser.add_argument(
+        "--learning_rate_end",
+        type=float,
+        default=None,
+        help="FlashSAC cosine schedule endpoint (default: half the initial rate)",
+    )
     parser.add_argument("--model_lib", type=str, default="flax", help="model lib")
     parser.add_argument("--env", type=str, default="Pendulum-v1", help="environment")
     add_env_args(parser)
@@ -60,6 +70,8 @@ def add_args(parser):
     parser.add_argument("--mixture", type=str, default="truncated", help="mixture type")
     parser.add_argument("--quantile_drop", type=float, default=0.1, help="quantile_drop ratio")
     parser.add_argument("--node", type=int, default=256, help="network node number")
+    parser.add_argument("--actor_node", type=int, default=128, help="FlashSAC actor width")
+    parser.add_argument("--critic_node", type=int, default=256, help="FlashSAC critic width")
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--action_noise", type=float, default=0.1, help="action_noise")
     parser.add_argument("--optimizer", type=str, default="adopt", help="optimaizer")
@@ -98,6 +110,12 @@ def build_env(args):
         args.env,
         **env_builder_kwargs(args),
     )
+    if args.algo == "FlashSAC":
+        return env_builder, {
+            "actor_node": args.actor_node,
+            "critic_node": args.critic_node,
+            "hidden_n": args.hidden_n,
+        }
     policy_kwargs = {
         "node": args.node,
         "hidden_n": args.hidden_n,
@@ -141,8 +159,20 @@ def _common(a):
         "replay_factory": make_replay_buffer,
         "use_checkpointing": a.use_checkpointing,
         "reward_normalization": (
-            a.algo == "XQC" if a.reward_normalization is None else a.reward_normalization
+            a.algo in ("XQC", "FlashSAC")
+            if a.reward_normalization is None
+            else a.reward_normalization
         ),
+    }
+
+
+def _sac(a):
+    return {
+        **_common(a),
+        "target_network_update_tau": a.target_update_tau,
+        "ent_coef": a.ent_coef if a.ent_coef is not None else "auto_0.01",
+        "sigma_target": a.sigma_target,
+        "actor_update_period": a.actor_update_period,
     }
 
 
@@ -161,15 +191,17 @@ ALGOS = {
             "action_noise": a.action_noise,
         },
     ),
-    "SAC": AlgoSpec(
-        SAC,
-        "sac",
+    "SAC": AlgoSpec(SAC, "sac", _sac),
+    "FlashSAC": AlgoSpec(
+        FlashSAC,
+        "flashsac",
         lambda a: {
-            **_common(a),
-            "target_network_update_tau": a.target_update_tau,
-            "ent_coef": a.ent_coef if a.ent_coef is not None else "auto_0.01",
-            "sigma_target": a.sigma_target,
-            "actor_update_period": a.actor_update_period,
+            **_sac(a),
+            "learning_rate_end": (
+                a.learning_rate / 2 if a.learning_rate_end is None else a.learning_rate_end
+            ),
+            "lr_transition_steps": max(1, int(a.steps) // a.train_freq * a.gradient_steps),
+            "optimizer_factory": make_optimizer_factory(a.optimizer, eps=1e-8),
         },
     ),
     "CrossQ": AlgoSpec(

--- a/experiments/configs/flashsac_mjlab_go1.yaml
+++ b/experiments/configs/flashsac_mjlab_go1.yaml
@@ -1,0 +1,38 @@
+family: dpg
+# FlashSAC's IsaacLab recipe, applied to the MJLab Go1 task.
+# https://github.com/Holiday-Robot/FlashSAC/blob/87edc9061150ae9e962dd84e6544e27a1554b3ab/scripts/run_isaaclab.sh
+runtime:
+  device: 0
+base:
+  env: Mjlab-Velocity-Flat-Unitree-Go1
+  env_backend: mjlab
+  env_device: cuda:0
+  env_jax_arrays: true
+  env_reuse_for_eval: true
+  model_lib: flax
+  worker: 1024
+  # train_freq counts transitions across all workers: two updates per vector step.
+  train_freq: 1024
+  gradient_steps: 2
+  steps: 50000896
+  eval_num: 10
+  learning_rate: 0.0003
+  learning_rate_end: 0.00015
+  optimizer: adam
+  memory_backend: gpu
+  buffer_size: 1e7
+  batch: 2048
+  learning_starts: 100000
+  gamma: 0.99
+  n_step: 3
+  actor_node: 128
+  critic_node: 256
+  hidden_n: 2
+  reward_normalization: true
+  target_update_tau: 0.01
+  ent_coef: auto_0.01
+  sigma_target: 0.15
+  actor_update_period: 2
+  seed: 0
+variants:
+  - {algo: FlashSAC, enabled: true}

--- a/jax_baselines/FlashSAC/__init__.py
+++ b/jax_baselines/FlashSAC/__init__.py
@@ -1,0 +1,1 @@
+"""FlashSAC for continuous control."""

--- a/jax_baselines/FlashSAC/flashsac.py
+++ b/jax_baselines/FlashSAC/flashsac.py
@@ -1,0 +1,361 @@
+"""FlashSAC with categorical critics, unit-normalized models and correlated exploration.
+
+Algorithm reference: Holiday-Robot/FlashSAC at 87edc9061150ae9e962dd84e6544e27a1554b3ab.
+Environment, replay, network construction and storage use the existing DPG adapter seams.
+"""
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import optax
+from flax import struct
+
+from jax_baselines.core.normalization import FlashSACRewardNormalizer
+from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.training import DPGTrainReport
+from jax_baselines.math.distributional import categorical_projection
+from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.param_updates import project_unit_norm_params
+from jax_baselines.math.policy_math import entropy_target_from_sigma
+
+
+@struct.dataclass
+class FlashSACCheckpointParams:
+    policy_params: Any
+    critic_params: Any
+    target_critic_params: Any
+    log_ent_coef: Any
+
+
+def sample_policy(mean: jax.Array, log_std: jax.Array, key: jax.Array):
+    noise = jax.random.normal(key, mean.shape)
+    raw_action = mean + jnp.exp(log_std) * noise
+    log_prob = -0.5 * (noise**2 + 2 * log_std + math.log(2 * math.pi))
+    log_prob -= 2 * (math.log(2) - raw_action - jax.nn.softplus(-2 * raw_action))
+    return jnp.tanh(raw_action), jnp.sum(log_prob, axis=-1, keepdims=True)
+
+
+class FlashSAC(Deteministic_Policy_Gradient_Family):
+    _run_name = "FlashSAC"
+    supports_bulk_training = True
+
+    def __init__(
+        self,
+        env_builder: Callable,
+        model_builder_maker: Callable,
+        ent_coef="auto_0.01",
+        sigma_target: float = 0.15,
+        actor_update_period: int = 2,
+        learning_rate: float = 3e-4,
+        learning_rate_end: float = 1.5e-4,
+        lr_transition_steps: int = 97_658,
+        normalized_G_max: float = 5.0,
+        actor_noise_zeta_mu: float = 2.0,
+        actor_noise_zeta_max: int = 16,
+        n_atoms: int = 101,
+        gamma: float = 0.99,
+        n_step: int = 3,
+        target_network_update_tau: float = 0.01,
+        reward_normalization: bool = True,
+        policy_kwargs: dict[str, Any] | None = None,
+        simba: bool = False,
+        simba_v2: bool = False,
+        scaled_by_reset: bool = False,
+        prioritized_replay: bool = False,
+        **kwargs: Any,
+    ):
+        if simba or simba_v2 or scaled_by_reset or prioritized_replay:
+            raise ValueError("FlashSAC requires its unit-normalized model and uniform replay")
+        if actor_update_period < 1 or lr_transition_steps < 1 or n_step < 1 or n_atoms < 2:
+            raise ValueError(
+                "update periods and n_step must be positive; n_atoms must be at least 2"
+            )
+        if not math.isfinite(learning_rate) or learning_rate <= 0:
+            raise ValueError("learning_rate must be finite and positive")
+        if not math.isfinite(learning_rate_end) or not 0 <= learning_rate_end <= learning_rate:
+            raise ValueError("learning_rate_end must be finite and in [0, learning_rate]")
+        if not math.isfinite(normalized_G_max) or normalized_G_max <= 0:
+            raise ValueError("normalized_G_max must be finite and positive")
+        if (
+            actor_noise_zeta_max < 1
+            or not math.isfinite(actor_noise_zeta_mu)
+            or actor_noise_zeta_mu <= 0
+        ):
+            raise ValueError("Zeta exponent and maximum repeat length must be positive")
+        if not 0 <= gamma <= 1 or not 0 < target_network_update_tau <= 1:
+            raise ValueError("gamma must be in [0, 1] and target tau in (0, 1]")
+        self._ent_coef = ent_coef
+        self.actor_update_period = actor_update_period
+        self.learning_rate_end = learning_rate_end
+        self.lr_transition_steps = lr_transition_steps
+        self.n_atoms = n_atoms
+        self.value_min = -normalized_G_max
+        self.value_max = normalized_G_max
+        self.support_delta = 2 * normalized_G_max / (n_atoms - 1)
+        self.value_support = jnp.linspace(self.value_min, self.value_max, n_atoms)
+        self.noise_logits = -actor_noise_zeta_mu * jnp.log(
+            jnp.arange(1, actor_noise_zeta_max + 1, dtype=jnp.float32)
+        )
+        model_options = {} if policy_kwargs is None else dict(policy_kwargs)
+        if "n_atoms" in model_options and model_options["n_atoms"] != n_atoms:
+            raise ValueError("model and critic support must use the same n_atoms")
+        model_options["n_atoms"] = n_atoms
+        super().__init__(
+            env_builder,
+            model_builder_maker,
+            learning_rate=learning_rate,
+            gamma=gamma,
+            n_step=n_step,
+            target_network_update_tau=target_network_update_tau,
+            reward_normalization=reward_normalization,
+            policy_kwargs=model_options,
+            **kwargs,
+        )
+        self.target_entropy = entropy_target_from_sigma(math.prod(self.action_size), sigma_target)
+        if reward_normalization:
+            with jax.default_device(self.memory_device):
+                self.reward_normalizer = FlashSACRewardNormalizer(
+                    self.worker_size, gamma, normalized_G_max
+                )
+
+    def _make_optimizer(self, learning_rate):
+        self.ent_coef_learning_rate = optax.cosine_decay_schedule(
+            learning_rate, self.lr_transition_steps, alpha=self.learning_rate_end / learning_rate
+        )
+        return self.optimizer_factory(self.ent_coef_learning_rate)
+
+    def setup_model(self):
+        (
+            self.preproc,
+            self.actor,
+            self.critic,
+            self.policy_params,
+            self.critic_params,
+        ) = self.model_builder_maker(self.observation_space, self.action_size, self.policy_kwargs)(
+            next(self.key_seq), print_model=True
+        )
+        self.target_critic_params = jax.tree.map(jnp.array, self.critic_params)
+        self.opt_policy_state = self.optimizer.init(self.policy_params["params"])
+        self.opt_critic_state = self.optimizer.init(self.critic_params["params"])
+        self._setup_entropy_coef()
+        self._noise = jnp.zeros((self.worker_size, math.prod(self.action_size)))
+        self._noise_count = jnp.asarray(0, dtype=jnp.int32)
+        self._noise_period = jnp.asarray(0, dtype=jnp.int32)
+        self._compiled_actions = jax.jit(self._get_actions)
+        self._compiled_eval = jax.jit(self._get_eval_actions)
+        self._compiled_updates = jax.jit(self._bulk_scan)
+
+    def checkpoint_params(self):
+        return FlashSACCheckpointParams(
+            self.policy_params,
+            self.critic_params,
+            self.target_critic_params,
+            self.log_ent_coef,
+        )
+
+    def load_checkpoint_params(self, bundle: FlashSACCheckpointParams):
+        self.policy_params = bundle.policy_params
+        self.critic_params = bundle.critic_params
+        self.target_critic_params = bundle.target_critic_params
+        self.log_ent_coef = bundle.log_ent_coef
+        self.opt_policy_state = self.optimizer.init(self.policy_params["params"])
+        self.opt_critic_state = self.optimizer.init(self.critic_params["params"])
+        self.opt_ent_coef_state = self.ent_coef_optimizer.init(self.log_ent_coef)
+        self._noise_count = jnp.asarray(0, dtype=jnp.int32)
+
+    def _policy_action_from_state(self, state, obs, eval, steps):
+        if eval:
+            return self._compiled_eval(state["policy"], obs)
+        actions, self._noise, self._noise_count, self._noise_period = self._compiled_actions(
+            state["policy"],
+            obs,
+            next(self.key_seq),
+            self._noise,
+            self._noise_count,
+            self._noise_period,
+        )
+        return actions
+
+    def _get_actions(self, params, obses, key, noise, count, period):
+        (mean, log_std), _ = self.actor(
+            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
+        )
+        noise_key, period_key = jax.random.split(key)
+        refresh = (count == 0) | (count >= period)
+        noise = jnp.where(refresh, jax.random.normal(noise_key, mean.shape), noise)
+        period = jnp.where(
+            refresh, jax.random.categorical(period_key, self.noise_logits) + 1, period
+        )
+        count = jnp.where(refresh, 0, count) + 1
+        return jnp.tanh(mean + jnp.exp(log_std) * noise), noise, count, period
+
+    def _get_eval_actions(self, params, obses):
+        (mean, _), _ = self.actor(
+            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
+        )
+        return jnp.tanh(mean)
+
+    def _train_on_batch(self, data, context):
+        return self._train_on_bulk(jax.tree.map(lambda x: jnp.expand_dims(x, 0), data), [context])
+
+    def _train_on_bulk(self, data, contexts):
+        carry, metrics = self._compiled_updates(
+            (
+                self.policy_params,
+                self.critic_params,
+                self.target_critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
+                self.opt_ent_coef_state,
+                self.log_ent_coef,
+            ),
+            jax.random.split(next(self.key_seq), len(contexts)),
+            jnp.asarray([context.train_steps_count for context in contexts]),
+            data,
+        )
+        (
+            self.policy_params,
+            self.critic_params,
+            self.target_critic_params,
+            self.opt_policy_state,
+            self.opt_critic_state,
+            self.opt_ent_coef_state,
+            self.log_ent_coef,
+        ) = carry
+        actor_updates = max(
+            sum(
+                (context.train_steps_count - 1) % self.actor_update_period == 0
+                for context in contexts
+            ),
+            1,
+        )
+        return DPGTrainReport(
+            loss=jnp.mean(metrics[0]),
+            target=jnp.mean(metrics[1]),
+            metrics={
+                "loss/ent_coef": jnp.mean(metrics[2]),
+                "loss/actor_loss": jnp.sum(metrics[3]) / actor_updates,
+                "loss/entropy": jnp.sum(metrics[4]) / actor_updates,
+            },
+            update_count=len(contexts),
+        )
+
+    def _bulk_scan(self, carry, keys, steps, data):
+        return jax.lax.scan(self._train_step, carry, (keys, steps, data))
+
+    def _train_step(self, carry, sample):
+        policy, critic, target, actor_opt, critic_opt, alpha_opt, log_alpha = carry
+        key, step, data = sample
+        actor_key, target_key = jax.random.split(key)
+        obs = convert_normalized_obs(data["obses"])
+        next_obs = convert_normalized_obs(data["nxtobses"])
+        joint_obs = {name: jnp.concatenate((value, next_obs[name])) for name, value in obs.items()}
+        batch_size = data["actions"].shape[0]
+
+        def update_actor(state):
+            policy, actor_opt, log_alpha, alpha_opt = state
+            (loss, (log_prob, stats)), grad = jax.value_and_grad(self._actor_loss, has_aux=True)(
+                policy["params"],
+                policy["batch_stats"],
+                critic,
+                joint_obs,
+                actor_key,
+                jnp.exp(log_alpha),
+            )
+            updates, actor_opt = self.optimizer.update(grad, actor_opt, policy["params"])
+            policy = {
+                "params": project_unit_norm_params(optax.apply_updates(policy["params"], updates)),
+                "batch_stats": stats,
+            }
+            if self.auto_entropy:
+                log_alpha, alpha_opt = self._train_ent_coef(log_alpha, alpha_opt, log_prob)
+            return policy, actor_opt, log_alpha, alpha_opt, loss, -jnp.mean(log_prob)
+
+        policy, actor_opt, log_alpha, alpha_opt, actor_loss, entropy = jax.lax.cond(
+            (step - 1) % self.actor_update_period == 0,
+            update_actor,
+            lambda state: (*state, jnp.asarray(0.0), jnp.asarray(0.0)),
+            (policy, actor_opt, log_alpha, alpha_opt),
+        )
+        features = self.preproc(policy, None, joint_obs)
+        next_features = jax.tree.map(lambda value: value[batch_size:], features)
+        (mean, log_std), _ = self.actor(policy, None, next_features, False)
+        next_actions, log_prob = sample_policy(mean, log_std, target_key)
+        joint_actions = jnp.concatenate((data["actions"], next_actions))
+        (target_logits1, target_logits2), target_updates = self.critic(
+            target, None, features, joint_actions, True
+        )
+        target_probs1 = jax.nn.softmax(target_logits1[batch_size:])
+        target_probs2 = jax.nn.softmax(target_logits2[batch_size:])
+        select_first = jnp.sum(target_probs1 * self.value_support, axis=-1) <= jnp.sum(
+            target_probs2 * self.value_support, axis=-1
+        )
+        target_probs = categorical_projection(
+            jnp.where(select_first[:, None], target_probs1, target_probs2),
+            data["rewards"].reshape(-1, 1)
+            + (1 - data["terminateds"].reshape(-1, 1))
+            * self._gamma
+            * (self.value_support - jnp.exp(log_alpha) * log_prob),
+            self.value_min,
+            self.value_max,
+            self.support_delta,
+            self.n_atoms,
+        )
+        target_probs = jax.lax.stop_gradient(target_probs)
+        (critic_loss, stats), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+            critic["params"], critic["batch_stats"], features, joint_actions, target_probs
+        )
+        updates, critic_opt = self.optimizer.update(grad, critic_opt, critic["params"])
+        critic = {
+            "params": project_unit_norm_params(optax.apply_updates(critic["params"], updates)),
+            "batch_stats": stats,
+        }
+        target = {
+            "params": optax.incremental_update(
+                critic["params"], target["params"], self.target_network_update_tau
+            ),
+            "batch_stats": target_updates["batch_stats"],
+        }
+        return (policy, critic, target, actor_opt, critic_opt, alpha_opt, log_alpha), (
+            critic_loss,
+            jnp.mean(jnp.sum(target_probs * self.value_support, axis=-1)),
+            jnp.exp(log_alpha),
+            actor_loss,
+            entropy,
+        )
+
+    def _actor_loss(self, params, stats, critic, joint_obs, key, alpha):
+        variables = {"params": params, "batch_stats": stats}
+        features = self.preproc(variables, None, joint_obs)
+        (mean, log_std), updates = self.actor(variables, None, features, True)
+        actions, log_prob = sample_policy(mean, log_std, key)
+        size = actions.shape[0] // 2
+        (logits1, logits2), _ = self.critic(
+            critic, None, jax.tree.map(lambda value: value[:size], features), actions[:size], False
+        )
+        minimum = jnp.minimum(
+            jnp.sum(jax.nn.softmax(logits1) * self.value_support, axis=-1),
+            jnp.sum(jax.nn.softmax(logits2) * self.value_support, axis=-1),
+        )
+        return jnp.mean(alpha * log_prob[:size, 0] - minimum), (
+            log_prob[:size],
+            updates["batch_stats"],
+        )
+
+    def _critic_loss(self, params, stats, features, actions, target_probs):
+        (logits1, logits2), updates = self.critic(
+            {"params": params, "batch_stats": stats}, None, features, actions, True
+        )
+        size = target_probs.shape[0]
+        loss = -jnp.mean(
+            jnp.sum(
+                target_probs
+                * (jax.nn.log_softmax(logits1[:size]) + jax.nn.log_softmax(logits2[:size]))
+                / 2,
+                axis=-1,
+            )
+        )
+        return loss, updates["batch_stats"]

--- a/jax_baselines/core/normalization.py
+++ b/jax_baselines/core/normalization.py
@@ -4,6 +4,8 @@ Rollouts record samples; learners and evaluation apply frozen statistics.
 Network-internal normalization belongs to the model construction adapter.
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -294,3 +296,86 @@ class RewardNormalizer:
     def restore(self, state):
         self.rms = RunningMeanStd.from_state(state, on_device=self.rms.on_device)
         self.reset()
+
+
+@jax.jit
+def _record_flashsac_returns(
+    returns, mean, variance, count, maximum, rewards, dones, active, gamma
+):
+    returns = jnp.where(active, gamma * (1 - dones) * returns + rewards, returns)
+    size = jnp.sum(active)
+    batch_mean = jnp.sum(jnp.where(active, returns, 0)) / jnp.maximum(size, 1)
+    batch_var = jnp.sum(jnp.where(active, (returns - batch_mean) ** 2, 0)) / jnp.maximum(size, 1)
+    total = count + size
+    ratio = size / jnp.maximum(total, 1)
+    delta = batch_mean - mean
+    # The reference adds epsilon to the old variance weight on every update.
+    next_var = (
+        variance * (count + 1e-4) + batch_var * size + delta**2 * count * ratio
+    ) / jnp.maximum(total, 1)
+    return (
+        returns,
+        jnp.where(size > 0, mean + delta * ratio, mean),
+        jnp.where(size > 0, next_var, variance),
+        total,
+        jnp.maximum(maximum, jnp.max(jnp.where(active, jnp.abs(returns), 0))),
+    )
+
+
+class FlashSACRewardNormalizer(RewardNormalizer):
+    def __init__(self, worker_size: int, gamma: float, normalized_G_max: float = 5.0):
+        if worker_size < 1 or not 0 <= gamma <= 1:
+            raise ValueError("worker_size must be positive and gamma must be in [0, 1]")
+        if not math.isfinite(normalized_G_max) or normalized_G_max <= 0:
+            raise ValueError("normalized_G_max must be finite and positive")
+        super().__init__(worker_size, gamma, on_device=True)
+        self.rms = RunningMeanStd(epsilon=0, shapes={"return": ()}, on_device=True)
+        self.normalized_G_max = normalized_G_max
+        self.max_abs_return = jnp.asarray(0.0, dtype=jnp.float32)
+
+    def record(self, rewards, dones, active=None):
+        rewards = jnp.atleast_1d(jnp.asarray(rewards, dtype=jnp.float32))
+        dones = jnp.atleast_1d(jnp.asarray(dones, dtype=bool))
+        active = self._all_active if active is None else jnp.asarray(active, dtype=bool)
+        if any(value.shape != self.discounted_returns.shape for value in (rewards, dones, active)):
+            raise ValueError("rewards, dones and active must match the configured worker shape")
+        (
+            self.discounted_returns,
+            self.rms.means["return"],
+            self.rms.vars["return"],
+            self.rms.count,
+            self.max_abs_return,
+        ) = _record_flashsac_returns(
+            self.discounted_returns,
+            self.rms.means["return"],
+            self.rms.vars["return"],
+            self.rms.count,
+            self.max_abs_return,
+            rewards,
+            dones,
+            active,
+            self.gamma,
+        )
+
+    @property
+    def scale(self):
+        return jnp.maximum(
+            jnp.sqrt(self.rms.vars["return"] + 1e-8),
+            self.max_abs_return / self.normalized_G_max,
+        )
+
+    def normalize(self, rewards):
+        return jnp.asarray(rewards, dtype=jnp.float32) / self.scale
+
+    def to_state(self):
+        return {
+            **super().to_state(),
+            "max_abs_return": np.asarray(jax.device_get(self.max_abs_return)),
+        }
+
+    def restore(self, state):
+        maximum = np.asarray(state["max_abs_return"])
+        if maximum.shape != () or not np.isfinite(maximum) or maximum < 0:
+            raise ValueError("max_abs_return must be a finite nonnegative scalar")
+        super().restore(state)
+        self.max_abs_return = jnp.asarray(maximum, dtype=jnp.float32)

--- a/jax_baselines/math/param_updates.py
+++ b/jax_baselines/math/param_updates.py
@@ -1,19 +1,21 @@
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import jax
 import jax.numpy as jnp
 import optax
 
 PyTree = Any
+Params = TypeVar("Params")
 
 
-def random_split_like_tree(rng_key: jax.random.PRNGKey, target: PyTree):
+def random_split_like_tree(rng_key: jax.Array, target: PyTree):
     treedef = jax.tree.structure(target)
     keys = jax.random.split(rng_key, treedef.num_leaves)
     return jax.tree.unflatten(treedef, keys)
 
 
-def tree_random_normal_like(rng_key: jax.random.PRNGKey, target: PyTree, mul=1.2):
+def tree_random_normal_like(rng_key: jax.Array, target: PyTree, mul=1.2):
     keys_tree = random_split_like_tree(rng_key, target)
     return jax.tree_util.tree_map(
         lambda t, k: jax.random.normal(k, t.shape, t.dtype) * jnp.std(t) * mul,
@@ -26,7 +28,7 @@ def scaled_by_reset(
     tensors: PyTree,
     optimizer_state: optax.GradientTransformationExtraArgs,
     optimizer: optax.GradientTransformation,
-    key: jax.random.PRNGKey,
+    key: jax.Array,
     steps: int,
     update_period: int,
     tau: float,
@@ -50,7 +52,7 @@ def scaled_by_reset_with_filter(
     tensors: PyTree,
     optimizer_state: optax.GradientTransformationExtraArgs,
     optimizer: optax.GradientTransformation,
-    key: jax.random.PRNGKey,
+    key: jax.Array,
     steps: int,
     update_period: int,
     taus: PyTree,
@@ -121,3 +123,31 @@ def project_dense_kernels(tensors: PyTree, epsilon: float = 1e-8):
         return value
 
     return jax.tree_util.tree_map_with_path(project, tensors)
+
+
+def project_unit_norm_params(params: Params) -> Params:
+    """Normalize dense kernels and affine normalization weights.
+
+    Dense kernels store input features on axis 0. Normalization layers use
+    ``scale`` and, for BatchNorm, ``bias`` in the same parameter mapping.
+    Predictor biases remain unconstrained. Pass trainable parameters only;
+    batch statistics are separate state.
+    """
+    leaves = dict(jax.tree_util.tree_flatten_with_path(params)[0])
+
+    def project(path, value):
+        if not isinstance(path[-1], jax.tree_util.DictKey):
+            raise TypeError("Unit-normalized parameters must use named dictionary leaves")
+        name = path[-1].key
+        if name == "kernel":
+            return value / jnp.maximum(jnp.linalg.norm(value, axis=0, keepdims=True), 1e-8)
+        scale_path = (*path[:-1], jax.tree_util.DictKey("scale"))
+        if name not in ("scale", "bias") or scale_path not in leaves:
+            return value
+        squared_norm = jnp.sum(jnp.square(leaves[scale_path]))
+        bias_path = (*path[:-1], jax.tree_util.DictKey("bias"))
+        if bias_path in leaves:
+            squared_norm += jnp.sum(jnp.square(leaves[bias_path]))
+        return value * jnp.sqrt(value.shape[-1]) * jax.lax.rsqrt(squared_norm + 1e-8)
+
+    return jax.tree_util.tree_map_with_path(project, params)

--- a/model_builder/flax/dpg/flashsac_builder.py
+++ b/model_builder/flax/dpg/flashsac_builder.py
@@ -1,0 +1,196 @@
+from collections.abc import Mapping, Sequence
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from jax_baselines.math.param_updates import project_unit_norm_params
+from model_builder.flax.apply import get_apply_fn_flax_module
+from model_builder.utils import (
+    ActorCriticFeatures,
+    dummy_observation,
+    observation_role_keys,
+    print_flax_model_summary,
+)
+
+
+class UnitBatchNorm(nn.Module):
+    @nn.compact
+    def __call__(self, inputs: jax.Array, training: bool) -> jax.Array:
+        scale = self.param("scale", nn.initializers.ones_init(), (inputs.shape[-1],))
+        bias = self.param("bias", nn.initializers.zeros_init(), (inputs.shape[-1],))
+        running_mean = self.variable("batch_stats", "mean", jnp.zeros, (inputs.shape[-1],))
+        running_var = self.variable("batch_stats", "var", jnp.ones, (inputs.shape[-1],))
+        if training:
+            if inputs.shape[0] < 2:
+                raise ValueError("FlashSAC training BatchNorm requires at least two samples")
+            mean = jnp.mean(inputs, axis=0)
+            variance = jnp.mean(jnp.square(inputs - mean), axis=0)
+            # PyTorch normalizes with population variance but stores an unbiased estimate.
+            running_mean.value = 0.99 * running_mean.value + 0.01 * jax.lax.stop_gradient(mean)
+            running_var.value = 0.99 * running_var.value + 0.01 * jax.lax.stop_gradient(
+                variance * (inputs.shape[0] / (inputs.shape[0] - 1))
+            )
+        else:
+            mean, variance = running_mean.value, running_var.value
+        return (inputs - mean) * jax.lax.rsqrt(variance + 1e-5) * scale + bias
+
+
+class Encoder(nn.Module):
+    node: int
+    hidden_n: int
+
+    @nn.compact
+    def __call__(self, feature: jax.Array, training: bool) -> jax.Array:
+        feature = UnitBatchNorm(name="input_norm")(feature, training)
+        feature = nn.Dense(
+            self.node,
+            use_bias=False,
+            kernel_init=nn.initializers.orthogonal(),
+            name="embed",
+        )(feature)
+        for block in range(self.hidden_n):
+            residual = feature
+            feature = nn.Dense(
+                self.node * 4,
+                use_bias=False,
+                kernel_init=nn.initializers.orthogonal(),
+                name=f"block_{block}_expand",
+            )(feature)
+            feature = UnitBatchNorm(name=f"block_{block}_norm1")(feature, training)
+            feature = jax.nn.relu(feature)
+            feature = nn.Dense(
+                self.node,
+                use_bias=False,
+                kernel_init=nn.initializers.orthogonal(),
+                name=f"block_{block}_contract",
+            )(feature)
+            feature = UnitBatchNorm(name=f"block_{block}_norm2")(feature, training)
+            feature = jax.nn.relu(feature) + residual
+        return nn.RMSNorm(epsilon=1e-6, name="post_norm")(feature)
+
+
+class Actor(nn.Module):
+    action_dim: int
+    node: int = 128
+    hidden_n: int = 2
+
+    @nn.compact
+    def __call__(
+        self, features: ActorCriticFeatures, training: bool = False
+    ) -> tuple[jax.Array, jax.Array]:
+        feature = Encoder(self.node, self.hidden_n)(features["actor"], training)
+        mean = nn.Dense(self.action_dim, kernel_init=nn.initializers.orthogonal(), name="mean")(
+            feature
+        )
+        raw_log_std = nn.Dense(
+            self.action_dim, kernel_init=nn.initializers.orthogonal(), name="std"
+        )(feature)
+        return mean, -10.0 + 6.0 * (1.0 + jax.nn.tanh(raw_log_std))
+
+
+class Critic(nn.Module):
+    node: int = 256
+    hidden_n: int = 2
+    n_atoms: int = 101
+
+    @nn.compact
+    def __call__(
+        self, features: ActorCriticFeatures, actions: jax.Array, training: bool = False
+    ) -> jax.Array:
+        feature = Encoder(self.node, self.hidden_n)(
+            jnp.concatenate((features["critic"], actions), axis=-1), training
+        )
+        return nn.Dense(self.n_atoms, kernel_init=nn.initializers.orthogonal(), name="value")(
+            feature
+        )
+
+
+def model_builder_maker(
+    observation_space: Mapping[str, Sequence[int]],
+    action_size: Sequence[int],
+    policy_kwargs,
+):
+    """Build FlashSAC's residual policy and independent categorical twin critics."""
+    policy_kwargs = {} if policy_kwargs is None else dict(policy_kwargs)
+    actor_node = policy_kwargs.pop("actor_node", 128)
+    critic_node = policy_kwargs.pop("critic_node", 256)
+    hidden_n = policy_kwargs.pop("hidden_n", 2)
+    n_atoms = policy_kwargs.pop("n_atoms", 101)
+    embedding_mode = policy_kwargs.pop("embedding_mode", "normal")
+    if policy_kwargs:
+        raise ValueError(f"Unsupported FlashSAC policy options: {sorted(policy_kwargs)}")
+    for name, value, minimum in (
+        ("actor_node", actor_node, 1),
+        ("critic_node", critic_node, 1),
+        ("hidden_n", hidden_n, 0),
+        ("n_atoms", n_atoms, 2),
+    ):
+        if type(value) is not int or value < minimum:
+            raise ValueError(f"FlashSAC {name} must be an integer >= {minimum}")
+    if embedding_mode != "normal":
+        raise ValueError("FlashSAC supports only embedding_mode='normal'")
+    if not observation_space or any(
+        len(shape) != 1 or shape[0] < 1 for shape in observation_space.values()
+    ):
+        raise ValueError("FlashSAC requires nonempty vector observations")
+    if len(action_size) != 1 or action_size[0] < 1:
+        raise ValueError("FlashSAC requires a nonempty vector action space")
+    observation_space = {name: tuple(shape) for name, shape in observation_space.items()}
+    role_keys = observation_role_keys(observation_space, actor_critic=True)
+
+    def model_builder(key=None, print_model=False):
+        class Merged_Actor(nn.Module):
+            def setup(self):
+                self.act = Actor(action_size[0], actor_node, hidden_n)
+
+            def __call__(self, observation, training: bool = False):
+                return self.actor(self.preprocess(observation), training)
+
+            def preprocess(self, observation) -> ActorCriticFeatures:
+                return ActorCriticFeatures(
+                    actor=jnp.concatenate(
+                        [observation[name] for name in role_keys["actor"]], axis=-1
+                    ),
+                    critic=jnp.concatenate(
+                        [observation[name] for name in role_keys["critic"]], axis=-1
+                    ),
+                )
+
+            def actor(self, features: ActorCriticFeatures, training: bool = False):
+                return self.act(features, training)
+
+        class Merged_Critic(nn.Module):
+            def setup(self):
+                self.crit1 = Critic(critic_node, hidden_n, n_atoms)
+                self.crit2 = Critic(critic_node, hidden_n, n_atoms)
+
+            def __call__(self, features, actions, training: bool = False):
+                return self.crit1(features, actions, training), self.crit2(
+                    features, actions, training
+                )
+
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
+        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor, mutable=["batch_stats"])
+        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        if key is None:
+            return preproc_fn, actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = jnp.zeros((1, *action_size), dtype=jnp.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_variables = actor_model.init(actor_key, observation, False)
+        policy_variables["params"] = project_unit_norm_params(policy_variables["params"])
+        features = preproc_fn(policy_variables, None, observation)
+        critic_variables = critic_model.init(critic_key, features, action, False)
+        critic_variables["params"] = project_unit_norm_params(critic_variables["params"])
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation, False),
+            (critic_model, features, action, False),
+        )
+        return preproc_fn, actor_fn, critic_fn, policy_variables, critic_variables
+
+    return model_builder

--- a/tests/test_cli_dpg_registry.py
+++ b/tests/test_cli_dpg_registry.py
@@ -30,7 +30,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 EXPECTED_ALGOS = {
-    "dpg": {"DDPG", "TD3", "SAC", "CrossQ", "XQC", "TQC", "TD7"},
+    "dpg": {"DDPG", "TD3", "SAC", "FlashSAC", "CrossQ", "XQC", "TQC", "TD7"},
     "pg": {"A2C", "PPO", "TPPO", "SPO"},
     "qnet": {"DQN", "C51", "QRDQN", "IQN", "FQF", "SPR", "BBF"},
 }
@@ -117,7 +117,7 @@ def test_dpg_simba_variants_resolve(flags: list[str]):
     from experiments.cli.dpg import DPG_RUNNER
 
     for algo, spec in DPG_RUNNER.algos.items():
-        if algo == "XQC":
+        if algo in ("XQC", "FlashSAC"):
             continue
         args = _parse(DPG_RUNNER, ["--algo", algo, "--model_lib", "flax", *flags])
         assert callable(resolve_maker(DPG_RUNNER, spec, args))
@@ -163,12 +163,12 @@ def test_dpg_xqc_respects_common_cli_settings():
     assert built["ent_coef"] == "auto_0.02"
 
 
-def test_dpg_reward_normalization_defaults_to_xqc_and_can_be_overridden():
+def test_dpg_reward_normalization_defaults_and_override():
     from experiments.cli.dpg import DPG_RUNNER
 
     for algo, spec in DPG_RUNNER.algos.items():
         built = spec.build(_parse(DPG_RUNNER, ["--algo", algo]))
-        assert built["reward_normalization"] is (algo == "XQC")
+        assert built["reward_normalization"] is (algo in ("XQC", "FlashSAC"))
 
     enabled = DPG_RUNNER.algos["DDPG"].build(
         _parse(DPG_RUNNER, ["--algo", "DDPG", "--reward_normalization"])
@@ -301,9 +301,9 @@ def test_qnet_hl_gauss_bbf_optimizer_policy_matches_historical_adamw_default():
     grads = {"w": jnp.array([0.5, -0.25], dtype=jnp.float32)}
 
     updates, _ = optimizer.update(grads, optimizer.init(params), params)
-    expected, _ = reference.update(grads, reference.init(params), params)
+    expected, _ = reference.update(grads["w"], reference.init(params["w"]), params["w"])
 
-    np.testing.assert_allclose(updates["w"], expected["w"], rtol=1e-6)
+    np.testing.assert_allclose(updates["w"], np.asarray(expected), rtol=1e-6)
 
 
 def test_qnet_bbf_haiku_is_unsupported_clean_error():
@@ -473,7 +473,7 @@ def test_dist_policy_kwargs_uses_shared_normal_embedding(family: str):
 
     runner = _dist_runner(family)
     assert runner.policy_kwargs is default_policy_kwargs
-    args = _parse(runner, ["--algo", sorted(runner.algos)[0], "--node", "128", "--hidden_n", "3"])
+    args = _parse(runner, ["--algo", min(runner.algos), "--node", "128", "--hidden_n", "3"])
     assert runner.policy_kwargs(args) == {
         "node": 128,
         "hidden_n": 3,


### PR DESCRIPTION
기존 DPG 실행 경로에서 `--algo FlashSAC`을 선택할 수 있도록 독립 알고리즘 구현과 Flax 모델 빌더를 추가합니다. MJLab Go1 설정과 README의 지원 알고리즘 목록도 추가합니다.

- categorical twin critic, joint-batch normalization과 target 통계, 지연 Actor·온도 업데이트, 파라미터 투영, Zeta 탐색, cosine 학습률 및 반복 업데이트를 구현했습니다.
- FlashSAC 리워드 정규화는 앞선 PR의 core 모듈에 두고, 파라미터 업데이트 유틸리티와 기존 DPG 실행·저장 경로를 재사용합니다.
- 관측 역할은 환경의 `actor_*`·`critic_*`·`unified_*` 계약으로 결정합니다. 별도 비대칭 관측 옵션은 추가하지 않습니다.
- 검증: 이 PR 트리의 관련 테스트 **78 passed**. 기존 모델 기본값으로 CPU Pendulum 정규 FlashSAC CLI가 16 환경 step 학습, 평가 10회, checkpoint 저장을 완료했으며 종료 코드는 0입니다. 변경 Python의 Ruff·ty는 모두 통과했습니다.

스택 2/4. 기준 브랜치는 `stack/flashsac-01-core-normalization`입니다. Go1의 장시간 GPU 학습 성능은 검증하지 않았습니다.

리뷰·머지 순서: `main` → #36 → #37 → #38 → #39. 각 PR의 Files changed는 바로 앞 단계와의 차이입니다.
