### PR TITLE
[3/4] Actor/Critic 파라미터·optimizer·너비 분리

### DIFF
--- a/experiments/cli/_run.py
+++ b/experiments/cli/_run.py
@@ -61,12 +61,16 @@ def resolve_maker(runner: _MakerRunner, spec: AlgoSpec, args: Namespace):
 
 
 def default_policy_kwargs(args: Namespace) -> dict:
-    """Network policy kwargs shared by the distributed families (APE-X / IMPALA).
-
-    All three distributed entry points feed Atari-style visual inputs, so they
-    use the ``normal`` embedding mode with the configured ``node``/``hidden_n``.
-    """
     return {"node": args.node, "hidden_n": args.hidden_n, "embedding_mode": "normal"}
+
+
+def actor_critic_policy_kwargs(args: Namespace) -> dict:
+    options = {"hidden_n": args.hidden_n, "embedding_mode": "normal"}
+    if args.actor_node is not None:
+        options["actor_node"] = args.actor_node
+    if args.critic_node is not None:
+        options["critic_node"] = args.critic_node
+    return options
 
 
 def run_family(runner: FamilyRunner, argv=None):

--- a/experiments/cli/apex_dpg.py
+++ b/experiments/cli/apex_dpg.py
@@ -6,7 +6,7 @@ from env_builder.env_builder import get_env_builder
 from experiments.cli._run import (
     AlgoSpec,
     DistributedFamilyRunner,
-    default_policy_kwargs,
+    actor_critic_policy_kwargs,
     run_distributed_family,
 )
 from experiments.optimizers import make_batch_scaled_optimizer_factory
@@ -41,7 +41,8 @@ def add_args(parser):
         "--logdir", type=str, default=default_logdir("apex_dpg"), help="log file dir"
     )
     parser.add_argument("--seed", type=int, default=42, help="random seed")
-    parser.add_argument("--node", type=int, default=256, help="network node number")
+    parser.add_argument("--actor_node", type=int, default=None, help="actor hidden width")
+    parser.add_argument("--critic_node", type=int, default=None, help="critic hidden width")
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--optimizer", type=str, default="adopt", help="optimaizer")
     parser.add_argument("--gradient_steps", type=int, default=1, help="gradient_steps")
@@ -89,7 +90,7 @@ ALGOS = {
 APEX_DPG_RUNNER = DistributedFamilyRunner(
     add_args=add_args,
     make_workers=make_workers,
-    policy_kwargs=default_policy_kwargs,
+    policy_kwargs=actor_critic_policy_kwargs,
     algos=ALGOS,
     maker_pkg="model_builder.{lib}.dpg",
     variant=lambda _args: "",

--- a/experiments/cli/dpg.py
+++ b/experiments/cli/dpg.py
@@ -4,7 +4,12 @@ from env_builder.env_builder import get_env_builder
 
 # isort: on
 from experiments.cli._env import add_env_args, env_builder_kwargs
-from experiments.cli._run import AlgoSpec, FamilyRunner, run_family
+from experiments.cli._run import (
+    AlgoSpec,
+    FamilyRunner,
+    actor_critic_policy_kwargs,
+    run_family,
+)
 from experiments.optimizers import (
     make_batch_scaled_optimizer_factory,
     make_optimizer_factory,
@@ -69,9 +74,8 @@ def add_args(parser):
     parser.add_argument("--n_support", type=int, default=25, help="n_support for QRDQN,IQN,FQF")
     parser.add_argument("--mixture", type=str, default="truncated", help="mixture type")
     parser.add_argument("--quantile_drop", type=float, default=0.1, help="quantile_drop ratio")
-    parser.add_argument("--node", type=int, default=256, help="network node number")
-    parser.add_argument("--actor_node", type=int, default=128, help="FlashSAC actor width")
-    parser.add_argument("--critic_node", type=int, default=256, help="FlashSAC critic width")
+    parser.add_argument("--actor_node", type=int, default=None, help="actor hidden width")
+    parser.add_argument("--critic_node", type=int, default=None, help="critic hidden width")
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--action_noise", type=float, default=0.1, help="action_noise")
     parser.add_argument("--optimizer", type=str, default="adopt", help="optimaizer")
@@ -110,18 +114,7 @@ def build_env(args):
         args.env,
         **env_builder_kwargs(args),
     )
-    if args.algo == "FlashSAC":
-        return env_builder, {
-            "actor_node": args.actor_node,
-            "critic_node": args.critic_node,
-            "hidden_n": args.hidden_n,
-        }
-    policy_kwargs = {
-        "node": args.node,
-        "hidden_n": args.hidden_n,
-        "embedding_mode": "normal",
-    }
-    return env_builder, policy_kwargs
+    return env_builder, actor_critic_policy_kwargs(args)
 
 
 def _variant(args):

--- a/experiments/cli/impala.py
+++ b/experiments/cli/impala.py
@@ -6,7 +6,7 @@ from env_builder.env_builder import get_env_builder
 from experiments.cli._run import (
     AlgoSpec,
     DistributedFamilyRunner,
-    default_policy_kwargs,
+    actor_critic_policy_kwargs,
     run_distributed_family,
 )
 from experiments.optimizers import make_batch_scaled_optimizer_factory
@@ -35,7 +35,8 @@ def add_args(parser):
     parser.add_argument("--steps", type=float, default=1e5, help="step size")
     parser.add_argument("--logdir", type=str, default=default_logdir("impala"), help="log file dir")
     parser.add_argument("--seed", type=int, default=42, help="random seed")
-    parser.add_argument("--node", type=int, default=256, help="network node number")
+    parser.add_argument("--actor_node", type=int, default=None, help="actor hidden width")
+    parser.add_argument("--critic_node", type=int, default=None, help="critic hidden width")
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--optimizer", type=str, default="rmsprop", help="optimaizer")
     parser.add_argument("--ent_coef", type=float, default=0.1, help="entropy coefficient")
@@ -80,7 +81,7 @@ ALGOS = {
 IMPALA_RUNNER = DistributedFamilyRunner(
     add_args=add_args,
     make_workers=make_workers,
-    policy_kwargs=default_policy_kwargs,
+    policy_kwargs=actor_critic_policy_kwargs,
     algos=ALGOS,
     maker_pkg="model_builder.{lib}.ac",
     variant=lambda _args: "",

--- a/experiments/cli/pg.py
+++ b/experiments/cli/pg.py
@@ -4,7 +4,12 @@ from env_builder.env_builder import get_env_builder
 
 # isort: on
 from experiments.cli._env import add_env_args, env_builder_kwargs
-from experiments.cli._run import AlgoSpec, FamilyRunner, run_family
+from experiments.cli._run import (
+    AlgoSpec,
+    FamilyRunner,
+    actor_critic_policy_kwargs,
+    run_family,
+)
 from experiments.optimizers import make_optimizer_factory
 from jax_baselines.A2C.a2c import A2C
 from jax_baselines.PPO.ppo import PPO
@@ -39,7 +44,8 @@ def add_args(parser):
     )
     parser.add_argument("--logdir", type=str, default=default_logdir("pg"), help="log file dir")
     parser.add_argument("--seed", type=int, default=0, help="random seed")
-    parser.add_argument("--node", type=int, default=256, help="network node number")
+    parser.add_argument("--actor_node", type=int, default=None, help="actor hidden width")
+    parser.add_argument("--critic_node", type=int, default=None, help="critic hidden width")
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--optimizer", type=str, default="adamw", help="optimaizer")
     parser.add_argument(
@@ -92,12 +98,7 @@ def build_env(args):
         args.env,
         **env_builder_kwargs(args),
     )
-    policy_kwargs = {
-        "node": args.node,
-        "hidden_n": args.hidden_n,
-        "embedding_mode": "normal",
-    }
-    return env_builder, policy_kwargs
+    return env_builder, actor_critic_policy_kwargs(args)
 
 
 def _common(a):

--- a/experiments/configs/apex_dpg.yaml
+++ b/experiments/configs/apex_dpg.yaml
@@ -13,7 +13,8 @@ base:
   gamma: 0.99
   buffer_size: 1e7
   worker: 8
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 2
   initial_eps: 0.1
   eps_decay: 0

--- a/experiments/configs/dpg_humanoid.yaml
+++ b/experiments/configs/dpg_humanoid.yaml
@@ -15,7 +15,8 @@ base:
   target_update_tau: 5e-3
   learning_starts: 50000
   use_checkpointing: true
-  node: 256
+  actor_node: 256
+  critic_node: 256
   hidden_n: 2
   optimizer: adam
 variants:
@@ -28,6 +29,6 @@ variants:
   - {algo: TQC}
   - {algo: TQC, simba: true}
   - {algo: TQC, simbav2: true}
-  - {algo: CrossQ}
-  - {algo: XQC}
+  - {algo: CrossQ, critic_node: 2048}
+  - {algo: XQC, critic_node: 512}
   - {algo: TD7}

--- a/experiments/configs/dpg_humanoid_32_vec_env.yaml
+++ b/experiments/configs/dpg_humanoid_32_vec_env.yaml
@@ -17,7 +17,8 @@ base:
   batch: 256
   target_update_tau: 5e-3
   learning_starts: 50000
-  node: 256
+  actor_node: 256
+  critic_node: 256
   hidden_n: 2
   optimizer: adam
 variants:
@@ -30,5 +31,5 @@ variants:
   - {algo: TQC}
   - {algo: TQC, simba: true}
   - {algo: TQC, simbav2: true}
-  - {algo: CrossQ}
-  - {algo: XQC}
+  - {algo: CrossQ, critic_node: 2048}
+  - {algo: XQC, critic_node: 512}

--- a/experiments/configs/dpg_mjlab_go1.yaml
+++ b/experiments/configs/dpg_mjlab_go1.yaml
@@ -23,7 +23,8 @@ base:
   n_step: 3
   # Local observation normalization uses the SIMBA residual-network variant.
   simba: true
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 2
   reward_normalization: true
   target_update_tau: 0.01

--- a/experiments/configs/dpg_walker2d.yaml
+++ b/experiments/configs/dpg_walker2d.yaml
@@ -12,7 +12,8 @@ base:
   batch: 256
   target_update_tau: 1e-3
   learning_starts: 50000
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 2
   optimizer: adam
 variants:

--- a/experiments/configs/impala_bipedal.yaml
+++ b/experiments/configs/impala_bipedal.yaml
@@ -9,7 +9,8 @@ base:
   gamma: 0.995
   worker: 8
   ent_coef: 1e-3
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 2
   sample_size: 8
   update_freq: 100

--- a/experiments/configs/impala_breakout.yaml
+++ b/experiments/configs/impala_breakout.yaml
@@ -8,7 +8,8 @@ base:
   gamma: 0.99
   worker: 16
   ent_coef: 1e-2
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 1
   sample_size: 32
   update_freq: 100

--- a/experiments/configs/impala_breakout_ppo.yaml
+++ b/experiments/configs/impala_breakout_ppo.yaml
@@ -10,7 +10,8 @@ base:
   gamma: 0.99
   worker: 16
   ent_coef: 1e-4
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 1
   sample_size: 32
   update_freq: 100

--- a/experiments/configs/pg_breakout.yaml
+++ b/experiments/configs/pg_breakout.yaml
@@ -17,7 +17,8 @@ base:
   mini_batch: 256
   gamma: 0.99
   lamda: 0.95
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 1
   optimizer: adam
   optimizer_eps: 0.00001

--- a/experiments/configs/pg_lunarlander.yaml
+++ b/experiments/configs/pg_lunarlander.yaml
@@ -17,7 +17,8 @@ base:
   mini_batch: 256
   gamma: 0.995
   lamda: 0.95
-  node: 128
+  actor_node: 128
+  critic_node: 128
   hidden_n: 2
   optimizer: rmsprop
 variants:

--- a/experiments/configs/pg_mjlab_go1.yaml
+++ b/experiments/configs/pg_mjlab_go1.yaml
@@ -11,7 +11,8 @@ base:
   steps: 491520000
   eval_num: 5
   batch: 24
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 3
   mini_batch: 24576
   epoch_num: 5

--- a/experiments/configs/ppo.yaml
+++ b/experiments/configs/ppo.yaml
@@ -16,7 +16,8 @@ base:
   gamma: 0.995
   lamda: 0.95
   ent_coef: 1e-3
-  node: 512
+  actor_node: 512
+  critic_node: 512
   hidden_n: 1
   optimizer: rmsprop
 variants:

--- a/experiments/configs/xqc.yaml
+++ b/experiments/configs/xqc.yaml
@@ -14,7 +14,8 @@ base:
   learning_starts: 5000
   optimizer: adam
   ent_coef: auto_0.01
-  node: 256
+  actor_node: 256
+  critic_node: 512
   hidden_n: 4
 variants:
   - {algo: XQC}

--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -18,10 +18,11 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             self.observation_space, self.action_size, self.action_type, self.policy_kwargs
         )
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
         self._get_actions = jax.jit(self._get_actions)
         self._train_step = jax.jit(self._train_step)
 
@@ -29,13 +30,22 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         data = self.buffer.get_buffer()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             targets,
-        ) = self._train_step(self.params, self.opt_state, None, **data)
+        ) = self._train_step(
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
+            None,
+            **data,
+        )
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)
@@ -47,8 +57,10 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -59,16 +71,8 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses),
-        )
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         targets = jax.vmap(discount_with_terminated, in_axes=(0, 0, 0, 0, None))(
             rewards, terminateds, truncateds, next_value, self.gamma
         )
@@ -77,20 +81,36 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         value = jnp.vstack(value)
         targets = jnp.vstack(targets)
         adv = targets - value
-        (_total_loss, (critic_loss, actor_loss, entropy_loss)), grad = jax.value_and_grad(
-            self._loss, has_aux=True
-        )(params, obses, actions, targets, adv, key)
-        updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-        params = optax.apply_updates(params, updates)
-        return params, opt_state, critic_loss, actor_loss, entropy_loss, jnp.mean(targets)
+        (_total_loss, (critic_loss, actor_loss, entropy_loss)), (actor_grad, critic_grad) = (
+            jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                actor_params, critic_params, obses, actions, targets, adv, key
+            )
+        )
+        actor_updates, actor_opt_state = self.optimizer.update(
+            actor_grad, actor_opt_state, params=actor_params
+        )
+        critic_updates, critic_opt_state = self.optimizer.update(
+            critic_grad, critic_opt_state, params=critic_params
+        )
+        actor_params = optax.apply_updates(actor_params, actor_updates)
+        critic_params = optax.apply_updates(critic_params, critic_updates)
+        return (
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            critic_loss,
+            actor_loss,
+            entropy_loss,
+            jnp.mean(targets),
+        )
 
-    def _loss_discrete(self, params, obses, actions, targets, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(self, actor_params, critic_params, obses, actions, targets, adv, key):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -109,13 +129,12 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, targets, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_continuous(self, actor_params, critic_params, obses, actions, targets, adv, key):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -55,7 +55,6 @@ class Actor_Critic_Policy_Gradient_Family:
     _run_name = "A2C"
     actor: Callable
     _get_actions: Callable
-    preproc: Callable
     logger: AbstractContextManager
 
     def __init__(
@@ -112,7 +111,8 @@ class Actor_Critic_Policy_Gradient_Family:
         self.lr_annealing = lr_annealing
         self.checkpoint_store = checkpoint_store_or_default(checkpoint_store)
 
-        self.params = None
+        self.actor_params = None
+        self.critic_params = None
         self.rollout_tracker = None
         self.optimizer = self._make_optimizer(self.learning_rate)
 
@@ -152,7 +152,8 @@ class Actor_Critic_Policy_Gradient_Family:
         self.checkpoint_store.save(
             path,
             ACCheckpointState(
-                params=self.params,
+                actor_params=self.actor_params,
+                critic_params=self.critic_params,
                 obs_rms_state=self.obs_rms.to_state() if self.obs_rms is not None else None,
             ),
         )
@@ -177,7 +178,8 @@ class Actor_Critic_Policy_Gradient_Family:
             )
         ):
             raise ValueError("Checkpoint observation statistics do not match the environment")
-        self.params = jax.device_put(state.params, self.memory_device)
+        self.actor_params = jax.device_put(state.actor_params, self.memory_device)
+        self.critic_params = jax.device_put(state.critic_params, self.memory_device)
         self.obs_rms = obs_rms
         self.obs_normalization = obs_rms is not None
 
@@ -234,19 +236,21 @@ class Actor_Critic_Policy_Gradient_Family:
     def train_step(self, steps, logger_run=None):
         raise NotImplementedError
 
-    def _get_actions_discrete(self, params, obses, key=None) -> jnp.ndarray:
+    def _get_actions_discrete(self, actor_params, obses, key=None) -> jnp.ndarray:
         prob = jax.nn.softmax(
-            self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses))),
+            self.actor(actor_params, key, convert_normalized_obs(obses)),
             axis=1,
         )
         return prob
 
-    def _get_actions_continuous(self, params, obses, key=None) -> tuple[jnp.ndarray, jnp.ndarray]:
-        mu, std = self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
+    def _get_actions_continuous(
+        self, actor_params, obses, key=None
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        mu, std = self.actor(actor_params, key, convert_normalized_obs(obses))
         return mu, jnp.exp(std)
 
     def action_discrete(self, obs, eval=False):
-        prob = self._get_actions(self.params, obs)
+        prob = self._get_actions(self.actor_params, obs)
         if self.memory_backend == "cpu":
             prob = np.asarray(prob)
             if eval:
@@ -261,7 +265,7 @@ class Actor_Critic_Policy_Gradient_Family:
         return _sample_discrete(prob, next(self.key_seq))
 
     def action_continuous(self, obs, eval=False):
-        mu, std = self._get_actions(self.params, obs)
+        mu, std = self._get_actions(self.actor_params, obs)
         if self.memory_backend == "cpu":
             if eval:
                 return np.asarray(mu)
@@ -340,7 +344,7 @@ class Actor_Critic_Policy_Gradient_Family:
         return train_steps * self._optimizer_updates_per_train_step()
 
     def prepare_run(self, total_timesteps):
-        if not self.lr_annealing or self.params is None:
+        if not self.lr_annealing or self.actor_params is None:
             return
 
         schedule = optax.linear_schedule(
@@ -350,7 +354,8 @@ class Actor_Critic_Policy_Gradient_Family:
         )
         self.optimizer = self._make_optimizer(schedule)
         with jax.default_device(self.memory_device):
-            self.opt_state = self.optimizer.init(self.params)
+            self.actor_opt_state = self.optimizer.init(self.actor_params)
+            self.critic_opt_state = self.optimizer.init(self.critic_params)
 
     def run_training_loop(self, ctx):
         with jax.default_device(self.memory_device):

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -16,10 +16,11 @@ class IMPALA(IMPALA_Family):
         )
         self.actor_builder = self.get_actor_builder()
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
@@ -33,16 +34,20 @@ class IMPALA(IMPALA_Family):
         data = self.buffer.sample()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             rho,
             targets,
         ) = self._train_step(
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             next(self.key_seq),
             data[0],
             data[1],
@@ -68,7 +73,8 @@ class IMPALA(IMPALA_Family):
 
     def preprocess(
         self,
-        params,
+        actor_params,
+        critic_params,
         key,
         obses,
         actions,
@@ -88,15 +94,10 @@ class IMPALA(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(params, key, feature),
+            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
         )
@@ -112,8 +113,10 @@ class IMPALA(IMPALA_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -124,7 +127,8 @@ class IMPALA(IMPALA_Family):
         truncateds,
     ):
         obses, actions, vs, rho, adv = self.preprocess(
-            params,
+            actor_params,
+            critic_params,
             key,
             obses,
             actions,
@@ -134,14 +138,28 @@ class IMPALA(IMPALA_Family):
             terminateds,
             truncateds,
         )
-        (_total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
-            self._loss, has_aux=True
-        )(params, obses, actions, vs, adv, key)
-        updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-        params = optax.apply_updates(params, updates)
+        (
+            (
+                _total_loss,
+                (critic_loss, actor_loss, entropy_loss),
+            ),
+            (actor_grad, critic_grad),
+        ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+            actor_params, critic_params, obses, actions, vs, adv, key
+        )
+        actor_updates, actor_opt_state = self.optimizer.update(
+            actor_grad, actor_opt_state, params=actor_params
+        )
+        critic_updates, critic_opt_state = self.optimizer.update(
+            critic_grad, critic_opt_state, params=critic_params
+        )
+        actor_params = optax.apply_updates(actor_params, actor_updates)
+        critic_params = optax.apply_updates(critic_params, critic_updates)
         return (
-            params,
-            opt_state,
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
@@ -149,12 +167,11 @@ class IMPALA(IMPALA_Family):
             jnp.mean(vs),
         )
 
-    def _loss_discrete(self, params, obses, actions, vs, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(self, actor_params, critic_params, obses, actions, vs, adv, key):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(vs - vals))
 
-        logit = self.actor(params, key, feature)
+        logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
         if self.use_entropy_adv_shaping:
@@ -172,12 +189,11 @@ class IMPALA(IMPALA_Family):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, vs, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_continuous(self, actor_params, critic_params, obses, actions, vs, adv, key):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(vs - vals))
 
-        prob = self.actor(params, key, feature)
+        prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -56,10 +56,11 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             self.observation_space, self.action_size, self.action_type, self.policy_kwargs
         )
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
 
         self._get_actions = jax.jit(self._get_actions)
         self._preprocess = jax.jit(self._preprocess)
@@ -69,13 +70,22 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         data = self.buffer.get_buffer()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             targets,
-        ) = self._train_step(self.params, self.opt_state, next(self.key_seq), **data)
+        ) = self._train_step(
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
+            next(self.key_seq),
+            **data,
+        )
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)
@@ -85,18 +95,24 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
 
         return critic_loss
 
-    def _preprocess(self, params, key, obses, actions, rewards, nxtobses, terminateds, truncateds):
+    def _preprocess(
+        self,
+        actor_params,
+        critic_params,
+        key,
+        obses,
+        actions,
+        rewards,
+        nxtobses,
+        terminateds,
+        truncateds,
+    ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(params, key, feature),
+            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
         )
@@ -115,8 +131,10 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -126,11 +144,28 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         truncateds,
     ):
         obses, actions, old_values, targets, act_prob, adv = self._preprocess(
-            params, key, obses, actions, rewards, nxtobses, terminateds, truncateds
+            actor_params,
+            critic_params,
+            key,
+            obses,
+            actions,
+            rewards,
+            nxtobses,
+            terminateds,
+            truncateds,
         )
 
         def i_f(idx, vals):
-            params, opt_state, key, critic_loss, actor_loss, entropy_loss = vals
+            (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            ) = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(targets.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -143,21 +178,33 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             adv_batch = adv[batch_idxes]
 
             def f(updates, input):
-                params, opt_state, key = updates
+                actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, oldv, target, act_prob, adv = input
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (total_loss, (c_loss, a_loss, entropy_loss)), grad = jax.value_and_grad(
-                    self._loss, has_aux=True
-                )(params, obs, act, oldv, target, act_prob, adv, use_key)
-                updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-                params = optax.apply_updates(params, updates)
-                return (params, opt_state, key), (c_loss, a_loss, entropy_loss)
+                (_total_loss, (c_loss, a_loss, entropy_loss)), (actor_grad, critic_grad) = (
+                    jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                        actor_params, critic_params, obs, act, oldv, target, act_prob, adv, use_key
+                    )
+                )
+                actor_updates, actor_opt_state = self.optimizer.update(
+                    actor_grad, actor_opt_state, params=actor_params
+                )
+                critic_updates, critic_opt_state = self.optimizer.update(
+                    critic_grad, critic_opt_state, params=critic_params
+                )
+                actor_params = optax.apply_updates(actor_params, actor_updates)
+                critic_params = optax.apply_updates(critic_params, critic_updates)
+                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
+                    c_loss,
+                    a_loss,
+                    entropy_loss,
+                )
 
             updates, losses = jax.lax.scan(
                 f,
-                (params, opt_state, key),
+                (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
                 (
                     obses_batch,
                     actions_batch,
@@ -167,18 +214,43 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                     adv_batch,
                 ),
             )
-            params, opt_state, key = updates
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
             cl, al, el = losses
             critic_loss += jnp.mean(cl)
             actor_loss += jnp.mean(al)
             entropy_loss += jnp.mean(el)
-            return params, opt_state, key, critic_loss, actor_loss, entropy_loss
+            return (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            )
 
-        val = jax.lax.fori_loop(0, self.epoch_num, i_f, (params, opt_state, key, 0.0, 0.0, 0.0))
-        params, opt_state, key, critic_loss, actor_loss, entropy_loss = val
+        val = jax.lax.fori_loop(
+            0,
+            self.epoch_num,
+            i_f,
+            (actor_params, critic_params, actor_opt_state, critic_opt_state, key, 0.0, 0.0, 0.0),
+        )
+        (
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            key,
+            critic_loss,
+            actor_loss,
+            entropy_loss,
+        ) = val
         return (
-            params,
-            opt_state,
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
             critic_loss / self.epoch_num,
             actor_loss / self.epoch_num,
             entropy_loss / self.epoch_num,

--- a/jax_baselines/APE_X/dpg_base_class.py
+++ b/jax_baselines/APE_X/dpg_base_class.py
@@ -1,5 +1,6 @@
 import time
 from collections import deque
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
@@ -25,8 +26,9 @@ from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
-class Ape_X_Deteministic_Policy_Gradient_Family(object):
+class Ape_X_Deteministic_Policy_Gradient_Family:
     _run_name = "APE_X_DPG"
+    actor: Callable
 
     def __init__(
         self,
@@ -90,8 +92,10 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
         self.n_step_method = n_step > 1
         self.n_step = n_step
 
-        self.params = None
-        self.target_params = None
+        self.policy_params = None
+        self.critic_params = None
+        self.target_policy_params = None
+        self.target_critic_params = None
         self.optimizer_factory = require_optimizer_factory(optimizer_factory)
         self.optimizer = self._make_optimizer(self.learning_rate)
         self.model_builder = None
@@ -110,10 +114,24 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
             self.setup_model()
 
     def save_params(self, path):
-        self.checkpoint_store.save(path, self.params)
+        self.checkpoint_store.save(
+            path,
+            {
+                "policy": self.policy_params,
+                "critic": self.critic_params,
+                "target_policy": self.target_policy_params,
+                "target_critic": self.target_critic_params,
+            },
+        )
 
     def load_params(self, path):
-        self.params = self.target_params = jax.device_put(self.checkpoint_store.restore(path))
+        params = jax.device_put(self.checkpoint_store.restore(path))
+        self.policy_params = params["policy"]
+        self.critic_params = params["critic"]
+        self.target_policy_params = params["target_policy"]
+        self.target_critic_params = params["target_critic"]
+        self.opt_policy_state = self.optimizer.init(self.policy_params)
+        self.opt_critic_state = self.optimizer.init(self.critic_params)
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
@@ -149,11 +167,11 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
     def setup_model(self):
         pass
 
-    def _train_step(self, steps):
-        pass
+    def _invoke_train_step(self, steps, data):
+        raise NotImplementedError
 
     def _get_actions(self, params, obses, key=None):
-        return self.actor(params, key, self.preproc(params, key, convert_normalized_obs(obses)))
+        return self.actor(params, key, convert_normalized_obs(obses))
 
     def description(self):
         array_module = jnp if any(isinstance(loss, jax.Array) for loss in self.lossque) else np
@@ -168,9 +186,12 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
             data = self.replay_buffer.sample(self.batch_size, self.prioritized_replay_beta0)
 
             (
-                self.params,
-                self.target_params,
-                self.opt_state,
+                self.policy_params,
+                self.critic_params,
+                self.target_policy_params,
+                self.target_critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
                 loss,
                 t_mean,
                 new_priorities,
@@ -206,7 +227,7 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
         if run_name is None:
             run_name = self._run_name
         if self.n_step_method:
-            run_name = "{}Step_".format(self.n_step) + run_name
+            run_name = f"{self.n_step}Step_" + run_name
 
         progress_factory = progress_factory or make_progress
         pbar = progress_factory(total_trainstep, miniters=log_interval)
@@ -244,7 +265,10 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
             for u in update:
                 u.clear()
 
-            cpu_param = jax.device_put(self.params, jax.devices("cpu")[0])
+            cpu_param = jax.device_put(
+                {"policy": self.policy_params, "critic": self.critic_params},
+                jax.devices("cpu")[0],
+            )
             param_server = self.runtime.create_param_server(cpu_param)
 
             epsilons = worker_epsilons(
@@ -286,7 +310,10 @@ class Ape_X_Deteministic_Policy_Gradient_Family(object):
                 if steps % log_interval == 0:
                     pbar.set_description(self.description())
                 if steps % self.param_broadcast_freq == 0:
-                    cpu_param = jax.device_put(self.params, jax.devices("cpu")[0])
+                    cpu_param = jax.device_put(
+                        {"policy": self.policy_params, "critic": self.critic_params},
+                        jax.devices("cpu")[0],
+                    )
                     param_server.update_params(cpu_param)
                     for u in update:
                         u.set()

--- a/jax_baselines/APE_X/dpg_worker.py
+++ b/jax_baselines/APE_X/dpg_worker.py
@@ -8,7 +8,7 @@ from jax_baselines.core.replay_protocol import make_worker_local_replay_buffer
 from jax_baselines.core.seeding import seed_prngs
 
 
-class Ape_X_Worker(object):
+class Ape_X_Worker:
     def __init__(self, env_builder, seed=None) -> None:
         seed_prngs(seed)
         # env_builder is the repo-local Environment Adapter callable injected by
@@ -38,7 +38,7 @@ class Ape_X_Worker(object):
             local_buffer = make_worker_local_replay_buffer(
                 worker_replay_factory, local_size, env_dict, n_s
             )
-            preproc, actor_model, critic_model = model_builder()
+            actor_model, critic_model = model_builder()
             (
                 get_abs_td_error,
                 actor,
@@ -48,21 +48,19 @@ class Ape_X_Worker(object):
                 key_seq,
             ) = actor_builder()
 
-            get_abs_td_error = jax.jit(
-                partial(get_abs_td_error, actor_model, critic_model, preproc)
-            )
-            actor = jax.jit(partial(actor, actor_model, preproc))
+            get_abs_td_error = jax.jit(partial(get_abs_td_error, actor_model, critic_model))
+            actor = jax.jit(partial(actor, actor_model))
             _get_action = partial(get_action, actor)
             get_action = random_action
 
             score = 0
             if seed is not None:
                 try:
-                    obs, info = self.env.reset(seed=seed)
+                    obs, _info = self.env.reset(seed=seed)
                 except TypeError:
-                    obs, info = self.env.reset()
+                    obs, _info = self.env.reset()
             else:
-                obs, info = self.env.reset()
+                obs, _info = self.env.reset()
             obs = batch_observation(obs)
             params = jax.device_put(param_server.get_params())
             eplen = 0
@@ -84,7 +82,7 @@ class Ape_X_Worker(object):
 
                 eplen += 1
                 actions = get_action(params, obs, noise, eps, next(key_seq))
-                next_obs, reward, terminated, truncated, info = self.env.step(actions)
+                next_obs, reward, terminated, truncated, _info = self.env.step(actions)
                 next_obs = batch_observation(next_obs)
                 local_buffer.add(obs, actions, reward, next_obs, terminated, truncated)
                 score += reward
@@ -92,7 +90,7 @@ class Ape_X_Worker(object):
 
                 if terminated or truncated:
                     local_buffer.episode_end()
-                    obs, info = self.env.reset()
+                    obs, _info = self.env.reset()
                     obs = batch_observation(obs)
                     if logger_server is not None:
                         log_dict = {
@@ -120,4 +118,3 @@ class Ape_X_Worker(object):
                 print("worker stopped")
             else:
                 stop.set()
-        return None

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -56,7 +56,6 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -85,8 +84,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         self.critic_params = bundle.critic_params
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, feature, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, feature)
+    def _get_pi_log_prob(self, params, obses, key=None) -> jnp.ndarray:
+        mu, log_std = self.actor(params, None, obses)
         std = jnp.exp(log_std)
         x_t = mu + std * jax.random.normal(key, std.shape)
         pi = jax.nn.tanh(x_t)
@@ -99,15 +98,13 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses))
-        )
+        mu, log_std = self.actor(params, None, convert_normalized_obs(obses))
         std = jnp.exp(log_std)
         pi = jax.nn.tanh(mu + std * jax.random.normal(key, std.shape))
         return pi
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        mu, _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
+        mu, _ = self.actor(params, None, convert_normalized_obs(obses))
         return jax.nn.tanh(mu)
 
     def _train_on_batch(self, data, context):
@@ -151,13 +148,16 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             self.log_ent_coef,
         )
         (
-            self.policy_params,
-            self.critic_params,
-            self.opt_policy_state,
-            self.opt_critic_state,
-            self.opt_ent_coef_state,
-            self.log_ent_coef,
-        ), (losses, targets, ent_coefs, priorities) = self._bulk_scan(carry, keys, steps, data)
+            (
+                self.policy_params,
+                self.critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
+                self.opt_ent_coef_state,
+                self.log_ent_coef,
+            ),
+            (losses, targets, ent_coefs, priorities),
+        ) = self._bulk_scan(carry, keys, steps, data)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
@@ -354,16 +354,12 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             obses,
             nxtobses,
         )
-        concated_preproc = self.preproc(policy_params, key, concated_obses)
-        next_preproc = jax.tree_util.tree_map(
-            lambda feature: jnp.split(feature, 2, axis=0)[1], concated_preproc
-        )
-        next_policy, log_prob = self._get_pi_log_prob(policy_params, next_preproc, key)
+        next_policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
         concated_actions = jnp.concatenate([actions, next_policy])
         (q1, q2), variable_updates = self.critic(
-            critic_params, key, concated_preproc, concated_actions, True
+            critic_params, key, concated_obses, concated_actions, True
         )
-        critic_params["batch_stats"] = variable_updates["batch_stats"]
+        critic_params = {**critic_params, **variable_updates}
         q1, next_q1 = jnp.split(q1, 2, axis=0)
         q2, next_q2 = jnp.split(q2, 2, axis=0)
         next_q = jnp.minimum(next_q1, next_q2) - ent_coef * log_prob
@@ -376,8 +372,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         return critic_loss, (jnp.abs(error1), targets, critic_params)
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        feature = self.preproc(policy_params, key, obses)
-        policy, log_prob = self._get_pi_log_prob(policy_params, feature, key)
-        (q1_pi, q2_pi), _ = self.critic(critic_params, key, feature, policy, False)
+        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        (q1_pi, q2_pi), _ = self.critic(critic_params, key, obses, policy, False)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
         return actor_loss, log_prob

--- a/jax_baselines/DDPG/apex_ddpg.py
+++ b/jax_baselines/DDPG/apex_ddpg.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from itertools import repeat
 
@@ -23,15 +24,16 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         )
         self.actor_builder = self.get_actor_builder()
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.policy_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.target_params = deepcopy(self.params)
+        self.target_policy_params = deepcopy(self.policy_params)
+        self.target_critic_params = deepcopy(self.critic_params)
 
-        self.opt_state = self.optimizer.init(self.params)
-
-        self._get_actions = jax.jit(self._get_actions)
-        self._train_step = jax.jit(self._train_step)
+        self.opt_policy_state = self.optimizer.init(self.policy_params)
+        self.opt_critic_state = self.optimizer.init(self.critic_params)
+        self._get_actions: Callable = jax.jit(self._get_actions)
+        self._compiled_train_step: Callable = jax.jit(self._train_step)
 
     def get_actor_builder(self):
         gamma = self._gamma
@@ -44,7 +46,6 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
             def get_abs_td_error(
                 actor,
                 critic,
-                preproc,
                 params,
                 obses,
                 actions,
@@ -53,17 +54,16 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
                 terminateds,
                 key,
             ):
-                next_feature = preproc(params, key, convert_normalized_obs(nxtobses))
-                next_action = actor(params, key, next_feature)
-                next_q = critic(params, key, next_feature, next_action)
-                feature = preproc(params, key, convert_normalized_obs(obses))
-                q_values = critic(params, key, feature, actions)
+                nxtobses = convert_normalized_obs(nxtobses)
+                next_action = actor(params["policy"], key, nxtobses)
+                next_q = critic(params["critic"], key, nxtobses, next_action)
+                q_values = critic(params["critic"], key, convert_normalized_obs(obses), actions)
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td_error = q_values - target
                 return jnp.squeeze(jnp.abs(td_error))
 
-            def actor(actor, preproc, params, obses, key):
-                return actor(params, key, preproc(params, key, convert_normalized_obs(obses)))
+            def actor(actor, params, obses, key):
+                return actor(params["policy"], key, convert_normalized_obs(obses))
 
             def get_action(actor, params, obs, noise, epsilon, key):
                 actions = np.clip(np.asarray(actor(params, obs, key)) + noise() * epsilon, -1, 1)[0]
@@ -77,13 +77,25 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         return builder
 
     def _invoke_train_step(self, steps, data):
-        return self._train_step(self.params, self.target_params, self.opt_state, None, **data)
+        return self._compiled_train_step(
+            self.policy_params,
+            self.critic_params,
+            self.target_policy_params,
+            self.target_critic_params,
+            self.opt_policy_state,
+            self.opt_critic_state,
+            next(self.key_seq),
+            **data,
+        )
 
     def _train_step(
         self,
-        params,
-        target_params,
-        opt_state,
+        policy_params,
+        critic_params,
+        target_policy_params,
+        target_critic_params,
+        opt_policy_state,
+        opt_critic_state,
         key,
         obses,
         actions,
@@ -102,23 +114,57 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         rewards_batch = rewards[batch_idxes]
         nxtobses_batch = jax.tree.map(lambda value: value[batch_idxes], nxtobses)
         not_terminateds_batch = not_terminateds[batch_idxes]
-        weights_batch = weights[batch_idxes]
+        weights_batch = jnp.broadcast_to(jnp.asarray(weights), (self.batch_size,))[batch_idxes]
 
         def f(carry, data):
-            params, opt_state, key = carry
+            policy_params, critic_params, opt_policy_state, opt_critic_state, key = carry
             obses, actions, rewards, nxtobses, not_terminateds, weights = data
             key, *subkeys = jax.random.split(key, 3)
-            targets = self._target(target_params, rewards, nxtobses, not_terminateds, subkeys[0])
-            (total_loss, (critic_loss, actor_loss, abs_error)), grad = jax.value_and_grad(
-                self._loss, has_aux=True
-            )(params, obses, actions, targets, weights, subkeys[1])
-            updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-            params = optax.apply_updates(params, updates)
-            return (params, opt_state, key), (total_loss, critic_loss, actor_loss, abs_error)
+            targets = self._target(
+                target_policy_params,
+                target_critic_params,
+                rewards,
+                nxtobses,
+                not_terminateds,
+                subkeys[0],
+            )
+            (_, (critic_loss, actor_loss, abs_error)), (actor_grad, critic_grad) = (
+                jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                    policy_params,
+                    critic_params,
+                    obses,
+                    actions,
+                    targets,
+                    weights,
+                    subkeys[1],
+                )
+            )
+            actor_updates, opt_policy_state = self.optimizer.update(
+                actor_grad, opt_policy_state, params=policy_params
+            )
+            critic_updates, opt_critic_state = self.optimizer.update(
+                critic_grad, opt_critic_state, params=critic_params
+            )
+            return (
+                optax.apply_updates(policy_params, actor_updates),
+                optax.apply_updates(critic_params, critic_updates),
+                opt_policy_state,
+                opt_critic_state,
+                key,
+            ), (critic_loss, actor_loss, abs_error)
 
-        (params, opt_state, key), (total_loss, critic_loss, actor_loss, abs_error) = jax.lax.scan(
+        (
+            (
+                policy_params,
+                critic_params,
+                opt_policy_state,
+                opt_critic_state,
+                key,
+            ),
+            (critic_loss, actor_loss, abs_error),
+        ) = jax.lax.scan(
             f,
-            (params, opt_state, key),
+            (policy_params, critic_params, opt_policy_state, opt_critic_state, key),
             (
                 obses_batch,
                 actions_batch,
@@ -128,30 +174,44 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
                 weights_batch,
             ),
         )
-        target_params = soft_update(params, target_params, self.target_network_update_tau)
+        target_policy_params = soft_update(
+            policy_params, target_policy_params, self.target_network_update_tau
+        )
+        target_critic_params = soft_update(
+            critic_params, target_critic_params, self.target_network_update_tau
+        )
         new_priorities = jnp.reshape(abs_error, (-1,))
         return (
-            params,
-            target_params,
-            opt_state,
+            policy_params,
+            critic_params,
+            target_policy_params,
+            target_critic_params,
+            opt_policy_state,
+            opt_critic_state,
             jnp.mean(critic_loss),
             -jnp.mean(actor_loss),
             new_priorities,
         )
 
-    def _loss(self, params, obses, actions, targets, weights, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature, actions)
+    def _loss(self, policy_params, critic_params, obses, actions, targets, weights, key):
+        vals = self.critic(critic_params, key, obses, actions)
         error = jnp.squeeze(vals - targets)
         critic_loss = jnp.mean(jnp.square(error) * weights)
-        policy = self.actor(params, key, feature)
-        vals = self.critic(jax.lax.stop_gradient(params), key, feature, policy)
+        policy = self.actor(policy_params, key, obses)
+        vals = self.critic(jax.lax.stop_gradient(critic_params), key, obses, policy)
         actor_loss = jnp.mean(-vals)
         total_loss = critic_loss + actor_loss
         return total_loss, (critic_loss, -actor_loss, jnp.abs(error))
 
-    def _target(self, target_params, rewards, nxtobses, not_terminateds, key):
-        next_feature = self.preproc(target_params, key, nxtobses)
-        next_action = self.actor(target_params, key, next_feature)
-        next_q = self.critic(target_params, key, next_feature, next_action)
+    def _target(
+        self,
+        target_policy_params,
+        target_critic_params,
+        rewards,
+        nxtobses,
+        not_terminateds,
+        key,
+    ):
+        next_action = self.actor(target_policy_params, key, nxtobses)
+        next_q = self.critic(target_critic_params, key, nxtobses, next_action)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -55,7 +55,6 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -85,9 +84,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(
-            policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses))
-        )
+        return self.actor(policy_params, key, convert_normalized_obs(obses))
 
     def description(self, eval_result=None):
         description = ""
@@ -159,13 +156,16 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             self.opt_critic_state,
         )
         (
-            self.policy_params,
-            self.critic_params,
-            self.target_policy_params,
-            self.target_critic_params,
-            self.opt_policy_state,
-            self.opt_critic_state,
-        ), (losses, targets, priorities) = self._bulk_scan(carry, keys, steps, data)
+            (
+                self.policy_params,
+                self.critic_params,
+                self.target_policy_params,
+                self.target_critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
+            ),
+            (losses, targets, priorities),
+        ) = self._bulk_scan(carry, keys, steps, data)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
@@ -247,7 +247,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             key,
         )
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key
+            critic_params, obses, actions, targets, weights, key
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -300,17 +300,15 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
-        feature = self.preproc(policy_params, key, obses)
-        vals = self.critic(critic_params, key, feature, actions)
+    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
+        vals = self.critic(critic_params, key, obses, actions)
         error = jnp.squeeze(vals - targets)
         critic_loss = jnp.mean(weights * jnp.square(error))
         return critic_loss, jnp.abs(error)
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
-        feature = self.preproc(policy_params, key, obses)
-        actions = self.actor(policy_params, key, feature)
-        q = self.critic(critic_params, key, feature, actions)
+        actions = self.actor(policy_params, key, obses)
+        q = self.critic(critic_params, key, obses, actions)
         return -jnp.mean(q)
 
     def _target(
@@ -322,7 +320,6 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         not_terminateds,
         key,
     ):
-        next_feature = self.preproc(target_policy_params, key, nxtobses)
-        next_action = self.actor(target_policy_params, key, next_feature)
-        next_q = self.critic(target_critic_params, key, next_feature, next_action)
+        next_action = self.actor(target_policy_params, key, nxtobses)
+        next_q = self.critic(target_critic_params, key, nxtobses, next_action)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/FlashSAC/flashsac.py
+++ b/jax_baselines/FlashSAC/flashsac.py
@@ -129,7 +129,6 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
 
     def setup_model(self):
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -180,9 +179,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         return actions
 
     def _get_actions(self, params, obses, key, noise, count, period):
-        (mean, log_std), _ = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
-        )
+        (mean, log_std), _ = self.actor(params, None, convert_normalized_obs(obses), False)
         noise_key, period_key = jax.random.split(key)
         refresh = (count == 0) | (count >= period)
         noise = jnp.where(refresh, jax.random.normal(noise_key, mean.shape), noise)
@@ -193,9 +190,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         return jnp.tanh(mean + jnp.exp(log_std) * noise), noise, count, period
 
     def _get_eval_actions(self, params, obses):
-        (mean, _), _ = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
-        )
+        (mean, _), _ = self.actor(params, None, convert_normalized_obs(obses), False)
         return jnp.tanh(mean)
 
     def _train_on_batch(self, data, context):
@@ -280,13 +275,11 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             lambda state: (*state, jnp.asarray(0.0), jnp.asarray(0.0)),
             (policy, actor_opt, log_alpha, alpha_opt),
         )
-        features = self.preproc(policy, None, joint_obs)
-        next_features = jax.tree.map(lambda value: value[batch_size:], features)
-        (mean, log_std), _ = self.actor(policy, None, next_features, False)
+        (mean, log_std), _ = self.actor(policy, None, next_obs, False)
         next_actions, log_prob = sample_policy(mean, log_std, target_key)
         joint_actions = jnp.concatenate((data["actions"], next_actions))
         (target_logits1, target_logits2), target_updates = self.critic(
-            target, None, features, joint_actions, True
+            target, None, joint_obs, joint_actions, True
         )
         target_probs1 = jax.nn.softmax(target_logits1[batch_size:])
         target_probs2 = jax.nn.softmax(target_logits2[batch_size:])
@@ -306,7 +299,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         )
         target_probs = jax.lax.stop_gradient(target_probs)
         (critic_loss, stats), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic["params"], critic["batch_stats"], features, joint_actions, target_probs
+            critic["params"], critic["batch_stats"], joint_obs, joint_actions, target_probs
         )
         updates, critic_opt = self.optimizer.update(grad, critic_opt, critic["params"])
         critic = {
@@ -329,12 +322,11 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
 
     def _actor_loss(self, params, stats, critic, joint_obs, key, alpha):
         variables = {"params": params, "batch_stats": stats}
-        features = self.preproc(variables, None, joint_obs)
-        (mean, log_std), updates = self.actor(variables, None, features, True)
+        (mean, log_std), updates = self.actor(variables, None, joint_obs, True)
         actions, log_prob = sample_policy(mean, log_std, key)
         size = actions.shape[0] // 2
         (logits1, logits2), _ = self.critic(
-            critic, None, jax.tree.map(lambda value: value[:size], features), actions[:size], False
+            critic, None, jax.tree.map(lambda value: value[:size], joint_obs), actions[:size], False
         )
         minimum = jnp.minimum(
             jnp.sum(jax.nn.softmax(logits1) * self.value_support, axis=-1),
@@ -345,9 +337,9 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             updates["batch_stats"],
         )
 
-    def _critic_loss(self, params, stats, features, actions, target_probs):
+    def _critic_loss(self, params, stats, obses, actions, target_probs):
         (logits1, logits2), updates = self.critic(
-            {"params": params, "batch_stats": stats}, None, features, actions, True
+            {"params": params, "batch_stats": stats}, None, obses, actions, True
         )
         size = target_probs.shape[0]
         loss = -jnp.mean(

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from jax_baselines.core.checkpoint_state import ACCheckpointState
 from jax_baselines.core.checkpoint_store import (
     CheckpointStore,
     checkpoint_store_or_default,
@@ -84,8 +85,8 @@ class IMPALA_Family:
         self.cut_max = 1.0
         self.log_dir = log_dir
 
-        self.params = None
-        self.target_params = None
+        self.actor_params = None
+        self.critic_params = None
         self.optimizer_factory = require_optimizer_factory(optimizer_factory)
         self.optimizer = self._make_optimizer(self.learning_rate)
         self.model_builder = None
@@ -100,10 +101,17 @@ class IMPALA_Family:
             self.setup_model()
 
     def save_params(self, path):
-        self.checkpoint_store.save(path, self.params)
+        self.checkpoint_store.save(
+            path,
+            ACCheckpointState(actor_params=self.actor_params, critic_params=self.critic_params),
+        )
 
     def load_params(self, path):
-        self.params = self.target_params = jax.device_put(self.checkpoint_store.restore(path))
+        state = self.checkpoint_store.restore(path)
+        if not isinstance(state, ACCheckpointState):
+            raise TypeError("Expected ACCheckpointState with separate actor and critic parameters")
+        self.actor_params = jax.device_put(state.actor_params)
+        self.critic_params = jax.device_put(state.critic_params)
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
@@ -191,14 +199,12 @@ class IMPALA_Family:
         def builder():
             if action_type == "discrete":
 
-                def actor(actor_model, preproc, params, obses, key=None):
-                    prob = actor_model(
-                        params, key, preproc(params, key, convert_normalized_obs(obses))
-                    )
+                def actor(actor_model, actor_params, obses, key=None):
+                    prob = actor_model(actor_params, key, convert_normalized_obs(obses))
                     return jax.nn.softmax(prob)
 
-                def get_action_prob(actor, params, obses):
-                    prob = np.asarray(actor(params, obses))
+                def get_action_prob(actor, actor_params, obses):
+                    prob = np.asarray(actor(actor_params, obses))
                     action = np.random.choice(action_size[0], p=prob[0])
                     return action, np.log(prob[0][action])
 
@@ -207,14 +213,12 @@ class IMPALA_Family:
 
             elif action_type == "continuous":
 
-                def actor(actor_model, preproc, params, obses, key=None):
-                    mean, log_std = actor_model(
-                        params, key, preproc(params, key, convert_normalized_obs(obses))
-                    )
+                def actor(actor_model, actor_params, obses, key=None):
+                    mean, log_std = actor_model(actor_params, key, convert_normalized_obs(obses))
                     return mean, log_std
 
-                def get_action_prob(actor, params, obses):
-                    mean, log_std = jax.device_get(actor(params, obses))
+                def get_action_prob(actor, actor_params, obses):
+                    mean, log_std = jax.device_get(actor(actor_params, obses))
                     std = np.exp(log_std)
                     action = np.random.normal(mean, std)
                     return action, -(
@@ -292,7 +296,7 @@ class IMPALA_Family:
             for u in update:
                 u.set()
 
-            cpu_param = jax.device_put(self.params, jax.devices("cpu")[0])
+            cpu_param = jax.device_put(self.actor_params, jax.devices("cpu")[0])
             param_server = self.runtime.create_param_server(cpu_param)
 
             worker_replay_factory = require_replay_factory(
@@ -331,7 +335,7 @@ class IMPALA_Family:
                     pbar.set_description(self.description())
 
                 if steps % self.update_freq == 0:
-                    cpu_param = jax.device_put(self.params, jax.devices("cpu")[0])
+                    cpu_param = jax.device_put(self.actor_params, jax.devices("cpu")[0])
                     param_server.update_params(cpu_param)
                     for u in update:
                         u.set()

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -79,10 +79,11 @@ class SurrogateIMPALA(IMPALA_Family):
         )
         self.actor_builder = self.get_actor_builder()
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
@@ -96,16 +97,20 @@ class SurrogateIMPALA(IMPALA_Family):
         data = self.buffer.sample()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             rho,
             targets,
         ) = self._train_step(
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             next(self.key_seq),
             data[0],
             data[1],
@@ -131,7 +136,8 @@ class SurrogateIMPALA(IMPALA_Family):
 
     def preprocess(
         self,
-        params,
+        actor_params,
+        critic_params,
         key,
         obses,
         actions,
@@ -151,15 +157,10 @@ class SurrogateIMPALA(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(params, key, feature),
+            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
         )
@@ -177,8 +178,10 @@ class SurrogateIMPALA(IMPALA_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -189,7 +192,8 @@ class SurrogateIMPALA(IMPALA_Family):
         truncateds,
     ):
         obses, actions, vs, mu_prob, pi_prob, rho, adv = self.preprocess(
-            params,
+            actor_params,
+            critic_params,
             key,
             obses,
             actions,
@@ -201,7 +205,16 @@ class SurrogateIMPALA(IMPALA_Family):
         )
 
         def i_f(idx, vals):
-            params, opt_state, key, critic_loss, actor_loss, entropy_loss = vals
+            (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            ) = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(vs.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -214,19 +227,35 @@ class SurrogateIMPALA(IMPALA_Family):
             adv_batch = adv[batch_idxes]
 
             def f(updates, input):
-                params, opt_state, key = updates
+                actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, vs, mu_prob, pi_prob, adv = input
                 use_key, key = jax.random.split(key)
-                (total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
-                    self._loss, has_aux=True
-                )(params, obs, act, vs, mu_prob, pi_prob, adv, use_key)
-                updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-                params = optax.apply_updates(params, updates)
-                return (params, opt_state, key), (critic_loss, actor_loss, entropy_loss)
+                (
+                    (
+                        _total_loss,
+                        (critic_loss, actor_loss, entropy_loss),
+                    ),
+                    (actor_grad, critic_grad),
+                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                    actor_params, critic_params, obs, act, vs, mu_prob, pi_prob, adv, use_key
+                )
+                actor_updates, actor_opt_state = self.optimizer.update(
+                    actor_grad, actor_opt_state, params=actor_params
+                )
+                critic_updates, critic_opt_state = self.optimizer.update(
+                    critic_grad, critic_opt_state, params=critic_params
+                )
+                actor_params = optax.apply_updates(actor_params, actor_updates)
+                critic_params = optax.apply_updates(critic_params, critic_updates)
+                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
+                    critic_loss,
+                    actor_loss,
+                    entropy_loss,
+                )
 
             updates, losses = jax.lax.scan(
                 f,
-                (params, opt_state, key),
+                (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
                 (
                     obses_batch,
                     actions_batch,
@@ -236,18 +265,43 @@ class SurrogateIMPALA(IMPALA_Family):
                     adv_batch,
                 ),
             )
-            params, opt_state, key = updates
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
             cl, al, el = losses
             critic_loss += jnp.mean(cl)
             actor_loss += jnp.mean(al)
             entropy_loss += jnp.mean(el)
-            return params, opt_state, key, critic_loss, actor_loss, entropy_loss
+            return (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            )
 
-        val = jax.lax.fori_loop(0, self.epoch_num, i_f, (params, opt_state, key, 0.0, 0.0, 0.0))
-        params, opt_state, key, critic_loss, actor_loss, entropy_loss = val
+        val = jax.lax.fori_loop(
+            0,
+            self.epoch_num,
+            i_f,
+            (actor_params, critic_params, actor_opt_state, critic_opt_state, key, 0.0, 0.0, 0.0),
+        )
+        (
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            key,
+            critic_loss,
+            actor_loss,
+            entropy_loss,
+        ) = val
         return (
-            params,
-            opt_state,
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
             critic_loss / self.epoch_num,
             actor_loss / self.epoch_num,
             entropy_loss / self.epoch_num,

--- a/jax_baselines/IMPALA/worker.py
+++ b/jax_baselines/IMPALA/worker.py
@@ -8,7 +8,7 @@ from jax_baselines.core.replay_protocol import make_worker_local_replay_buffer
 from jax_baselines.core.seeding import seed_prngs
 
 
-class Impala_Worker(object):
+class Impala_Worker:
     def __init__(self, env_builder, seed=None) -> None:
         seed_prngs(seed)
         # env_builder is the repo-local Environment Adapter callable injected by
@@ -33,14 +33,14 @@ class Impala_Worker(object):
     ):
         try:
             seed_prngs(seed)
-            queue, env_dict, actor_num = buffer_info
+            queue, env_dict, _actor_num = buffer_info
             local_buffer = make_worker_local_replay_buffer(
                 worker_replay_factory, local_size, env_dict, None
             )
-            preproc, actor_model, _ = model_builder()
+            actor_model, _ = model_builder()
             actor, get_action_prob, convert_action = actor_builder()
 
-            actor = jax.jit(partial(actor, actor_model, preproc))
+            actor = jax.jit(partial(actor, actor_model))
             get_action_prob = partial(get_action_prob, actor)
 
             if seed is not None:
@@ -50,8 +50,8 @@ class Impala_Worker(object):
                     obs, info = self.env.reset()
             else:
                 obs, info = self.env.reset()
-            have_original_reward = "original_reward" in info.keys()
-            have_lives = "lives" in info.keys()
+            have_original_reward = "original_reward" in info
+            have_lives = "lives" in info
             if have_original_reward:
                 original_score = 0
             score = 0
@@ -64,16 +64,16 @@ class Impala_Worker(object):
             len_label = "rollout/episode_length"
             to_label = "rollout/timeout_rate"
 
-            # Eager initial fetch so `params` is always bound before first use,
+            # Eager initial fetch so actor parameters are always bound before first use,
             # mirroring the APE-X workers (avoids reliance on update being pre-set).
-            params = jax.device_put(param_server.get_params())
+            actor_params = jax.device_put(param_server.get_params())
             while not stop.is_set():
                 if update.is_set():
-                    params = jax.device_put(param_server.get_params())
+                    actor_params = jax.device_put(param_server.get_params())
                     update.clear()
                 for _ in range(local_size):
                     eplen += 1
-                    actions, log_prob = get_action_prob(params, obs)
+                    actions, log_prob = get_action_prob(actor_params, obs)
                     next_obs, reward, terminated, truncated, info = self.env.step(
                         convert_action(actions)
                     )
@@ -114,4 +114,3 @@ class Impala_Worker(object):
                 print("worker stopped")
             else:
                 stop.set()
-        return None

--- a/jax_baselines/PPO/impala_ppo.py
+++ b/jax_baselines/PPO/impala_ppo.py
@@ -8,12 +8,13 @@ class IMPALA_PPO(SurrogateIMPALA):
     _run_name = "IMPALA_PPO"
     _learn_log_interval = 10
 
-    def _loss_discrete(self, params, obses, actions, vs, mu_prob, pi_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(
+        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
-        logit = self.actor(params, key, feature)
+        logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -37,14 +38,15 @@ class IMPALA_PPO(SurrogateIMPALA):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, vs, mu_prob, pi_prob, adv, key):
+    def _loss_continuous(
+        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
+    ):
         # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
-        prob = self.actor(params, key, feature)
+        prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -7,16 +7,17 @@ from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
 class PPO(SurrogatePolicyGradient):
     _run_name = "PPO"
 
-    def _loss_discrete(self, params, obses, actions, old_value, targets, old_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(
+        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -39,16 +40,17 @@ class PPO(SurrogatePolicyGradient):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, old_value, targets, old_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_continuous(
+        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(jnp.squeeze(vals - targets))
         vf2 = jnp.square(jnp.squeeze(vals_clip - targets))
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -64,7 +64,6 @@ class SAC(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -96,8 +95,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, feature, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(params, None, feature)
+    def _get_pi_log_prob(self, params, obses, key=None) -> jnp.ndarray:
+        mu, log_std = self.actor(params, None, obses)
         std = jnp.exp(log_std)
         x_t = mu + std * jax.random.normal(key, std.shape)
         pi = jax.nn.tanh(x_t)
@@ -110,13 +109,11 @@ class SAC(Deteministic_Policy_Gradient_Family):
         return pi, log_prob
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        mu, log_std = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses))
-        )
+        mu, log_std = self.actor(params, None, convert_normalized_obs(obses))
         return sample_action(mu, log_std, key)
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        mu, _ = self.actor(params, None, self.preproc(params, None, convert_normalized_obs(obses)))
+        mu, _ = self.actor(params, None, convert_normalized_obs(obses))
         return mode_action(mu)
 
     def _train_on_batch(self, data, context):
@@ -163,14 +160,17 @@ class SAC(Deteministic_Policy_Gradient_Family):
             self.log_ent_coef,
         )
         (
-            self.policy_params,
-            self.critic_params,
-            self.target_critic_params,
-            self.opt_policy_state,
-            self.opt_critic_state,
-            self.opt_ent_coef_state,
-            self.log_ent_coef,
-        ), (losses, targets, ent_coefs, priorities) = self._bulk_scan(carry, keys, steps, data)
+            (
+                self.policy_params,
+                self.critic_params,
+                self.target_critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
+                self.opt_ent_coef_state,
+                self.log_ent_coef,
+            ),
+            (losses, targets, ent_coefs, priorities),
+        ) = self._bulk_scan(carry, keys, steps, data)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
@@ -261,7 +261,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
         )
 
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key2
+            critic_params, obses, actions, targets, weights, key2
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -341,9 +341,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
-        feature = self.preproc(policy_params, key, obses)
-        q1, q2 = self.critic(critic_params, key, feature, actions)
+    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
+        q1, q2 = self.critic(critic_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
@@ -352,9 +351,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
         return critic_loss, jnp.abs(error1)
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        feature = self.preproc(policy_params, key, obses)
-        policy, log_prob = self._get_pi_log_prob(policy_params, feature, key)
-        q1_pi, q2_pi = self.critic(critic_params, key, feature, policy)
+        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        q1_pi, q2_pi = self.critic(critic_params, key, obses, policy)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
         return actor_loss, log_prob
 
@@ -368,8 +366,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
         key,
         ent_coef,
     ):
-        next_feature = self.preproc(policy_params, key, nxtobses)
-        policy, log_prob = self._get_pi_log_prob(policy_params, next_feature, key)
-        q1_pi, q2_pi = self.critic(target_critic_params, key, next_feature, policy)
+        policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
+        q1_pi, q2_pi = self.critic(target_critic_params, key, nxtobses, policy)
         next_q = jnp.minimum(q1_pi, q2_pi) - ent_coef * log_prob
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/SPO/impala_spo.py
+++ b/jax_baselines/SPO/impala_spo.py
@@ -8,12 +8,13 @@ class IMPALA_SPO(SurrogateIMPALA):
     _run_name = "IMPALA_SPO"
     _learn_log_interval = 10
 
-    def _loss_discrete(self, params, obses, actions, vs, mu_prob, pi_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(
+        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
-        logit = self.actor(params, key, feature)
+        logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -38,14 +39,15 @@ class IMPALA_SPO(SurrogateIMPALA):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, vs, mu_prob, pi_prob, adv, key):
+    def _loss_continuous(
+        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
+    ):
         # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
-        prob = self.actor(params, key, feature)
+        prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -33,16 +33,17 @@ class SPO(SurrogatePolicyGradient):
             **kwargs,
         )
 
-    def _loss_discrete(self, params, obses, actions, old_value, targets, old_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_discrete(
+        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -66,16 +67,17 @@ class SPO(SurrogatePolicyGradient):
             total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
-    def _loss_continuous(self, params, obses, actions, old_value, targets, old_prob, adv, key):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+    def _loss_continuous(
+        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
+    ):
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         mu, log_std = prob
         # Paper's Gaussian entropy: H = sum(log(sigma)) + 0.5*d*(1+log(2*pi))

--- a/jax_baselines/TD3/apex_td3.py
+++ b/jax_baselines/TD3/apex_td3.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 
 import jax
@@ -93,15 +94,16 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
         )
         self.actor_builder = self.get_actor_builder()
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.policy_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.target_params = deepcopy(self.params)
+        self.target_policy_params = deepcopy(self.policy_params)
+        self.target_critic_params = deepcopy(self.critic_params)
 
-        self.opt_state = self.optimizer.init(self.params)
-
-        self._get_actions = jax.jit(self._get_actions)
-        self._train_step = jax.jit(self._train_step)
+        self.opt_policy_state = self.optimizer.init(self.policy_params)
+        self.opt_critic_state = self.optimizer.init(self.critic_params)
+        self._get_actions: Callable = jax.jit(self._get_actions)
+        self._compiled_train_step: Callable = jax.jit(self._train_step)
 
     def get_actor_builder(self):
         gamma = self._gamma
@@ -126,7 +128,6 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
             def get_abs_td_error(
                 actor,
                 critic,
-                preproc,
                 params,
                 obses,
                 actions,
@@ -136,9 +137,9 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                 key,
             ):
                 size = next(iter(obses.values())).shape[0]
-                next_feature = preproc(params, key, convert_normalized_obs(nxtobses))
+                nxtobses = convert_normalized_obs(nxtobses)
                 next_action = jnp.clip(
-                    actor(params, key, next_feature)
+                    actor(params["policy"], key, nxtobses)
                     + jnp.clip(
                         target_action_noise * jax.random.normal(key, (size, action_size)),
                         -action_noise_clamp,
@@ -147,16 +148,15 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                     -1.0,
                     1.0,
                 )
-                q1, q2 = critic(params, key, next_feature, next_action)
+                q1, q2 = critic(params["critic"], key, nxtobses, next_action)
                 next_q = jnp.minimum(q1, q2)
-                feature = preproc(params, key, convert_normalized_obs(obses))
-                q_values1, _ = critic(params, key, feature, actions)
+                q_values1, _ = critic(params["critic"], key, convert_normalized_obs(obses), actions)
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td1_error = jnp.abs(q_values1 - target)
                 return jnp.squeeze(td1_error)
 
-            def actor(actor, preproc, params, obses, key):
-                return actor(params, key, preproc(params, key, convert_normalized_obs(obses)))
+            def actor(actor, params, obses, key):
+                return actor(params["policy"], key, convert_normalized_obs(obses))
 
             def get_action(actor, params, obs, noise, epsilon, key):
                 actions = np.clip(np.asarray(actor(params, obs, key)) + noise() * epsilon, -1, 1)[0]
@@ -170,15 +170,26 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
         return builder
 
     def _invoke_train_step(self, steps, data):
-        return self._train_step(
-            self.params, self.target_params, self.opt_state, next(self.key_seq), steps, **data
+        return self._compiled_train_step(
+            self.policy_params,
+            self.critic_params,
+            self.target_policy_params,
+            self.target_critic_params,
+            self.opt_policy_state,
+            self.opt_critic_state,
+            next(self.key_seq),
+            steps,
+            **data,
         )
 
     def _train_step(
         self,
-        params,
-        target_params,
-        opt_state,
+        policy_params,
+        critic_params,
+        target_policy_params,
+        target_critic_params,
+        opt_policy_state,
+        opt_critic_state,
         key,
         step,
         obses,
@@ -198,29 +209,89 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
         rewards_batch = rewards[batch_idxes]
         nxtobses_batch = jax.tree.map(lambda value: value[batch_idxes], nxtobses)
         not_terminateds_batch = not_terminateds[batch_idxes]
-        weights_batch = weights[batch_idxes]
+        weights_batch = jnp.broadcast_to(jnp.asarray(weights), (self.batch_size,))[batch_idxes]
 
         def f(carry, data):
-            params, opt_state, key, step = carry
+            (
+                policy_params,
+                critic_params,
+                opt_policy_state,
+                opt_critic_state,
+                key,
+                step,
+            ) = carry
             obses, actions, rewards, nxtobses, not_terminateds, weights = data
             key, *subkeys = jax.random.split(key, 3)
-            targets = self._target(target_params, rewards, nxtobses, not_terminateds, subkeys[0])
-            (total_loss, (critic_loss, actor_loss, abs_error)), grad = jax.value_and_grad(
-                self._loss, has_aux=True
-            )(params, obses, actions, targets, weights, subkeys[1], step)
-            updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-            params = optax.apply_updates(params, updates)
-            step = step + 1
-            return (params, opt_state, key, step), (total_loss, critic_loss, actor_loss, abs_error)
+            targets = self._target(
+                target_policy_params,
+                target_critic_params,
+                rewards,
+                nxtobses,
+                not_terminateds,
+                subkeys[0],
+            )
+            (_, (critic_loss, actor_loss, abs_error)), (actor_grad, critic_grad) = (
+                jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                    policy_params,
+                    critic_params,
+                    obses,
+                    actions,
+                    targets,
+                    weights,
+                    subkeys[1],
+                    step,
+                )
+            )
+            critic_updates, opt_critic_state = self.optimizer.update(
+                critic_grad, opt_critic_state, params=critic_params
+            )
 
-        (params, opt_state, key, step), (
-            total_loss,
-            critic_loss,
-            actor_loss,
-            abs_error,
+            def update_actor(state):
+                policy_params, opt_policy_state = state
+                updates, opt_policy_state = self.optimizer.update(
+                    actor_grad, opt_policy_state, params=policy_params
+                )
+                return optax.apply_updates(policy_params, updates), opt_policy_state
+
+            policy_params, opt_policy_state = jax.lax.cond(
+                step % self.policy_delay == 0,
+                update_actor,
+                lambda state: state,
+                (policy_params, opt_policy_state),
+            )
+            return (
+                policy_params,
+                optax.apply_updates(critic_params, critic_updates),
+                opt_policy_state,
+                opt_critic_state,
+                key,
+                step + 1,
+            ), (critic_loss, actor_loss, abs_error)
+
+        (
+            (
+                policy_params,
+                critic_params,
+                opt_policy_state,
+                opt_critic_state,
+                key,
+                step,
+            ),
+            (
+                critic_loss,
+                actor_loss,
+                abs_error,
+            ),
         ) = jax.lax.scan(
             f,
-            (params, opt_state, key, step),
+            (
+                policy_params,
+                critic_params,
+                opt_policy_state,
+                opt_critic_state,
+                key,
+                step,
+            ),
             (
                 obses_batch,
                 actions_batch,
@@ -230,37 +301,51 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                 weights_batch,
             ),
         )
-        target_params = soft_update(params, target_params, self.target_network_update_tau)
+        target_policy_params = soft_update(
+            policy_params, target_policy_params, self.target_network_update_tau
+        )
+        target_critic_params = soft_update(
+            critic_params, target_critic_params, self.target_network_update_tau
+        )
         new_priorities = jnp.reshape(abs_error, (-1,))
         return (
-            params,
-            target_params,
-            opt_state,
+            policy_params,
+            critic_params,
+            target_policy_params,
+            target_critic_params,
+            opt_policy_state,
+            opt_critic_state,
             jnp.mean(critic_loss),
             -jnp.mean(actor_loss),
             new_priorities,
         )
 
-    def _loss(self, params, obses, actions, targets, weights, key, step):
-        feature = self.preproc(params, key, obses)
-        q1, q2 = self.critic(params, key, feature, actions)
+    def _loss(self, policy_params, critic_params, obses, actions, targets, weights, key, step):
+        q1, q2 = self.critic(critic_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
             weights * jnp.square(error2)
         )
-        policy = self.actor(params, key, feature)
-        vals, _ = self.critic(jax.lax.stop_gradient(params), key, feature, policy)
+        policy = self.actor(policy_params, key, obses)
+        vals, _ = self.critic(jax.lax.stop_gradient(critic_params), key, obses, policy)
         actor_loss = jnp.mean(-vals)
         total_loss = jax.lax.select(
             step % self.policy_delay == 0, critic_loss + actor_loss, critic_loss
         )
         return total_loss, (critic_loss, actor_loss, jnp.abs(error1))
 
-    def _target(self, target_params, rewards, nxtobses, not_terminateds, key):
-        next_feature = self.preproc(target_params, key, nxtobses)
+    def _target(
+        self,
+        target_policy_params,
+        target_critic_params,
+        rewards,
+        nxtobses,
+        not_terminateds,
+        key,
+    ):
         next_action = jnp.clip(
-            self.actor(target_params, key, next_feature)
+            self.actor(target_policy_params, key, nxtobses)
             + jnp.clip(
                 self.target_action_noise
                 * jax.random.normal(key, (self.mini_batch_size, self.action_size[0])),
@@ -270,6 +355,6 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
             -1.0,
             1.0,
         )
-        q1, q2 = self.critic(target_params, key, next_feature, next_action)
+        q1, q2 = self.critic(target_critic_params, key, nxtobses, next_action)
         next_q = jnp.minimum(q1, q2)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -49,7 +49,6 @@ class TD3(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -79,9 +78,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
 
     def _get_actions(self, policy_params, obses, key=None) -> jnp.ndarray:
-        return self.actor(
-            policy_params, key, self.preproc(policy_params, key, convert_normalized_obs(obses))
-        )
+        return self.actor(policy_params, key, convert_normalized_obs(obses))
 
     def _policy_action_from_state(self, state, obs, eval, steps):
         return self._get_actions(state["policy"], obs, None)
@@ -139,13 +136,16 @@ class TD3(Deteministic_Policy_Gradient_Family):
             self.opt_critic_state,
         )
         (
-            self.policy_params,
-            self.critic_params,
-            self.target_policy_params,
-            self.target_critic_params,
-            self.opt_policy_state,
-            self.opt_critic_state,
-        ), (losses, targets, priorities) = self._bulk_scan(carry, keys, steps, data)
+            (
+                self.policy_params,
+                self.critic_params,
+                self.target_policy_params,
+                self.target_critic_params,
+                self.opt_policy_state,
+                self.opt_critic_state,
+            ),
+            (losses, targets, priorities),
+        ) = self._bulk_scan(carry, keys, steps, data)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
@@ -226,7 +226,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
             key,
         )
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key
+            critic_params, obses, actions, targets, weights, key
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -316,9 +316,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
-        feature = self.preproc(policy_params, key, obses)
-        q1, q2 = self.critic(critic_params, key, feature, actions)
+    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
+        q1, q2 = self.critic(critic_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
@@ -327,9 +326,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
         return critic_loss, jnp.abs(error1)
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
-        feature = self.preproc(policy_params, key, obses)
-        actions = self.actor(policy_params, key, feature)
-        q1, _ = self.critic(critic_params, key, feature, actions)
+        actions = self.actor(policy_params, key, obses)
+        q1, _ = self.critic(critic_params, key, obses, actions)
         return -jnp.mean(q1)
 
     def _target(
@@ -341,9 +339,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
         not_terminateds,
         key,
     ):
-        next_feature = self.preproc(target_policy_params, key, nxtobses)
         next_action = jnp.clip(
-            self.actor(target_policy_params, key, next_feature)
+            self.actor(target_policy_params, key, nxtobses)
             + jnp.clip(
                 self.target_action_noise
                 * jax.random.normal(key, (self.batch_size, self.action_size[0])),
@@ -353,6 +350,6 @@ class TD3(Deteministic_Policy_Gradient_Family):
             -1.0,
             1.0,
         )
-        q1, q2 = self.critic(target_critic_params, key, next_feature, next_action)
+        q1, q2 = self.critic(target_critic_params, key, nxtobses, next_action)
         next_q = jnp.minimum(q1, q2)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
@@ -16,11 +17,14 @@ from jax_baselines.math.param_updates import hard_update, scaled_by_reset
 
 @struct.dataclass
 class TD7CheckpointParams:
-    encoder_params: Any
+    actor_encoder_params: Any
+    critic_encoder_params: Any
     policy_params: Any
     critic_params: Any
-    fixed_encoder_params: Any
-    fixed_encoder_target_params: Any
+    fixed_actor_encoder_params: Any
+    fixed_critic_encoder_params: Any
+    fixed_actor_encoder_target_params: Any
+    fixed_critic_encoder_target_params: Any
     target_policy_params: Any
     target_critic_params: Any
 
@@ -31,7 +35,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         target_action_noise_mul=2.0,
         action_noise=0.1,
@@ -65,17 +69,21 @@ class TD7(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
-            self.encoder,
-            self.action_encoder,
+            self.actor_encoder,
+            self.critic_encoder,
+            self.actor_action_encoder,
+            self.critic_action_encoder,
             self.actor,
             self.critic,
-            self.encoder_params,
+            self.actor_encoder_params,
+            self.critic_encoder_params,
             self.policy_params,
             self.critic_params,
         ) = model_builder(next(self.key_seq), print_model=True)
-        self.fixed_encoder_params = deepcopy(self.encoder_params)
-        self.fixed_encoder_target_params = deepcopy(self.encoder_params)
+        self.fixed_actor_encoder_params = deepcopy(self.actor_encoder_params)
+        self.fixed_critic_encoder_params = deepcopy(self.critic_encoder_params)
+        self.fixed_actor_encoder_target_params = deepcopy(self.actor_encoder_params)
+        self.fixed_critic_encoder_target_params = deepcopy(self.critic_encoder_params)
         self.target_policy_params = deepcopy(self.policy_params)
         self.target_critic_params = deepcopy(self.critic_params)
 
@@ -88,41 +96,47 @@ class TD7(Deteministic_Policy_Gradient_Family):
             "max_value": jnp.array([0], dtype=jnp.float32),
         }
 
-        self.encoder_opt_state = self.optimizer.init(self.encoder_params)
+        self.actor_encoder_opt_state = self.optimizer.init(self.actor_encoder_params)
+        self.critic_encoder_opt_state = self.optimizer.init(self.critic_encoder_params)
         self.opt_policy_state = self.optimizer.init(self.policy_params)
         self.opt_critic_state = self.optimizer.init(self.critic_params)
-        self._get_actions = jax.jit(self._get_actions)
-        self._train_step = jax.jit(self._train_step)
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_get_actions: Callable = jax.jit(self._get_actions)
+        self._compiled_train_step: Callable = jax.jit(self._train_step)
+        self._compiled_bulk_scan: Callable = jax.jit(self._bulk_scan)
 
     def checkpoint_params(self):
         return TD7CheckpointParams(
-            encoder_params=self.encoder_params,
+            actor_encoder_params=self.actor_encoder_params,
+            critic_encoder_params=self.critic_encoder_params,
             policy_params=self.policy_params,
             critic_params=self.critic_params,
-            fixed_encoder_params=self.fixed_encoder_params,
-            fixed_encoder_target_params=self.fixed_encoder_target_params,
+            fixed_actor_encoder_params=self.fixed_actor_encoder_params,
+            fixed_critic_encoder_params=self.fixed_critic_encoder_params,
+            fixed_actor_encoder_target_params=self.fixed_actor_encoder_target_params,
+            fixed_critic_encoder_target_params=self.fixed_critic_encoder_target_params,
             target_policy_params=self.target_policy_params,
             target_critic_params=self.target_critic_params,
         )
 
     def load_checkpoint_params(self, bundle):
-        self.encoder_params = bundle.encoder_params
+        self.actor_encoder_params = bundle.actor_encoder_params
+        self.critic_encoder_params = bundle.critic_encoder_params
         self.policy_params = bundle.policy_params
         self.critic_params = bundle.critic_params
-        self.fixed_encoder_params = bundle.fixed_encoder_params
-        self.fixed_encoder_target_params = bundle.fixed_encoder_target_params
+        self.fixed_actor_encoder_params = bundle.fixed_actor_encoder_params
+        self.fixed_critic_encoder_params = bundle.fixed_critic_encoder_params
+        self.fixed_actor_encoder_target_params = bundle.fixed_actor_encoder_target_params
+        self.fixed_critic_encoder_target_params = bundle.fixed_critic_encoder_target_params
         self.target_policy_params = bundle.target_policy_params
         self.target_critic_params = bundle.target_critic_params
 
-    def _get_actions(self, encoder_params, policy_params, obses, key=None) -> jnp.ndarray:
-        feature = self.preproc(encoder_params, key, convert_normalized_obs(obses))
-        zs = self.encoder(encoder_params, key, feature)
+    def _get_actions(self, actor_encoder_params, policy_params, obses, key=None):
+        feature, zs = self.actor_encoder(actor_encoder_params, key, convert_normalized_obs(obses))
         return self.actor(policy_params, key, feature, zs)
 
     def get_behavior_state(self):
         return {
-            "encoder": self.fixed_encoder_params,
+            "actor_encoder": self.fixed_actor_encoder_params,
             "policy": self.policy_params,
         }
 
@@ -132,7 +146,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
         return self.get_behavior_state()
 
     def _policy_action_from_state(self, state, obs, eval, steps):
-        return self._get_actions(state["encoder"], state["policy"], obs, None)
+        return self._compiled_get_actions(state["actor_encoder"], state["policy"], obs, None)
 
     def _apply_action_noise(self, actions, steps, eval):
         if eval:
@@ -153,29 +167,37 @@ class TD7(Deteministic_Policy_Gradient_Family):
 
     def _train_on_batch(self, data, context):
         (
-            self.encoder_params,
+            self.actor_encoder_params,
+            self.critic_encoder_params,
             self.policy_params,
             self.critic_params,
-            self.fixed_encoder_params,
-            self.fixed_encoder_target_params,
+            self.fixed_actor_encoder_params,
+            self.fixed_critic_encoder_params,
+            self.fixed_actor_encoder_target_params,
+            self.fixed_critic_encoder_target_params,
             self.target_policy_params,
             self.target_critic_params,
-            self.encoder_opt_state,
+            self.actor_encoder_opt_state,
+            self.critic_encoder_opt_state,
             self.opt_policy_state,
             self.opt_critic_state,
             repr_loss,
             loss,
             t_mean,
             new_priorities,
-        ) = self._train_step(
-            self.encoder_params,
+        ) = self._compiled_train_step(
+            self.actor_encoder_params,
+            self.critic_encoder_params,
             self.policy_params,
             self.critic_params,
-            self.fixed_encoder_params,
-            self.fixed_encoder_target_params,
+            self.fixed_actor_encoder_params,
+            self.fixed_critic_encoder_params,
+            self.fixed_actor_encoder_target_params,
+            self.fixed_critic_encoder_target_params,
             self.target_policy_params,
             self.target_critic_params,
-            self.encoder_opt_state,
+            self.actor_encoder_opt_state,
+            self.critic_encoder_opt_state,
             self.opt_policy_state,
             self.opt_critic_state,
             next(self.key_seq),
@@ -193,29 +215,40 @@ class TD7(Deteministic_Policy_Gradient_Family):
         steps = jnp.asarray([context.train_steps_count for context in contexts])
         keys = jax.random.split(next(self.key_seq), len(contexts))
         carry = (
-            self.encoder_params,
+            self.actor_encoder_params,
+            self.critic_encoder_params,
             self.policy_params,
             self.critic_params,
-            self.fixed_encoder_params,
-            self.fixed_encoder_target_params,
+            self.fixed_actor_encoder_params,
+            self.fixed_critic_encoder_params,
+            self.fixed_actor_encoder_target_params,
+            self.fixed_critic_encoder_target_params,
             self.target_policy_params,
             self.target_critic_params,
-            self.encoder_opt_state,
+            self.actor_encoder_opt_state,
+            self.critic_encoder_opt_state,
             self.opt_policy_state,
             self.opt_critic_state,
         )
         (
-            self.encoder_params,
-            self.policy_params,
-            self.critic_params,
-            self.fixed_encoder_params,
-            self.fixed_encoder_target_params,
-            self.target_policy_params,
-            self.target_critic_params,
-            self.encoder_opt_state,
-            self.opt_policy_state,
-            self.opt_critic_state,
-        ), (repr_losses, losses, targets, priorities) = self._bulk_scan(carry, keys, steps, data)
+            (
+                self.actor_encoder_params,
+                self.critic_encoder_params,
+                self.policy_params,
+                self.critic_params,
+                self.fixed_actor_encoder_params,
+                self.fixed_critic_encoder_params,
+                self.fixed_actor_encoder_target_params,
+                self.fixed_critic_encoder_target_params,
+                self.target_policy_params,
+                self.target_critic_params,
+                self.actor_encoder_opt_state,
+                self.critic_encoder_opt_state,
+                self.opt_policy_state,
+                self.opt_critic_state,
+            ),
+            (repr_losses, losses, targets, priorities),
+        ) = self._compiled_bulk_scan(carry, keys, steps, data)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
@@ -227,27 +260,35 @@ class TD7(Deteministic_Policy_Gradient_Family):
     def _bulk_scan(self, carry, keys, steps, data):
         def train_one(carry, xs):
             (
-                encoder_params,
+                actor_encoder_params,
+                critic_encoder_params,
                 policy_params,
                 critic_params,
-                fixed_encoder_params,
-                fixed_encoder_target_params,
+                fixed_actor_encoder_params,
+                fixed_critic_encoder_params,
+                fixed_actor_encoder_target_params,
+                fixed_critic_encoder_target_params,
                 target_policy_params,
                 target_critic_params,
-                encoder_opt_state,
+                actor_encoder_opt_state,
+                critic_encoder_opt_state,
                 opt_policy_state,
                 opt_critic_state,
             ) = carry
             key, step, batch = xs
             (
-                encoder_params,
+                actor_encoder_params,
+                critic_encoder_params,
                 policy_params,
                 critic_params,
-                fixed_encoder_params,
-                fixed_encoder_target_params,
+                fixed_actor_encoder_params,
+                fixed_critic_encoder_params,
+                fixed_actor_encoder_target_params,
+                fixed_critic_encoder_target_params,
                 target_policy_params,
                 target_critic_params,
-                encoder_opt_state,
+                actor_encoder_opt_state,
+                critic_encoder_opt_state,
                 opt_policy_state,
                 opt_critic_state,
                 repr_loss,
@@ -255,14 +296,18 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 t_mean,
                 priorities,
             ) = self._train_step(
-                encoder_params,
+                actor_encoder_params,
+                critic_encoder_params,
                 policy_params,
                 critic_params,
-                fixed_encoder_params,
-                fixed_encoder_target_params,
+                fixed_actor_encoder_params,
+                fixed_critic_encoder_params,
+                fixed_actor_encoder_target_params,
+                fixed_critic_encoder_target_params,
                 target_policy_params,
                 target_critic_params,
-                encoder_opt_state,
+                actor_encoder_opt_state,
+                critic_encoder_opt_state,
                 opt_policy_state,
                 opt_critic_state,
                 key,
@@ -270,14 +315,18 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 **batch,
             )
             return (
-                encoder_params,
+                actor_encoder_params,
+                critic_encoder_params,
                 policy_params,
                 critic_params,
-                fixed_encoder_params,
-                fixed_encoder_target_params,
+                fixed_actor_encoder_params,
+                fixed_critic_encoder_params,
+                fixed_actor_encoder_target_params,
+                fixed_critic_encoder_target_params,
                 target_policy_params,
                 target_critic_params,
-                encoder_opt_state,
+                actor_encoder_opt_state,
+                critic_encoder_opt_state,
                 opt_policy_state,
                 opt_critic_state,
             ), (repr_loss, loss, t_mean, priorities)
@@ -306,14 +355,18 @@ class TD7(Deteministic_Policy_Gradient_Family):
 
     def _train_step(
         self,
-        encoder_params,
+        actor_encoder_params,
+        critic_encoder_params,
         policy_params,
         critic_params,
-        fixed_encoder_params,
-        fixed_encoder_target_params,
+        fixed_actor_encoder_params,
+        fixed_critic_encoder_params,
+        fixed_actor_encoder_target_params,
+        fixed_critic_encoder_target_params,
         target_policy_params,
         target_critic_params,
-        encoder_opt_state,
+        actor_encoder_opt_state,
+        critic_encoder_opt_state,
         opt_policy_state,
         opt_critic_state,
         key,
@@ -328,23 +381,26 @@ class TD7(Deteministic_Policy_Gradient_Family):
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        not_terminateds = 1.0 - terminateds
-
-        repr_loss, grad = jax.value_and_grad(self._encoder_loss)(
-            encoder_params, obses, nxtobses, actions, key
+        repr_loss, (actor_encoder_grad, critic_encoder_grad) = jax.value_and_grad(
+            self._encoder_loss, argnums=(0, 1)
+        )(actor_encoder_params, critic_encoder_params, obses, nxtobses, actions, key)
+        updates, actor_encoder_opt_state = self.optimizer.update(
+            actor_encoder_grad, actor_encoder_opt_state, params=actor_encoder_params
         )
-        updates, encoder_opt_state = self.optimizer.update(
-            grad, encoder_opt_state, params=encoder_params
+        actor_encoder_params = optax.apply_updates(actor_encoder_params, updates)
+        updates, critic_encoder_opt_state = self.optimizer.update(
+            critic_encoder_grad, critic_encoder_opt_state, params=critic_encoder_params
         )
-        encoder_params = optax.apply_updates(encoder_params, updates)
+        critic_encoder_params = optax.apply_updates(critic_encoder_params, updates)
 
         targets = self._target(
-            fixed_encoder_target_params,
+            fixed_actor_encoder_target_params,
+            fixed_critic_encoder_target_params,
             target_policy_params,
             target_critic_params,
             rewards,
             nxtobses,
-            not_terminateds,
+            1.0 - terminateds,
             key,
         )
         critic_params["values"]["min_value"] = jnp.minimum(
@@ -353,48 +409,74 @@ class TD7(Deteministic_Policy_Gradient_Family):
         critic_params["values"]["max_value"] = jnp.maximum(
             jnp.max(targets), critic_params["values"]["max_value"]
         )
-
-        feature, zs = self.feature_and_zs(fixed_encoder_params, obses, key)
-
+        actor_feature, actor_zs = self.actor_encoder(fixed_actor_encoder_params, key, obses)
+        critic_feature, critic_zs = self.critic_encoder(fixed_critic_encoder_params, key, obses)
         (critic_loss, priority), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, fixed_encoder_params, feature, zs, actions, targets, key
+            critic_params,
+            fixed_critic_encoder_params,
+            critic_feature,
+            critic_zs,
+            actions,
+            targets,
+            key,
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
         critic_params = optax.apply_updates(critic_params, updates)
 
-        def _opt_actor(policy_params, opt_policy_state, key):
+        def update_actor(state):
+            policy_params, opt_policy_state = state
             grad = jax.grad(self._actor_loss)(
-                policy_params, critic_params, fixed_encoder_params, feature, zs, key
+                policy_params,
+                critic_params,
+                fixed_critic_encoder_params,
+                actor_feature,
+                actor_zs,
+                critic_feature,
+                critic_zs,
+                key,
             )
             updates, opt_policy_state = self.optimizer.update(
                 grad, opt_policy_state, params=policy_params
             )
-            policy_params = optax.apply_updates(policy_params, updates)
-            return policy_params, opt_policy_state, key
+            return optax.apply_updates(policy_params, updates), opt_policy_state
 
-        policy_params, opt_policy_state, key = jax.lax.cond(
+        policy_params, opt_policy_state = jax.lax.cond(
             step % self.policy_delay == 0,
-            lambda x: _opt_actor(*x),
-            lambda x: x,
-            (policy_params, opt_policy_state, key),
+            update_actor,
+            lambda state: state,
+            (policy_params, opt_policy_state),
         )
-
         target_policy_params = hard_update(
             policy_params, target_policy_params, step, self.target_network_update_freq
         )
         target_critic_params = hard_update(
             critic_params, target_critic_params, step, self.target_network_update_freq
         )
-        fixed_encoder_target_params = hard_update(
-            fixed_encoder_params,
-            fixed_encoder_target_params,
+        fixed_actor_encoder_target_params = hard_update(
+            fixed_actor_encoder_params,
+            fixed_actor_encoder_target_params,
             step,
             self.target_network_update_freq,
         )
-        fixed_encoder_params = hard_update(
-            encoder_params, fixed_encoder_params, step, self.target_network_update_freq
+        fixed_critic_encoder_target_params = hard_update(
+            fixed_critic_encoder_params,
+            fixed_critic_encoder_target_params,
+            step,
+            self.target_network_update_freq,
+        )
+        fixed_actor_encoder_params = hard_update(
+            actor_encoder_params,
+            fixed_actor_encoder_params,
+            step,
+            self.target_network_update_freq,
+        )
+        fixed_critic_encoder_params = hard_update(
+            critic_encoder_params,
+            fixed_critic_encoder_params,
+            step,
+            self.target_network_update_freq,
         )
         if self.scaled_by_reset:
             policy_params, opt_policy_state = scaled_by_reset(
@@ -404,7 +486,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 key,
                 step,
                 self.reset_freq,
-                0.1,  # tau = 0.1 is softreset, but original paper uses 1.0
+                0.1,
             )
             critic_params, opt_critic_state = scaled_by_reset(
                 critic_params,
@@ -413,17 +495,21 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 key,
                 step,
                 self.reset_freq,
-                0.1,  # tau = 0.1 is softreset, but original paper uses 1.0
+                0.1,
             )
         return (
-            encoder_params,
+            actor_encoder_params,
+            critic_encoder_params,
             policy_params,
             critic_params,
-            fixed_encoder_params,
-            fixed_encoder_target_params,
+            fixed_actor_encoder_params,
+            fixed_critic_encoder_params,
+            fixed_actor_encoder_target_params,
+            fixed_critic_encoder_target_params,
             target_policy_params,
             target_critic_params,
-            encoder_opt_state,
+            actor_encoder_opt_state,
+            critic_encoder_opt_state,
             opt_policy_state,
             opt_critic_state,
             repr_loss,
@@ -432,40 +518,64 @@ class TD7(Deteministic_Policy_Gradient_Family):
             priority,
         )
 
-    def feature_and_zs(self, encoder_params, obses, key):
-        feature = self.preproc(encoder_params, key, convert_normalized_obs(obses))
-        zs = self.encoder(encoder_params, key, feature)
-        return feature, zs
+    def _encoder_loss(
+        self,
+        actor_encoder_params,
+        critic_encoder_params,
+        obses,
+        next_obses,
+        actions,
+        key,
+    ):
+        losses = []
+        for encoder, action_encoder, params in (
+            (self.actor_encoder, self.actor_action_encoder, actor_encoder_params),
+            (self.critic_encoder, self.critic_action_encoder, critic_encoder_params),
+        ):
+            _, next_zs = encoder(params, key, next_obses)
+            _, zs = encoder(params, key, obses)
+            pred_zs = action_encoder(params, key, zs, actions)
+            losses.append(jnp.mean(jnp.square(jax.lax.stop_gradient(next_zs) - pred_zs)))
+        return losses[0] + losses[1]
 
-    def _encoder_loss(self, encoder_params, obses, next_obses, actions, key):
-        next_zs = jax.lax.stop_gradient(
-            self.encoder(encoder_params, key, self.preproc(encoder_params, key, next_obses))
-        )
-        zs = self.encoder(encoder_params, key, self.preproc(encoder_params, key, obses))
-        pred_zs = self.action_encoder(encoder_params, key, zs, actions)
-        loss = jnp.mean(jnp.square(next_zs - pred_zs))
-        return loss
-
-    def _actor_loss(self, policy_params, critic_params, fixed_encoder_params, feature, zs, key):
-        actions = self.actor(policy_params, key, feature, zs)
-        zsa = self.action_encoder(fixed_encoder_params, key, zs, actions)
-        q1, q2 = self.critic(critic_params, key, feature, zs, zsa, actions)
+    def _actor_loss(
+        self,
+        policy_params,
+        critic_params,
+        fixed_critic_encoder_params,
+        actor_feature,
+        actor_zs,
+        critic_feature,
+        critic_zs,
+        key,
+    ):
+        actions = self.actor(policy_params, key, actor_feature, actor_zs)
+        zsa = self.critic_action_encoder(fixed_critic_encoder_params, key, critic_zs, actions)
+        q1, q2 = self.critic(critic_params, key, critic_feature, critic_zs, zsa, actions)
         return -jnp.mean(jnp.minimum(q1, q2))
 
-    def _critic_loss(self, critic_params, fixed_encoder_params, feature, zs, actions, targets, key):
-        zsa = self.action_encoder(fixed_encoder_params, key, zs, actions)
-
+    def _critic_loss(
+        self,
+        critic_params,
+        fixed_critic_encoder_params,
+        feature,
+        zs,
+        actions,
+        targets,
+        key,
+    ):
+        zsa = self.critic_action_encoder(fixed_critic_encoder_params, key, zs, actions)
         q1, q2 = self.critic(critic_params, key, feature, zs, zsa, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(hubberloss(error1, 1.0)) + jnp.mean(hubberloss(error2, 1.0))
-
         priority = jnp.maximum(jnp.maximum(jnp.abs(error1), jnp.abs(error2)), 1.0)
         return critic_loss, priority
 
     def _target(
         self,
-        fixed_encoder_target_params,
+        fixed_actor_encoder_target_params,
+        fixed_critic_encoder_target_params,
         target_policy_params,
         target_critic_params,
         rewards,
@@ -473,11 +583,14 @@ class TD7(Deteministic_Policy_Gradient_Family):
         not_terminateds,
         key,
     ):
-        next_feature = self.preproc(fixed_encoder_target_params, key, nxtobses)
-        fixed_target_zs = self.encoder(fixed_encoder_target_params, key, next_feature)
-
+        actor_feature, actor_zs = self.actor_encoder(
+            fixed_actor_encoder_target_params, key, nxtobses
+        )
+        critic_feature, critic_zs = self.critic_encoder(
+            fixed_critic_encoder_target_params, key, nxtobses
+        )
         next_action = jnp.clip(
-            self.actor(target_policy_params, key, next_feature, fixed_target_zs)
+            self.actor(target_policy_params, key, actor_feature, actor_zs)
             + jnp.clip(
                 self.target_action_noise
                 * jax.random.normal(key, (self.batch_size, self.action_size[0])),
@@ -487,17 +600,15 @@ class TD7(Deteministic_Policy_Gradient_Family):
             -1.0,
             1.0,
         )
-
-        fixed_target_zsa = self.action_encoder(
-            fixed_encoder_target_params, key, fixed_target_zs, next_action
+        critic_zsa = self.critic_action_encoder(
+            fixed_critic_encoder_target_params, key, critic_zs, next_action
         )
-
         q1, q2 = self.critic(
             target_critic_params,
             key,
-            next_feature,
-            fixed_target_zs,
-            fixed_target_zsa,
+            critic_feature,
+            critic_zs,
+            critic_zsa,
             next_action,
         )
         next_q = jnp.clip(

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -82,10 +82,11 @@ class IMPALA_TPPO(IMPALA_Family):
         )
         self.actor_builder = self.get_actor_builder()
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
@@ -99,16 +100,20 @@ class IMPALA_TPPO(IMPALA_Family):
         data = self.buffer.sample()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             rho,
             targets,
         ) = self._train_step(
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             next(self.key_seq),
             data[0],
             data[1],
@@ -134,7 +139,8 @@ class IMPALA_TPPO(IMPALA_Family):
 
     def preprocess(
         self,
-        params,
+        actor_params,
+        critic_params,
         key,
         obses,
         actions,
@@ -154,15 +160,10 @@ class IMPALA_TPPO(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         prob, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(params, key, feature),
+            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
             True,
@@ -191,8 +192,10 @@ class IMPALA_TPPO(IMPALA_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -203,7 +206,8 @@ class IMPALA_TPPO(IMPALA_Family):
         truncateds,
     ):
         obses, actions, vs, old_prob, old_act_prob, rho, adv = self.preprocess(
-            params,
+            actor_params,
+            critic_params,
             key,
             obses,
             actions,
@@ -215,7 +219,16 @@ class IMPALA_TPPO(IMPALA_Family):
         )
 
         def i_f(idx, vals):
-            params, opt_state, key, critic_loss, actor_loss, entropy_loss = vals
+            (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            ) = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(vs.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -228,19 +241,35 @@ class IMPALA_TPPO(IMPALA_Family):
             adv_batch = adv[batch_idxes]
 
             def f(updates, input):
-                params, opt_state, key = updates
+                actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, vs, old_prob, old_act_prob, adv = input
                 use_key, key = jax.random.split(key)
-                (_total_loss, (critic_loss, actor_loss, entropy_loss),), grad = jax.value_and_grad(
-                    self._loss, has_aux=True
-                )(params, obs, act, vs, old_prob, old_act_prob, adv, use_key)
-                updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-                params = optax.apply_updates(params, updates)
-                return (params, opt_state, key), (critic_loss, actor_loss, entropy_loss)
+                (
+                    (
+                        _total_loss,
+                        (critic_loss, actor_loss, entropy_loss),
+                    ),
+                    (actor_grad, critic_grad),
+                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                    actor_params, critic_params, obs, act, vs, old_prob, old_act_prob, adv, use_key
+                )
+                actor_updates, actor_opt_state = self.optimizer.update(
+                    actor_grad, actor_opt_state, params=actor_params
+                )
+                critic_updates, critic_opt_state = self.optimizer.update(
+                    critic_grad, critic_opt_state, params=critic_params
+                )
+                actor_params = optax.apply_updates(actor_params, actor_updates)
+                critic_params = optax.apply_updates(critic_params, critic_updates)
+                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
+                    critic_loss,
+                    actor_loss,
+                    entropy_loss,
+                )
 
             updates, losses = jax.lax.scan(
                 f,
-                (params, opt_state, key),
+                (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
                 (
                     obses_batch,
                     actions_batch,
@@ -250,18 +279,43 @@ class IMPALA_TPPO(IMPALA_Family):
                     adv_batch,
                 ),
             )
-            params, opt_state, key = updates
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
             cl, al, el = losses
             critic_loss += jnp.mean(cl)
             actor_loss += jnp.mean(al)
             entropy_loss += jnp.mean(el)
-            return params, opt_state, key, critic_loss, actor_loss, entropy_loss
+            return (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+            )
 
-        val = jax.lax.fori_loop(0, self.epoch_num, i_f, (params, opt_state, key, 0.0, 0.0, 0.0))
-        params, opt_state, key, critic_loss, actor_loss, entropy_loss = val
+        val = jax.lax.fori_loop(
+            0,
+            self.epoch_num,
+            i_f,
+            (actor_params, critic_params, actor_opt_state, critic_opt_state, key, 0.0, 0.0, 0.0),
+        )
+        (
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            key,
+            critic_loss,
+            actor_loss,
+            entropy_loss,
+        ) = val
         return (
-            params,
-            opt_state,
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
             critic_loss / self.epoch_num,
             actor_loss / self.epoch_num,
             entropy_loss / self.epoch_num,
@@ -271,7 +325,8 @@ class IMPALA_TPPO(IMPALA_Family):
 
     def _loss_discrete(
         self,
-        params,
+        actor_params,
+        critic_params,
         obses,
         actions,
         vs,
@@ -280,12 +335,11 @@ class IMPALA_TPPO(IMPALA_Family):
         adv,
         key,
     ):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -315,7 +369,8 @@ class IMPALA_TPPO(IMPALA_Family):
 
     def _loss_continuous(
         self,
-        params,
+        actor_params,
+        critic_params,
         obses,
         actions,
         vs,
@@ -324,12 +379,11 @@ class IMPALA_TPPO(IMPALA_Family):
         adv,
         key,
     ):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         mu, log_std = prob
         prob_std = (mu, jnp.broadcast_to(jnp.exp(log_std), mu.shape))

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -56,10 +56,11 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             self.observation_space, self.action_size, self.action_type, self.policy_kwargs
         )
 
-        self.preproc, self.actor, self.critic, self.params = self.model_builder(
+        self.actor, self.critic, self.actor_params, self.critic_params = self.model_builder(
             next(self.key_seq), print_model=True
         )
-        self.opt_state = self.optimizer.init(self.params)
+        self.actor_opt_state = self.optimizer.init(self.actor_params)
+        self.critic_opt_state = self.optimizer.init(self.critic_params)
 
         self._get_actions = jax.jit(self._get_actions)
         self._preprocess = jax.jit(self._preprocess)
@@ -69,14 +70,23 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         data = self.buffer.get_buffer()
 
         (
-            self.params,
-            self.opt_state,
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
             critic_loss,
             actor_loss,
             entropy_loss,
             kls,
             targets,
-        ) = self._train_step(self.params, self.opt_state, next(self.key_seq), **data)
+        ) = self._train_step(
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
+            next(self.key_seq),
+            **data,
+        )
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)
@@ -87,18 +97,24 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
 
         return critic_loss
 
-    def _preprocess(self, params, key, obses, actions, rewards, nxtobses, terminateds, truncateds):
+    def _preprocess(
+        self,
+        actor_params,
+        critic_params,
+        key,
+        obses,
+        actions,
+        rewards,
+        nxtobses,
+        terminateds,
+        truncateds,
+    ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        feature = jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, obses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(params, key, feature)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(
-            params,
-            key,
-            jax.vmap(self.preproc, in_axes=(None, None, 0))(params, key, nxtobses),
-        )
+        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
+        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
         prob, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(params, key, feature),
+            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
             True,
@@ -122,8 +138,10 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
 
     def _train_step(
         self,
-        params,
-        opt_state,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
         key,
         obses,
         actions,
@@ -133,11 +151,29 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         truncateds,
     ):
         obses, actions, old_value, targets, old_prob, old_act_prob, adv = self._preprocess(
-            params, key, obses, actions, rewards, nxtobses, terminateds, truncateds
+            actor_params,
+            critic_params,
+            key,
+            obses,
+            actions,
+            rewards,
+            nxtobses,
+            terminateds,
+            truncateds,
         )
 
         def i_f(idx, vals):
-            params, opt_state, key, critic_loss, actor_loss, entropy_loss, kls = vals
+            (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+                kls,
+            ) = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(targets.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -151,21 +187,47 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             adv_batch = adv[batch_idxes]
 
             def f(updates, input):
-                params, opt_state, key = updates
+                actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, old_value, target, old_prob, old_act_prob, adv = input
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (_total_loss, (c_loss, a_loss, entropy_loss, kl),), grad = jax.value_and_grad(
-                    self._loss, has_aux=True
-                )(params, obs, act, old_value, target, old_prob, old_act_prob, adv, use_key)
-                updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
-                params = optax.apply_updates(params, updates)
-                return (params, opt_state, key), (c_loss, a_loss, entropy_loss, kl)
+                (
+                    (
+                        _total_loss,
+                        (c_loss, a_loss, entropy_loss, kl),
+                    ),
+                    (actor_grad, critic_grad),
+                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                    actor_params,
+                    critic_params,
+                    obs,
+                    act,
+                    old_value,
+                    target,
+                    old_prob,
+                    old_act_prob,
+                    adv,
+                    use_key,
+                )
+                actor_updates, actor_opt_state = self.optimizer.update(
+                    actor_grad, actor_opt_state, params=actor_params
+                )
+                critic_updates, critic_opt_state = self.optimizer.update(
+                    critic_grad, critic_opt_state, params=critic_params
+                )
+                actor_params = optax.apply_updates(actor_params, actor_updates)
+                critic_params = optax.apply_updates(critic_params, critic_updates)
+                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
+                    c_loss,
+                    a_loss,
+                    entropy_loss,
+                    kl,
+                )
 
             updates, losses = jax.lax.scan(
                 f,
-                (params, opt_state, key),
+                (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
                 (
                     obses_batch,
                     actions_batch,
@@ -176,21 +238,56 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                     adv_batch,
                 ),
             )
-            params, opt_state, key = updates
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
             cl, al, el, kl = losses
             critic_loss += jnp.mean(cl)
             actor_loss += jnp.mean(al)
             entropy_loss += jnp.mean(el)
             kls += jnp.mean(kl)
-            return params, opt_state, key, critic_loss, actor_loss, entropy_loss, kls
+            return (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                critic_loss,
+                actor_loss,
+                entropy_loss,
+                kls,
+            )
 
         val = jax.lax.fori_loop(
-            0, self.epoch_num, i_f, (params, opt_state, key, 0.0, 0.0, 0.0, 0.0)
+            0,
+            self.epoch_num,
+            i_f,
+            (
+                actor_params,
+                critic_params,
+                actor_opt_state,
+                critic_opt_state,
+                key,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ),
         )
-        params, opt_state, key, critic_loss, actor_loss, entropy_loss, kls = val
+        (
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            key,
+            critic_loss,
+            actor_loss,
+            entropy_loss,
+            kls,
+        ) = val
         return (
-            params,
-            opt_state,
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
             critic_loss / self.epoch_num,
             actor_loss / self.epoch_num,
             entropy_loss / self.epoch_num,
@@ -199,17 +296,26 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         )
 
     def _loss_discrete(
-        self, params, obses, actions, old_value, targets, old_prob, old_act_prob, adv, key
+        self,
+        actor_params,
+        critic_params,
+        obses,
+        actions,
+        old_value,
+        targets,
+        old_prob,
+        old_act_prob,
+        adv,
+        key,
     ):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         # Paper's entropy: H = -sum(p * log(p)) >= 0
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -240,17 +346,26 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         return total_loss, (critic_loss, actor_loss, entropy_loss, jnp.mean(kl))
 
     def _loss_continuous(
-        self, params, obses, actions, old_value, targets, old_prob, old_act_prob, adv, key
+        self,
+        actor_params,
+        critic_params,
+        obses,
+        actions,
+        old_value,
+        targets,
+        old_prob,
+        old_act_prob,
+        adv,
+        key,
     ):
-        feature = self.preproc(params, key, obses)
-        vals = self.critic(params, key, feature)
+        vals = self.critic(critic_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
         critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
 
         prob, log_prob = self.get_logprob(
-            self.actor(params, key, feature), actions, key, out_prob=True
+            self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
         mu, log_std = prob
         std = jnp.broadcast_to(jnp.exp(log_std), mu.shape)

--- a/jax_baselines/TQC/tqc.py
+++ b/jax_baselines/TQC/tqc.py
@@ -48,7 +48,6 @@ class TQC(SAC):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -74,9 +73,8 @@ class TQC(SAC):
         self._train_ent_coef = jax.jit(self._train_ent_coef)
         self._bulk_scan = jax.jit(self._bulk_scan)
 
-    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
-        feature = self.preproc(policy_params, key, obses)
-        qnets = self.critic(critic_params, key, feature, actions)
+    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
+        qnets = self.critic(critic_params, key, obses, actions)
         logit_valid_tile = jnp.expand_dims(targets, axis=2)  # batch x support x 1
         huber0 = QuantileHuberLosses(
             logit_valid_tile,
@@ -98,9 +96,8 @@ class TQC(SAC):
         return critic_loss, huber0
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        feature = self.preproc(policy_params, key, obses)
-        policy, log_prob = self._get_pi_log_prob(policy_params, feature, key)
-        qnets_pi = self.critic(critic_params, key, feature, policy)
+        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        qnets_pi = self.critic(critic_params, key, obses, policy)
         actor_loss = jnp.mean(
             ent_coef * log_prob - jnp.mean(jnp.concatenate(qnets_pi, axis=1), axis=1)
         )
@@ -116,11 +113,8 @@ class TQC(SAC):
         key,
         ent_coef,
     ):
-        next_feature = self.preproc(target_critic_params, key, nxtobses)
-        policy, log_prob = self._get_pi_log_prob(
-            policy_params, self.preproc(policy_params, key, nxtobses), key
-        )
-        qnets_pi = self.critic(target_critic_params, key, next_feature, policy)
+        policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
+        qnets_pi = self.critic(target_critic_params, key, nxtobses, policy)
         if self.mixture_type == "min":
             next_q = jnp.min(jnp.stack(qnets_pi, axis=-1), axis=-1) - ent_coef * log_prob
         else:

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -83,7 +83,6 @@ class XQC(Deteministic_Policy_Gradient_Family):
             self.policy_kwargs,
         )
         (
-            self.preproc,
             self.actor,
             self.critic,
             self.policy_params,
@@ -117,8 +116,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = getattr(bundle, "target_critic_params", bundle.critic_params)
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, feature, key=None, training: bool = True) -> jnp.ndarray:
-        (mu, log_std), updates = self.actor(params, None, feature, training)
+    def _get_pi_log_prob(self, params, obses, key=None, training: bool = True) -> jnp.ndarray:
+        (mu, log_std), updates = self.actor(params, None, obses, training)
         params["batch_stats"] = updates["batch_stats"]
         std = jnp.exp(log_std)
         x_t = mu + std * jax.random.normal(key, std.shape)
@@ -132,17 +131,13 @@ class XQC(Deteministic_Policy_Gradient_Family):
         return pi, log_prob, params
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
-        (mu, log_std), _ = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
-        )
+        (mu, log_std), _ = self.actor(params, None, convert_normalized_obs(obses), False)
         std = jnp.exp(log_std)
         pi = jax.nn.tanh(mu + std * jax.random.normal(key, std.shape))
         return pi
 
     def _get_eval_actions(self, params, obses) -> jnp.ndarray:
-        (mu, _), _ = self.actor(
-            params, None, self.preproc(params, None, convert_normalized_obs(obses)), False
-        )
+        (mu, _), _ = self.actor(params, None, convert_normalized_obs(obses), False)
         return jax.nn.tanh(mu)
 
     def _train_on_batch(self, data, context):
@@ -295,7 +290,6 @@ class XQC(Deteministic_Policy_Gradient_Family):
             self._critic_loss, has_aux=True
         )(
             critic_params,
-            policy_params,
             obses,
             actions,
             nxtobses,
@@ -402,7 +396,6 @@ class XQC(Deteministic_Policy_Gradient_Family):
     def _critic_loss(
         self,
         critic_params,
-        policy_params,
         obses,
         actions,
         nxtobses,
@@ -414,12 +407,11 @@ class XQC(Deteministic_Policy_Gradient_Family):
         concated_obses = {
             name: jnp.concatenate([obs, nxtobses[name]]) for name, obs in obses.items()
         }
-        concated_preproc = self.preproc(policy_params, key, concated_obses)
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), variable_updates = self.critic(
-            critic_params, key, concated_preproc, concated_actions, True
+            critic_params, key, concated_obses, concated_actions, True
         )
-        critic_params["batch_stats"] = variable_updates["batch_stats"]
+        critic_params = {**critic_params, **variable_updates}
         logits1 = jnp.split(logits1, 2, axis=0)[0]
         logits2 = jnp.split(logits2, 2, axis=0)[0]
         cross_entropy1 = -jnp.sum(
@@ -437,9 +429,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
         return jnp.sum(jax.nn.softmax(logits, axis=-1) * self.value_support, axis=-1)
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        feature = self.preproc(policy_params, key, obses)
-        policy, log_prob, policy_params = self._get_pi_log_prob(policy_params, feature, key)
-        (logits1, logits2), _ = self.critic(critic_params, key, feature, policy, False)
+        policy, log_prob, policy_params = self._get_pi_log_prob(policy_params, obses, key)
+        (logits1, logits2), _ = self.critic(critic_params, key, obses, policy, False)
         q1_pi = self._categorical_q(logits1)
         q2_pi = self._categorical_q(logits2)
         actor_loss = jnp.mean(ent_coef * jnp.squeeze(log_prob, axis=-1) - jnp.minimum(q1_pi, q2_pi))
@@ -460,14 +451,10 @@ class XQC(Deteministic_Policy_Gradient_Family):
         concated_obses = {
             name: jnp.concatenate([obs, nxtobses[name]]) for name, obs in obses.items()
         }
-        concated_preproc = self.preproc(policy_params, key, concated_obses)
-        next_preproc = jax.tree_util.tree_map(
-            lambda feature: jnp.split(feature, 2, axis=0)[1], concated_preproc
-        )
-        next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, next_preproc, key, False)
+        next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key, False)
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), _ = self.critic(
-            target_critic_params, key, concated_preproc, concated_actions, True
+            target_critic_params, key, concated_obses, concated_actions, True
         )
         next_logits1 = jnp.split(logits1, 2, axis=0)[1]
         next_logits2 = jnp.split(logits2, 2, axis=0)[1]

--- a/jax_baselines/core/checkpoint_state.py
+++ b/jax_baselines/core/checkpoint_state.py
@@ -31,7 +31,8 @@ from flax import struct
 class ACCheckpointState:
     """Actor-critic parameters and the observation statistics used for inference."""
 
-    params: Any
+    actor_params: Any
+    critic_params: Any
     obs_rms_state: dict | None = None
 
 

--- a/model_builder/flax/Module.py
+++ b/model_builder/flax/Module.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import flax
 import flax.linen as nn
@@ -13,7 +13,7 @@ from flax.linen.normalization import _canonicalize_axes, _compute_stats, _normal
 from jax import lax
 from jax.nn import initializers
 
-from model_builder.utils import ActorCriticFeatures, observation_role_keys
+from model_builder.utils import observation_role_keys
 
 
 class ResBlock(nn.Module):
@@ -130,11 +130,10 @@ class PreProcess(nn.Module):
     flatten: bool = True
     pre_postprocess: Callable = lambda x: x  # Identity function
     multiple: int = 1
-    paired: bool = False
+    role: Literal["actor", "critic"] = "actor"
 
     def setup(self):
-        self.role_keys = observation_role_keys(self.states_size, self.paired)
-        selected = {key for keys in self.role_keys.values() for key in keys}
+        self.observation_keys = observation_role_keys(self.states_size, self.role)
         self.embedding = {
             key: (
                 visual_embedding(self.embedding_mode, self.flatten, multiple=self.multiple)
@@ -142,26 +141,15 @@ class PreProcess(nn.Module):
                 else lambda x: x
             )
             for key, st in self.states_size.items()
-            if key in selected
+            if key in self.observation_keys
         }
 
     @nn.compact
     def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
         return self.pre_postprocess(
             jnp.concatenate(
-                [self.embedding[key](obses[key]) for key in self.role_keys["actor"]], axis=1
+                [self.embedding[key](obses[key]) for key in self.observation_keys], axis=1
             )
-        )
-
-    def actor_critic(self, obses: dict[str, jnp.ndarray]) -> ActorCriticFeatures:
-        embedded = {key: pre(obses[key]) for key, pre in self.embedding.items()}
-        return ActorCriticFeatures(
-            actor=self.pre_postprocess(
-                jnp.concatenate([embedded[key] for key in self.role_keys["actor"]], axis=1)
-            ),
-            critic=self.pre_postprocess(
-                jnp.concatenate([embedded[key] for key in self.role_keys["critic"]], axis=1)
-            ),
         )
 
     @property

--- a/model_builder/flax/ac/ac_builder.py
+++ b/model_builder/flax/ac/ac_builder.py
@@ -7,24 +7,24 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
 class Actor(nn.Module):
-    action_size: int
+    action_size: list[int]
     action_type: str
     node: int
     hidden_n: int
-    layer: nn.Module = Dense
+    layer: type[nn.Module] = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray]:
         mlp = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(features["actor"])
+        )(features)
         if self.action_type == "discrete":
             action_probs = self.layer(
                 self.action_size[0], kernel_init=clip_factorized_uniform(0.01)
@@ -38,57 +38,53 @@ class Actor(nn.Module):
                 2,
             )
             return mu, log_std
+        raise ValueError(f"Unsupported action type: {self.action_type}")
 
 
 class Critic(nn.Module):
     node: int
     hidden_n: int
-    layer: nn.Module = Dense
+    layer: type[nn.Module] = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(0.01))]
-        )(features["critic"])
+        )(features)
         return net
 
 
 def model_builder_maker(observation_space, action_size, action_type, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def _model_builder(key=None, print_model=False):
-        class Merged(nn.Module):
-            def setup(self):
-                self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
-                )
-                self.act = Actor(action_size, action_type, **policy_kwargs)
-                self.cri = Critic(**policy_kwargs)
-
+        class ActorModel(nn.Module):
+            @nn.compact
             def __call__(self, x):
-                x = self.preproc.actor_critic(x)
-                return self.act(x), self.cri(x)
+                return Actor(action_size, action_type, **actor_kwargs)(
+                    PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(x)
+                )
 
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
+        class CriticModel(nn.Module):
+            @nn.compact
+            def __call__(self, x):
+                return Critic(**critic_kwargs)(
+                    PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(x)
+                )
 
-            def actor(self, x):
-                return self.act(x)
-
-            def critic(self, x):
-                return self.cri(x)
-
-        model = Merged()
-        preproc_fn = get_apply_fn_flax_module(model, model.preprocess)
-        actor_fn = get_apply_fn_flax_module(model, model.actor)
-        critic_fn = get_apply_fn_flax_module(model, model.critic)
+        actor = ActorModel()
+        critic = CriticModel()
+        actor_fn = get_apply_fn_flax_module(actor)
+        critic_fn = get_apply_fn_flax_module(critic)
         if key is not None:
+            actor_key, critic_key = jax.random.split(key)
             observation = dummy_observation(observation_space)
-            params = model.init(key, observation)
-            print_flax_model_summary(print_model, key, (model, observation))
-            return preproc_fn, actor_fn, critic_fn, params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+            actor_params = actor.init(actor_key, observation)
+            critic_params = critic.init(critic_key, observation)
+            print_flax_model_summary(print_model, key, (actor, observation), (critic, observation))
+            return actor_fn, critic_fn, actor_params, critic_params
+        return actor_fn, critic_fn
 
     return _model_builder

--- a/model_builder/flax/dpg/crossq_builder.py
+++ b/model_builder/flax/dpg/crossq_builder.py
@@ -8,9 +8,9 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -21,8 +21,8 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        feature = features["actor"]
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        feature = features
         for _ in range(self.hidden_n):
             feature = self.layer(self.node)(feature)
             feature = jax.nn.relu(feature)
@@ -31,26 +31,24 @@ class Actor(nn.Module):
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
             bias_init=lambda key, shape, dtype: jnp.full(shape, 10.0, dtype=dtype),
-        )(
-            feature
-        )  # initialize std with high values
+        )(feature)  # initialize std with high values
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
 
 class Critic(nn.Module):
-    node: int = 256
+    node: int = 2048
     hidden_n: int = 2
     layer: nn.Module = Dense
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
+        self, features: jnp.ndarray, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
-        feature = features["critic"]
+        feature = features
         concat = jnp.concatenate([feature, actions], axis=1)
         feature = BatchReNorm(use_running_average=not training)(concat)
         for _ in range(self.hidden_n):
-            feature = self.layer(self.node * 8)(feature)
+            feature = self.layer(self.node)(feature)
             feature = BatchReNorm(use_running_average=not training)(feature)
             feature = jax.nn.tanh(feature)
         q_net = self.layer(1, kernel_init=clip_factorized_uniform(3))(feature)
@@ -59,54 +57,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs, critic_node=2048)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a, training: bool = True):
-                return (self.crit1(x, a, training), self.crit2(x, a, training))
+            def __call__(self, observation, action, training: bool = True):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic, mutable=["batch_stats"])
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action, True)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action, True),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action, True)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action, True),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/ddpg_builder.py
+++ b/model_builder/flax/dpg/ddpg_builder.py
@@ -1,10 +1,15 @@
 import flax.linen as nn
+import jax
 import numpy as np
 
 from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    dummy_observation,
+    print_flax_model_summary,
+    split_actor_critic_kwargs,
+)
 
 
 def _make_model_builder(
@@ -17,51 +22,52 @@ def _make_model_builder(
     twin_critic,
 ):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = actor_cls(action_size, **policy_kwargs)
+                self.act = actor_cls(action_size, **actor_kwargs)
 
             def __call__(self, x):
-                return self.actor(self.preprocess(x))
-
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
-
-            def actor(self, x):
-                return self.act(x)
+                return self.act(self.preproc(x))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = critic_cls(**policy_kwargs)
-                self.crit2 = critic_cls(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = critic_cls(**critic_kwargs)
+                if twin_critic:
+                    self.crit2 = critic_cls(**critic_kwargs)
 
             def __call__(self, x, a):
-                return self.crit1(x, a), self.crit2(x, a)
+                feature = self.preproc(x)
+                if twin_critic:
+                    return self.crit1(feature, a), self.crit2(feature, a)
+                return self.crit1(feature, a)
 
         actor_model = Merged_Actor()
-        critic_model = Merged_Critic() if twin_critic else critic_cls(**policy_kwargs)
-        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
-        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor)
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
         critic_fn = get_apply_fn_flax_module(critic_model)
         if key is not None:
             observation = dummy_observation(observation_space)
             action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = actor_model.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = critic_model.init(key, feature, action)
+            actor_key, critic_key = jax.random.split(key)
+            policy_params = actor_model.init(actor_key, observation)
+            critic_params = critic_model.init(critic_key, observation, action)
             print_flax_model_summary(
                 print_model,
                 key,
                 (actor_model, observation),
-                (critic_model, feature, action),
+                (critic_model, observation, action),
             )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        return preproc_fn, actor_fn, critic_fn
+            return actor_fn, critic_fn, policy_params, critic_params
+        return actor_fn, critic_fn
 
     return model_builder
 

--- a/model_builder/flax/dpg/ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/ddpg_td3_blocks.py
@@ -12,7 +12,6 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
-from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -22,14 +21,14 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         action = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
                 self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3)),
                 jax.nn.tanh,
             ]
-        )(features["actor"])
+        )(features)
         return action
 
 
@@ -39,8 +38,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(3))]

--- a/model_builder/flax/dpg/flashsac_builder.py
+++ b/model_builder/flax/dpg/flashsac_builder.py
@@ -6,11 +6,11 @@ import jax.numpy as jnp
 
 from jax_baselines.math.param_updates import project_unit_norm_params
 from model_builder.flax.apply import get_apply_fn_flax_module
+from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
-    observation_role_keys,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -77,9 +77,9 @@ class Actor(nn.Module):
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, training: bool = False
+        self, features: jnp.ndarray, training: bool = False
     ) -> tuple[jax.Array, jax.Array]:
-        feature = Encoder(self.node, self.hidden_n)(features["actor"], training)
+        feature = Encoder(self.node, self.hidden_n)(features, training)
         mean = nn.Dense(self.action_dim, kernel_init=nn.initializers.orthogonal(), name="mean")(
             feature
         )
@@ -96,10 +96,10 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, actions: jax.Array, training: bool = False
+        self, features: jnp.ndarray, actions: jax.Array, training: bool = False
     ) -> jax.Array:
         feature = Encoder(self.node, self.hidden_n)(
-            jnp.concatenate((features["critic"], actions), axis=-1), training
+            jnp.concatenate((features, actions), axis=-1), training
         )
         return nn.Dense(self.n_atoms, kernel_init=nn.initializers.orthogonal(), name="value")(
             feature
@@ -112,20 +112,16 @@ def model_builder_maker(
     policy_kwargs,
 ):
     """Build FlashSAC's residual policy and independent categorical twin critics."""
-    policy_kwargs = {} if policy_kwargs is None else dict(policy_kwargs)
-    actor_node = policy_kwargs.pop("actor_node", 128)
-    critic_node = policy_kwargs.pop("critic_node", 256)
+    policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
     hidden_n = policy_kwargs.pop("hidden_n", 2)
     n_atoms = policy_kwargs.pop("n_atoms", 101)
-    embedding_mode = policy_kwargs.pop("embedding_mode", "normal")
-    if policy_kwargs:
-        raise ValueError(f"Unsupported FlashSAC policy options: {sorted(policy_kwargs)}")
-    for name, value, minimum in (
-        ("actor_node", actor_node, 1),
-        ("critic_node", critic_node, 1),
-        ("hidden_n", hidden_n, 0),
-        ("n_atoms", n_atoms, 2),
-    ):
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(
+        policy_kwargs, actor_node=128, critic_node=256
+    )
+    unsupported = set(actor_kwargs) - {"node"}
+    if unsupported:
+        raise ValueError(f"Unsupported FlashSAC policy options: {sorted(unsupported)}")
+    for name, value, minimum in (("hidden_n", hidden_n, 0), ("n_atoms", n_atoms, 2)):
         if type(value) is not int or value < minimum:
             raise ValueError(f"FlashSAC {name} must be an integer >= {minimum}")
     if embedding_mode != "normal":
@@ -137,60 +133,47 @@ def model_builder_maker(
     if len(action_size) != 1 or action_size[0] < 1:
         raise ValueError("FlashSAC requires a nonempty vector action space")
     observation_space = {name: tuple(shape) for name, shape in observation_space.items()}
-    role_keys = observation_role_keys(observation_space, actor_critic=True)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
-                self.act = Actor(action_size[0], actor_node, hidden_n)
+                self.preproc = PreProcess(observation_space, role="actor")
+                self.act = Actor(action_size[0], hidden_n=hidden_n, **actor_kwargs)
 
             def __call__(self, observation, training: bool = False):
-                return self.actor(self.preprocess(observation), training)
-
-            def preprocess(self, observation) -> ActorCriticFeatures:
-                return ActorCriticFeatures(
-                    actor=jnp.concatenate(
-                        [observation[name] for name in role_keys["actor"]], axis=-1
-                    ),
-                    critic=jnp.concatenate(
-                        [observation[name] for name in role_keys["critic"]], axis=-1
-                    ),
-                )
-
-            def actor(self, features: ActorCriticFeatures, training: bool = False):
-                return self.act(features, training)
+                return self.act(self.preproc(observation), training)
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(critic_node, hidden_n, n_atoms)
-                self.crit2 = Critic(critic_node, hidden_n, n_atoms)
+                self.preproc = PreProcess(observation_space, role="critic")
+                self.crit1 = Critic(hidden_n=hidden_n, n_atoms=n_atoms, **critic_kwargs)
+                self.crit2 = Critic(hidden_n=hidden_n, n_atoms=n_atoms, **critic_kwargs)
 
-            def __call__(self, features, actions, training: bool = False):
-                return self.crit1(features, actions, training), self.crit2(
-                    features, actions, training
+            def __call__(self, observation, actions, training: bool = False):
+                feature = self.preproc(observation)
+                return self.crit1(feature, actions, training), self.crit2(
+                    feature, actions, training
                 )
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
-        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
-        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor, mutable=["batch_stats"])
+        actor_fn = get_apply_fn_flax_module(actor_model, mutable=["batch_stats"])
         critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
         if key is None:
-            return preproc_fn, actor_fn, critic_fn
+            return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = jnp.zeros((1, *action_size), dtype=jnp.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_variables = actor_model.init(actor_key, observation, False)
         policy_variables["params"] = project_unit_norm_params(policy_variables["params"])
-        features = preproc_fn(policy_variables, None, observation)
-        critic_variables = critic_model.init(critic_key, features, action, False)
+        critic_variables = critic_model.init(critic_key, observation, action, False)
         critic_variables["params"] = project_unit_norm_params(critic_variables["params"])
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation, False),
-            (critic_model, features, action, False),
+            (critic_model, observation, action, False),
         )
-        return preproc_fn, actor_fn, critic_fn, policy_variables, critic_variables
+        return actor_fn, critic_fn, policy_variables, critic_variables
 
     return model_builder

--- a/model_builder/flax/dpg/gaussian_blocks.py
+++ b/model_builder/flax/dpg/gaussian_blocks.py
@@ -11,7 +11,6 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
-from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -21,18 +20,16 @@ class Actor(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         linear = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(features["actor"])
+        )(features)
         mu = self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))(linear)
         log_std = self.layer(
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
             bias_init=lambda key, shape, dtype: jnp.full(shape, 10.0, dtype=dtype),
-        )(
-            linear
-        )  # initialize std with high values
+        )(linear)  # initialize std with high values
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
 
@@ -42,8 +39,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, kernel_init=clip_factorized_uniform(3))]

--- a/model_builder/flax/dpg/sac_builder.py
+++ b/model_builder/flax/dpg/sac_builder.py
@@ -1,62 +1,61 @@
 import flax.linen as nn
+import jax
 import numpy as np
 
 from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.dpg.gaussian_blocks import Actor, Critic
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_flax_model_summary
+from model_builder.utils import (
+    dummy_observation,
+    print_flax_model_summary,
+    split_actor_critic_kwargs,
+)
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a):
-                return (self.crit1(x, a), self.crit2(x, a))
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simba_crossq_builder.py
+++ b/model_builder/flax/dpg/simba_crossq_builder.py
@@ -8,9 +8,9 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -20,8 +20,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        feature = features["actor"]
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        feature = features
         for _ in range(self.hidden_n):
             feature = Dense(self.node)(feature)
             feature = jax.nn.relu(feature)
@@ -33,25 +33,23 @@ class Actor(nn.Module):
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
             bias_init=lambda key, shape, dtype: jnp.full(shape, 10.0, dtype=dtype),
-        )(
-            feature
-        )  # initialize std with high values
+        )(feature)  # initialize std with high values
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
 
 class Critic(nn.Module):
-    node: int = 256
+    node: int = 2048
     hidden_n: int = 2
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
+        self, features: jnp.ndarray, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
-        feature = features["critic"]
+        feature = features
         actions_norm = BatchReNorm(use_running_average=not training)(actions)
         feature = jnp.concatenate([feature, actions_norm], axis=1)
         for _ in range(self.hidden_n):
-            feature = Dense(self.node * 8)(feature)
+            feature = Dense(self.node)(feature)
             feature = BatchReNorm(use_running_average=not training)(feature)
             feature = jax.nn.tanh(feature)
         q_net = Dense(1, kernel_init=clip_factorized_uniform(3))(feature)
@@ -60,54 +58,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs, critic_node=2048)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a, training: bool = True):
-                return (self.crit1(x, a, training), self.crit2(x, a, training))
+            def __call__(self, observation, action, training: bool = True):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic, mutable=["batch_stats"])
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action, True)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action, True),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action, True)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action, True),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simba_ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/simba_ddpg_td3_blocks.py
@@ -11,7 +11,6 @@ import jax.numpy as jnp
 
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, ResidualBlock
-from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -20,7 +19,7 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         action = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -29,7 +28,7 @@ class Actor(nn.Module):
                 Dense(self.action_size[0], kernel_init=clip_factorized_uniform(3)),
                 jax.nn.tanh,
             ]
-        )(features["actor"])
+        )(features)
         return action
 
 
@@ -38,8 +37,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]

--- a/model_builder/flax/dpg/simba_sac_builder.py
+++ b/model_builder/flax/dpg/simba_sac_builder.py
@@ -8,9 +8,9 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, ResidualBlock
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -20,14 +20,14 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         linear = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
             + [
                 nn.LayerNorm(),
             ]
-        )(features["actor"])
+        )(features)
         mu = Dense(
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
@@ -36,9 +36,7 @@ class Actor(nn.Module):
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
             bias_init=lambda key, shape, dtype: jnp.full(shape, 10.0, dtype=dtype),
-        )(
-            linear
-        )  # initialize std with high values
+        )(linear)  # initialize std with high values
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
 
@@ -47,8 +45,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -59,54 +57,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a):
-                return (self.crit1(x, a), self.crit2(x, a))
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simba_td7_builder.py
+++ b/model_builder/flax/dpg/simba_td7_builder.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
@@ -8,32 +10,32 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, ResidualBlock, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
 class Encoder(nn.Module):
     node: int = 256
     hidden_n: int = 3
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         encoder = nn.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(features["actor"])
+        )(features)
         return avgl1norm(encoder)
 
 
 class Action_Encoder(nn.Module):
     node: int = 256
     hidden_n: int = 3
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
     def __call__(self, zs: jnp.ndarray, action: jnp.ndarray) -> jnp.ndarray:
@@ -53,8 +55,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(Dense(self.node)(features["actor"]))
+    def __call__(self, features: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(Dense(self.node)(features))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         action = nn.Sequential(
             [Dense(self.node)]
@@ -75,12 +77,12 @@ class Critic(nn.Module):
     @nn.compact
     def __call__(
         self,
-        features: ActorCriticFeatures,
+        features: jnp.ndarray,
         zs: jnp.ndarray,
         zsa: jnp.ndarray,
         actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+        concat = jnp.concatenate([features, actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(Dense(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -94,84 +96,78 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
-        class Merge_encoder(nn.Module):
+        class RoleEncoder(nn.Module):
+            role: Literal["actor", "critic"]
+            node: int
+            hidden_n: int
+
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role=self.role
                 )
-                self.enc = Encoder()
-                self.act_enc = Action_Encoder()
+                self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
+                self.act_enc = Action_Encoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, x, a):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                zsa = self.action_encoder(zs, a)
-                return feature, zs, zsa
+            def __call__(self, obs, actions):
+                feature, zs = self.encode_state(obs)
+                return feature, zs, self.encode_action(zs, actions)
 
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
+            def encode_state(self, obs):
+                feature = self.preproc(obs)
+                return feature, self.enc(feature)
 
-            def encoder(self, feature):
-                return self.enc(feature)
+            def encode_action(self, zs, actions):
+                return self.act_enc(zs, actions)
 
-            def action_encoder(self, zs, a):
-                return self.act_enc(zs, a)
-
-            def feature_and_zs(self, x):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                return feature, zs
-
-        class Merged_Critic(nn.Module):
+        class TwinCritic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
             def __call__(self, feature, zs, zsa, actions):
-                q = self.critic(feature, zs, zsa, actions)
-                return q
+                return self.crit1(feature, zs, zsa, actions), self.crit2(feature, zs, zsa, actions)
 
-            def critic(self, feature, zs, zsa, a):
-                return (
-                    self.crit1(feature, zs, zsa, a),
-                    self.crit2(feature, zs, zsa, a),
-                )
-
-        encoder_model = Merge_encoder()
-        preproc_fn = get_apply_fn_flax_module(encoder_model, encoder_model.preprocess)
-        encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.encoder)
-        action_encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.action_encoder)
-        policy_model = Actor(action_size=action_size)
-        critic_model = Merged_Critic()
-        actor_fn = get_apply_fn_flax_module(policy_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            encoder_params = encoder_model.init(key, observation, action)
-            feature, zs, zsa = encoder_model.apply(encoder_params, observation, action)
-            policy_params = policy_model.init(key, feature, zs)
-            critic_params = critic_model.init(key, feature, zs, zsa, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (encoder_model, observation, action),
-                (policy_model, feature, zs),
-                (critic_model, feature, zs, zsa, action),
-            )
-            return (
-                preproc_fn,
-                encoder_fn,
-                action_encoder_fn,
-                actor_fn,
-                critic_fn,
-                encoder_params,
-                policy_params,
-                critic_params,
-            )
-        else:
-            return preproc_fn, encoder_fn, action_encoder_fn, actor_fn, critic_fn
+        actor_encoder_model = RoleEncoder("actor", actor_kwargs["node"], 3)
+        critic_encoder_model = RoleEncoder("critic", critic_kwargs["node"], 3)
+        policy_model = Actor(action_size=action_size, **actor_kwargs)
+        critic_model = TwinCritic()
+        functions = (
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
+            get_apply_fn_flax_module(policy_model),
+            get_apply_fn_flax_module(critic_model),
+        )
+        if key is None:
+            return functions
+        actor_encoder_key, critic_encoder_key, actor_key, critic_key = jax.random.split(key, 4)
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
+        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
+        policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
+        critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_encoder_model, observation, action),
+            (critic_encoder_model, observation, action),
+            (policy_model, actor_feature, actor_zs),
+            (critic_model, critic_feature, critic_zs, critic_zsa, action),
+        )
+        return (
+            *functions,
+            actor_encoder_params,
+            critic_encoder_params,
+            policy_params,
+            critic_params,
+        )
 
     return model_builder

--- a/model_builder/flax/dpg/simba_tqc_builder.py
+++ b/model_builder/flax/dpg/simba_tqc_builder.py
@@ -8,9 +8,9 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, ResidualBlock
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -20,14 +20,14 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         linear = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
             + [
                 nn.LayerNorm(),
             ]
-        )(features["actor"])
+        )(features)
         mu = Dense(
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
@@ -36,9 +36,7 @@ class Actor(nn.Module):
             self.action_size[0],
             kernel_init=clip_factorized_uniform(3),
             bias_init=lambda key, shape, dtype: jnp.full(shape, 10.0, dtype=dtype),
-        )(
-            linear
-        )  # initialize std with high values
+        )(linear)  # initialize std with high values
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
 
@@ -48,8 +46,8 @@ class Critic(nn.Module):
     support_n: int = 200
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [Dense(self.node)]
             + [ResidualBlock(self.node) for _ in range(self.hidden_n)]
@@ -66,54 +64,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, support_n, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(support_n=support_n, **policy_kwargs)
-                self.crit2 = Critic(support_n=support_n, **policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(support_n=support_n, **critic_kwargs)
+                self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, x, a):
-                return (self.crit1(x, a), self.crit2(x, a))
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simbav2_crossq_builder.py
+++ b/model_builder/flax/dpg/simbav2_crossq_builder.py
@@ -14,9 +14,9 @@ from model_builder.flax.layers import (
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -26,8 +26,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -52,10 +52,10 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
+        self, features: jnp.ndarray, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
         del training
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+        concat = jnp.concatenate([features, actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -65,53 +65,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                return self.actor(feature)
-
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a, training: bool = True):
-                return self.crit1(x, a, training), self.crit2(x, a, training)
+            def __call__(self, observation, action, training: bool = True):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
         actor_model = Merged_Actor()
-        critics_model = Merged_Critic()
-        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
-        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor)
-        critic_fn = get_apply_fn_flax_module(critics_model)
-
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = actor_model.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = critics_model.init(key, feature, action, True)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (actor_model, observation),
-                (critics_model, feature, action, True),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action, True)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action, True),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simbav2_ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/simbav2_ddpg_td3_blocks.py
@@ -10,7 +10,6 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.flax.layers import SimbaV2Block, SimbaV2Embedding, SimbaV2Head
-from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(nn.Module):
@@ -19,8 +18,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         logits = SimbaV2Head(self.node, self.action_size[0])(encoded)
@@ -32,8 +31,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)

--- a/model_builder/flax/dpg/simbav2_sac_builder.py
+++ b/model_builder/flax/dpg/simbav2_sac_builder.py
@@ -13,9 +13,9 @@ from model_builder.flax.layers import (
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -25,8 +25,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -46,8 +46,8 @@ class Critic(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -57,53 +57,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                return self.actor(feature)
-
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a):
-                return self.crit1(x, a), self.crit2(x, a)
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
-        critics_model = Merged_Critic()
-        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
-        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor)
-        critic_fn = get_apply_fn_flax_module(critics_model)
-
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = actor_model.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = critics_model.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (actor_model, observation),
-                (critics_model, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/simbav2_td7_builder.py
+++ b/model_builder/flax/dpg/simbav2_td7_builder.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
@@ -7,9 +9,9 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.layers import SimbaV2Block, SimbaV2Embedding, SimbaV2Head
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -18,8 +20,8 @@ class Encoder(nn.Module):
     hidden_n: int = 3
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         return encoded
@@ -44,8 +46,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
-        base = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
+        base = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             base = SimbaV2Block(self.node)(base)
         embed = jnp.concatenate([base, zs], axis=1)
@@ -63,12 +65,12 @@ class Critic(nn.Module):
     @nn.compact
     def __call__(
         self,
-        features: ActorCriticFeatures,
+        features: jnp.ndarray,
         zs: jnp.ndarray,
         zsa: jnp.ndarray,
         actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+        concat = jnp.concatenate([features, actions], axis=1)
         base = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             base = SimbaV2Block(self.node)(base)
@@ -82,94 +84,86 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
-        class Merge_encoder(nn.Module):
+        class RoleEncoder(nn.Module):
+            role: Literal["actor", "critic"]
+            node: int
+            hidden_n: int
+
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role=self.role
                 )
-                self.enc = Encoder(**policy_kwargs)
-                self.act_enc = ActionEncoder(**policy_kwargs)
+                self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
+                self.act_enc = ActionEncoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, x, a):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                zsa = self.action_encoder(zs, a)
-                return feature, zs, zsa
+            def __call__(self, obs, actions):
+                feature, zs = self.encode_state(obs)
+                return feature, zs, self.encode_action(zs, actions)
 
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
+            def encode_state(self, obs):
+                feature = self.preproc(obs)
+                return feature, self.enc(feature)
 
-            def encoder(self, feature):
-                return self.enc(feature)
+            def encode_action(self, zs, actions):
+                return self.act_enc(zs, actions)
 
-            def action_encoder(self, zs, a):
-                return self.act_enc(zs, a)
-
-            def feature_and_zs(self, x):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                return feature, zs
-
-        class Merged_Critic(nn.Module):
+        class TwinCritic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
             def __call__(self, feature, zs, zsa, actions):
                 return self.crit1(feature, zs, zsa, actions), self.crit2(feature, zs, zsa, actions)
 
-        encoder_model = Merge_encoder()
-        policy_model = Actor(action_size=action_size, **policy_kwargs)
-        critic_model = Merged_Critic()
-
-        preproc_fn = get_apply_fn_flax_module(encoder_model, encoder_model.preprocess)
-        encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.encoder)
-        action_encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.action_encoder)
-        actor_fn = get_apply_fn_flax_module(policy_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
-
-        if key is not None:
-            zero_obs = dummy_observation(observation_space)
-            zero_action = np.zeros((1, *action_size), dtype=np.float32)
-            encoder_params = encoder_model.init(key, zero_obs, zero_action)
-            feature, zs = encoder_model.apply(
-                encoder_params,
-                zero_obs,
-                method=encoder_model.feature_and_zs,
-            )
-            policy_params = policy_model.init(key, feature, zs)
-            feature_full, zs_full, zsa_full = encoder_model.apply(
-                encoder_params,
-                zero_obs,
-                zero_action,
-            )
-            critic_params = critic_model.init(
-                key,
-                feature_full,
-                zs_full,
-                zsa_full,
-                zero_action,
-            )
-            print_flax_model_summary(
-                print_model,
-                key,
-                (encoder_model, zero_obs, zero_action),
-                (policy_model, feature, zs),
-                (critic_model, feature_full, zs_full, zsa_full, zero_action),
-            )
-            return (
-                preproc_fn,
-                encoder_fn,
-                action_encoder_fn,
-                actor_fn,
-                critic_fn,
-                encoder_params,
-                policy_params,
-                critic_params,
-            )
-        else:
-            return preproc_fn, encoder_fn, action_encoder_fn, actor_fn, critic_fn
+        actor_encoder_model = RoleEncoder(
+            "actor",
+            actor_kwargs["node"],
+            {"hidden_n": 3, **actor_kwargs}["hidden_n"],
+        )
+        critic_encoder_model = RoleEncoder(
+            "critic",
+            critic_kwargs["node"],
+            {"hidden_n": 3, **critic_kwargs}["hidden_n"],
+        )
+        policy_model = Actor(action_size=action_size, **actor_kwargs)
+        critic_model = TwinCritic()
+        functions = (
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
+            get_apply_fn_flax_module(policy_model),
+            get_apply_fn_flax_module(critic_model),
+        )
+        if key is None:
+            return functions
+        actor_encoder_key, critic_encoder_key, actor_key, critic_key = jax.random.split(key, 4)
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
+        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
+        policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
+        critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_encoder_model, observation, action),
+            (critic_encoder_model, observation, action),
+            (policy_model, actor_feature, actor_zs),
+            (critic_model, critic_feature, critic_zs, critic_zsa, action),
+        )
+        return (
+            *functions,
+            actor_encoder_params,
+            critic_encoder_params,
+            policy_params,
+            critic_params,
+        )
 
     return model_builder

--- a/model_builder/flax/dpg/simbav2_tqc_builder.py
+++ b/model_builder/flax/dpg/simbav2_tqc_builder.py
@@ -13,9 +13,9 @@ from model_builder.flax.layers import (
 )
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -25,8 +25,8 @@ class Actor(nn.Module):
     hidden_n: int = 2
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
-        encoded = SimbaV2Embedding(self.node)(features["actor"])
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
+        encoded = SimbaV2Embedding(self.node)(features)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
         mu = SimbaV2Head(
@@ -47,8 +47,8 @@ class Critic(nn.Module):
     support_n: int = 200
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         encoded = SimbaV2Embedding(self.node)(concat)
         for _ in range(self.hidden_n):
             encoded = SimbaV2Block(self.node)(encoded)
@@ -61,53 +61,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, support_n, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                return self.actor(feature)
-
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(support_n=support_n, **policy_kwargs)
-                self.crit2 = Critic(support_n=support_n, **policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(support_n=support_n, **critic_kwargs)
+                self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, x, a):
-                return self.crit1(x, a), self.crit2(x, a)
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
-        critics_model = Merged_Critic()
-        preproc_fn = get_apply_fn_flax_module(actor_model, actor_model.preprocess)
-        actor_fn = get_apply_fn_flax_module(actor_model, actor_model.actor)
-        critic_fn = get_apply_fn_flax_module(critics_model)
-
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = actor_model.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = critics_model.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (actor_model, observation),
-                (critics_model, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/td7_builder.py
+++ b/model_builder/flax/dpg/td7_builder.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
@@ -8,32 +10,32 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
 class Encoder(nn.Module):
     node: int = 256
     hidden_n: int = 3
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         encoder = nn.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(features["actor"])
+        )(features)
         return avgl1norm(encoder)
 
 
 class Action_Encoder(nn.Module):
     node: int = 256
     hidden_n: int = 3
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
     def __call__(self, zs: jnp.ndarray, action: jnp.ndarray) -> jnp.ndarray:
@@ -51,11 +53,11 @@ class Actor(nn.Module):
     action_size: tuple
     node: int = 256
     hidden_n: int = 2
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(self.layer(self.node)(features["actor"]))
+    def __call__(self, features: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(self.layer(self.node)(features))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         action = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
@@ -70,17 +72,17 @@ class Actor(nn.Module):
 class Critic(nn.Module):
     node: int = 256
     hidden_n: int = 2
-    layer: nn.Module = Dense
+    layer: type[nn.Dense] = Dense
 
     @nn.compact
     def __call__(
         self,
-        features: ActorCriticFeatures,
+        features: jnp.ndarray,
         zs: jnp.ndarray,
         zsa: jnp.ndarray,
         actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+        concat = jnp.concatenate([features, actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(self.layer(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -93,84 +95,78 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
-        class Merge_encoder(nn.Module):
+        class RoleEncoder(nn.Module):
+            role: Literal["actor", "critic"]
+            node: int
+            hidden_n: int
+
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role=self.role
                 )
-                self.enc = Encoder()
-                self.act_enc = Action_Encoder()
+                self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
+                self.act_enc = Action_Encoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, x, a):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                zsa = self.action_encoder(zs, a)
-                return feature, zs, zsa
+            def __call__(self, obs, actions):
+                feature, zs = self.encode_state(obs)
+                return feature, zs, self.encode_action(zs, actions)
 
-            def preprocess(self, x):
-                return self.preproc.actor_critic(x)
+            def encode_state(self, obs):
+                feature = self.preproc(obs)
+                return feature, self.enc(feature)
 
-            def encoder(self, feature):
-                return self.enc(feature)
+            def encode_action(self, zs, actions):
+                return self.act_enc(zs, actions)
 
-            def action_encoder(self, zs, a):
-                return self.act_enc(zs, a)
-
-            def feature_and_zs(self, x):
-                feature = self.preprocess(x)
-                zs = self.encoder(feature)
-                return feature, zs
-
-        class Merged_Critic(nn.Module):
+        class TwinCritic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
             def __call__(self, feature, zs, zsa, actions):
-                q = self.critic(feature, zs, zsa, actions)
-                return q
+                return self.crit1(feature, zs, zsa, actions), self.crit2(feature, zs, zsa, actions)
 
-            def critic(self, feature, zs, zsa, a):
-                return (
-                    self.crit1(feature, zs, zsa, a),
-                    self.crit2(feature, zs, zsa, a),
-                )
-
-        encoder_model = Merge_encoder()
-        preproc_fn = get_apply_fn_flax_module(encoder_model, encoder_model.preprocess)
-        encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.encoder)
-        action_encoder_fn = get_apply_fn_flax_module(encoder_model, encoder_model.action_encoder)
-        policy_model = Actor(action_size=action_size)
-        critic_model = Merged_Critic()
-        actor_fn = get_apply_fn_flax_module(policy_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            encoder_params = encoder_model.init(key, observation, action)
-            feature, zs, zsa = encoder_model.apply(encoder_params, observation, action)
-            policy_params = policy_model.init(key, feature, zs)
-            critic_params = critic_model.init(key, feature, zs, zsa, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (encoder_model, observation, action),
-                (policy_model, feature, zs),
-                (critic_model, feature, zs, zsa, action),
-            )
-            return (
-                preproc_fn,
-                encoder_fn,
-                action_encoder_fn,
-                actor_fn,
-                critic_fn,
-                encoder_params,
-                policy_params,
-                critic_params,
-            )
-        else:
-            return preproc_fn, encoder_fn, action_encoder_fn, actor_fn, critic_fn
+        actor_encoder_model = RoleEncoder("actor", actor_kwargs["node"], 3)
+        critic_encoder_model = RoleEncoder("critic", critic_kwargs["node"], 3)
+        policy_model = Actor(action_size=action_size, **actor_kwargs)
+        critic_model = TwinCritic()
+        functions = (
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
+            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
+            get_apply_fn_flax_module(policy_model),
+            get_apply_fn_flax_module(critic_model),
+        )
+        if key is None:
+            return functions
+        actor_encoder_key, critic_encoder_key, actor_key, critic_key = jax.random.split(key, 4)
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
+        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
+        policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
+        critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_encoder_model, observation, action),
+            (critic_encoder_model, observation, action),
+            (policy_model, actor_feature, actor_zs),
+            (critic_model, critic_feature, critic_zs, critic_zsa, action),
+        )
+        return (
+            *functions,
+            actor_encoder_params,
+            critic_encoder_params,
+            policy_params,
+            critic_params,
+        )
 
     return model_builder

--- a/model_builder/flax/dpg/tqc_builder.py
+++ b/model_builder/flax/dpg/tqc_builder.py
@@ -9,9 +9,9 @@ from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -22,8 +22,8 @@ class Critic(nn.Module):
     layer: nn.Module = Dense
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         q_net = nn.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
@@ -38,54 +38,48 @@ class Critic(nn.Module):
 
 def model_builder_maker(observation_space, action_size, support_n, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x):
-                return self.act(x)
+            def __call__(self, observation):
+                return self.act(self.preproc(observation))
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(support_n=support_n, **policy_kwargs)
-                self.crit2 = Critic(support_n=support_n, **policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(support_n=support_n, **critic_kwargs)
+                self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, x, a):
-                return (self.crit1(x, a), self.crit2(x, a))
+            def __call__(self, observation, action):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action), self.crit2(feature, action)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor)
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation),
-                (model_critic, feature, action),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model)
+        critic_fn = get_apply_fn_flax_module(critic_model)
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation)
+        critic_params = critic_model.init(critic_key, observation, action)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation),
+            (critic_model, observation, action),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/flax/dpg/xqc_builder.py
+++ b/model_builder/flax/dpg/xqc_builder.py
@@ -6,9 +6,9 @@ import numpy as np
 from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_flax_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -21,8 +21,8 @@ class Actor(nn.Module):
         return nn.BatchNorm(use_running_average=not training, momentum=0.99, epsilon=0.001)(feature)
 
     @nn.compact
-    def __call__(self, features: ActorCriticFeatures, training: bool = True) -> jnp.ndarray:
-        feature = features["actor"]
+    def __call__(self, features: jnp.ndarray, training: bool = True) -> jnp.ndarray:
+        feature = features
         feature = self.normalize(feature, training)
         for _ in range(self.hidden_n):
             feature = nn.Dense(
@@ -44,7 +44,7 @@ class Actor(nn.Module):
 
 
 class Critic(nn.Module):
-    node: int = 256
+    node: int = 512
     hidden_n: int = 4
     n_atoms: int = 101
 
@@ -53,14 +53,14 @@ class Critic(nn.Module):
 
     @nn.compact
     def __call__(
-        self, features: ActorCriticFeatures, actions: jnp.ndarray, training: bool = True
+        self, features: jnp.ndarray, actions: jnp.ndarray, training: bool = True
     ) -> jnp.ndarray:
-        feature = features["critic"]
+        feature = features
         concat = jnp.concatenate([feature, actions], axis=1)
         feature = self.normalize(concat, training)
         for _ in range(self.hidden_n):
             feature = nn.Dense(
-                self.node * 2,
+                self.node,
                 use_bias=False,
                 kernel_init=nn.initializers.orthogonal(jnp.sqrt(2.0)),
             )(feature)
@@ -73,56 +73,50 @@ class Critic(nn.Module):
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
-    policy_kwargs = {**policy_kwargs, "hidden_n": 4}
+    policy_kwargs = {**({} if policy_kwargs is None else policy_kwargs), "hidden_n": 4}
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs, critic_node=512)
 
     def model_builder(key=None, print_model=False):
         class Merged_Actor(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
-                    observation_space, embedding_mode=embedding_mode, paired=True
+                    observation_space, embedding_mode=embedding_mode, role="actor"
                 )
-                self.act = Actor(action_size, **policy_kwargs)
+                self.act = Actor(action_size, **actor_kwargs)
 
-            def __call__(self, x, training: bool = True):
-                feature = self.preprocess(x)
-                mu, log_std = self.actor(feature, training)
-                return mu, log_std
-
-            def preprocess(self, x):
-                x = self.preproc.actor_critic(x)
-                return x
-
-            def actor(self, x, training: bool = True):
-                return self.act(x, training)
+            def __call__(self, observation, training: bool = True):
+                return self.act(self.preproc(observation), training)
 
         class Merged_Critic(nn.Module):
             def setup(self):
-                self.crit1 = Critic(**policy_kwargs)
-                self.crit2 = Critic(**policy_kwargs)
+                self.preproc = PreProcess(
+                    observation_space, embedding_mode=embedding_mode, role="critic"
+                )
+                self.crit1 = Critic(**critic_kwargs)
+                self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, x, a, training: bool = True):
-                return (self.crit1(x, a, training), self.crit2(x, a, training))
+            def __call__(self, observation, action, training: bool = True):
+                feature = self.preproc(observation)
+                return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
-        model_actor = Merged_Actor()
-        preproc_fn = get_apply_fn_flax_module(model_actor, model_actor.preprocess)
-        actor_fn = get_apply_fn_flax_module(model_actor, model_actor.actor, mutable=["batch_stats"])
-        model_critic = Merged_Critic()
-        critic_fn = get_apply_fn_flax_module(model_critic, mutable=["batch_stats"])
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, *action_size), dtype=np.float32)
-            policy_params = model_actor.init(key, observation, True)
-            feature = preproc_fn(policy_params, key, observation)
-            critic_params = model_critic.init(key, feature, action, True)
-            print_flax_model_summary(
-                print_model,
-                key,
-                (model_actor, observation, True),
-                (model_critic, feature, action, True),
-            )
-            return preproc_fn, actor_fn, critic_fn, policy_params, critic_params
-        else:
-            return preproc_fn, actor_fn, critic_fn
+        actor_model = Merged_Actor()
+        critic_model = Merged_Critic()
+        actor_fn = get_apply_fn_flax_module(actor_model, mutable=["batch_stats"])
+        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        if key is None:
+            return actor_fn, critic_fn
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor_model.init(actor_key, observation, True)
+        critic_params = critic_model.init(critic_key, observation, action, True)
+        print_flax_model_summary(
+            print_model,
+            key,
+            (actor_model, observation, True),
+            (critic_model, observation, action, True),
+        )
+        return actor_fn, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/haiku/Module.py
+++ b/model_builder/haiku/Module.py
@@ -2,7 +2,7 @@ import haiku as hk
 import jax
 import jax.numpy as jnp
 
-from model_builder.utils import ActorCriticFeatures, observation_role_keys
+from model_builder.utils import observation_role_keys
 
 
 def pop_embedding_mode(policy_kwargs: dict | None, default: str = "normal") -> tuple[dict, str]:
@@ -56,24 +56,16 @@ def visual_embedding(mode="normal"):
 
 
 class PreProcess(hk.Module):
-    def __init__(self, state_size, embedding_mode="normal", paired=False):
+    def __init__(self, state_size, embedding_mode="normal", *, role="actor"):
         super().__init__()
-        self.role_keys = observation_role_keys(state_size, paired)
-        selected = {key for keys in self.role_keys.values() for key in keys}
+        self.observation_keys = observation_role_keys(state_size, role)
         self.embedding = {
             key: visual_embedding(embedding_mode) if len(st) == 3 else lambda x: x
             for key, st in state_size.items()
-            if key in selected
+            if key in self.observation_keys
         }
 
     def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
         return jnp.concatenate(
-            [self.embedding[key](obses[key]) for key in self.role_keys["actor"]], axis=1
-        )
-
-    def actor_critic(self, obses: dict[str, jnp.ndarray]) -> ActorCriticFeatures:
-        embedded = {key: pre(obses[key]) for key, pre in self.embedding.items()}
-        return ActorCriticFeatures(
-            actor=jnp.concatenate([embedded[key] for key in self.role_keys["actor"]], axis=1),
-            critic=jnp.concatenate([embedded[key] for key in self.role_keys["critic"]], axis=1),
+            [self.embedding[key](obses[key]) for key in self.observation_keys], axis=1
         )

--- a/model_builder/haiku/ac/ac_builder.py
+++ b/model_builder/haiku/ac/ac_builder.py
@@ -4,9 +4,9 @@ import jax.numpy as jnp
 
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_haiku_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -19,10 +19,10 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray]:
         mlp = hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
-        )(features["actor"])
+        )(features)
         if self.action_type == "discrete":
             return self.layer(
                 self.action_size[0], w_init=hk.initializers.RandomUniform(-0.03, 0.03)
@@ -35,6 +35,7 @@ class Actor(hk.Module):
                 "log_std", [1, self.action_size[0]], jnp.float32, init=jnp.zeros
             )
             return mu, log_std
+        raise ValueError(f"Unsupported action type: {self.action_type}")
 
 
 class Critic(hk.Module):
@@ -44,43 +45,41 @@ class Critic(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]
-        )(features["critic"])
+        )(features)
 
 
 def model_builder_maker(observation_space, action_size, action_type, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
+        actor = hk.transform(
+            lambda x: Actor(action_size, action_type, **actor_kwargs)(
+                PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(x)
+            )
         )
-        actor = hk.transform(lambda x: Actor(action_size, action_type, **policy_kwargs)(x))
-        critic = hk.transform(lambda x: Critic(**policy_kwargs)(x))
-        preproc_fn = preproc.apply
+        critic = hk.transform(
+            lambda x: Critic(**critic_kwargs)(
+                PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(x)
+            )
+        )
         actor_fn = actor.apply
         critic_fn = critic.apply
         if key is not None:
-            key1, key2, key3, key4 = jax.random.split(key, num=4)
+            actor_key, critic_key = jax.random.split(key)
             observation = dummy_observation(observation_space)
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key2, observation)
-            actor_param = actor.init(key3, feature)
-            critic_param = critic.init(key4, feature)
-
-            params = hk.data_structures.merge(pre_param, actor_param, critic_param)
+            actor_params = actor.init(actor_key, observation)
+            critic_params = critic.init(critic_key, observation)
             print_haiku_model_summary(
                 print_model,
-                (preproc, observation),
-                (actor, feature),
-                (critic, feature),
+                (actor, observation),
+                (critic, observation),
             )
-            return preproc_fn, actor_fn, critic_fn, params
-        return preproc_fn, actor_fn, critic_fn
+            return actor_fn, critic_fn, actor_params, critic_params
+        return actor_fn, critic_fn
 
     return _model_builder

--- a/model_builder/haiku/dpg/ddpg_builder.py
+++ b/model_builder/haiku/dpg/ddpg_builder.py
@@ -4,40 +4,44 @@ import numpy as np
 
 from model_builder.haiku.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    dummy_observation,
+    print_haiku_model_summary,
+    split_actor_critic_kwargs,
+)
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
-        )
-        actor = hk.transform(lambda x: Actor(action_size, **policy_kwargs)(x))
-        critic = hk.transform(lambda x, a: Critic(**policy_kwargs)(x, a))
-        preproc_fn = preproc.apply
-        actor_fn = actor.apply
-        critic_fn = critic.apply
-        if key is not None:
-            key1, key2, key3, key4 = jax.random.split(key, num=4)
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, action_size[0]))
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key2, observation)
-            actor_param = actor.init(key3, feature)
-            critic_param = critic.init(key4, feature, action)
-
-            params = hk.data_structures.merge(pre_param, actor_param, critic_param)
-            print_haiku_model_summary(
-                print_model,
-                (preproc, observation),
-                (actor, feature),
-                (critic, feature, action),
+    def model_builder(key=None, print_model=False):
+        def actor_forward(observation):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(
+                observation
             )
-            return preproc_fn, actor_fn, critic_fn, params
-        return preproc_fn, actor_fn, critic_fn
+            return Actor(action_size, **actor_kwargs)(feature)
 
-    return _model_builder
+        def critic_forward(observation, action):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                observation
+            )
+            return Critic(**critic_kwargs)(feature, action)
+
+        actor = hk.transform(actor_forward)
+        critic = hk.transform(critic_forward)
+        if key is None:
+            return actor.apply, critic.apply
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor.init(actor_key, observation)
+        critic_params = critic.init(critic_key, observation, action)
+        print_haiku_model_summary(
+            print_model,
+            (actor, observation),
+            (critic, observation, action),
+        )
+        return actor.apply, critic.apply, policy_params, critic_params
+
+    return model_builder

--- a/model_builder/haiku/dpg/ddpg_td3_blocks.py
+++ b/model_builder/haiku/dpg/ddpg_td3_blocks.py
@@ -19,7 +19,6 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.haiku.layers import LOG_STD_MEAN, LOG_STD_SCALE
-from model_builder.utils import ActorCriticFeatures
 
 
 class Actor(hk.Module):
@@ -30,7 +29,7 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
@@ -40,7 +39,7 @@ class Actor(hk.Module):
                 ),
                 jax.nn.tanh,
             ]
-        )(features["actor"])
+        )(features)
 
 
 class GaussianActor(hk.Module):
@@ -51,7 +50,7 @@ class GaussianActor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         linear = hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [
@@ -60,7 +59,7 @@ class GaussianActor(hk.Module):
                     w_init=hk.initializers.RandomUniform(-0.03, 0.03),
                 )
             ]
-        )(features["actor"])
+        )(features)
         mu, log_std = jnp.split(linear, 2, axis=-1)
         return mu, LOG_STD_MEAN + LOG_STD_SCALE * jax.nn.tanh(log_std / LOG_STD_SCALE)
 
@@ -72,8 +71,8 @@ class Critic(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(1, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]

--- a/model_builder/haiku/dpg/sac_builder.py
+++ b/model_builder/haiku/dpg/sac_builder.py
@@ -4,45 +4,47 @@ import numpy as np
 
 from model_builder.haiku.dpg.ddpg_td3_blocks import Critic, GaussianActor
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    dummy_observation,
+    print_haiku_model_summary,
+    split_actor_critic_kwargs,
+)
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
-        )
-        actor = hk.transform(lambda x: GaussianActor(action_size, **policy_kwargs)(x))
-        critic = hk.transform(
-            lambda x, a: (
-                Critic(**policy_kwargs)(x, a),
-                Critic(**policy_kwargs)(x, a),
+    def model_builder(key=None, print_model=False):
+        def actor_forward(observation):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(
+                observation
             )
-        )
-        preproc_fn = preproc.apply
-        actor_fn = actor.apply
-        critic_fn = critic.apply
-        if key is not None:
-            key1, key2, key3, key4 = jax.random.split(key, num=4)
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, action_size[0]))
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key2, observation)
-            actor_param = actor.init(key3, feature)
-            critic_param = critic.init(key4, feature, action)
+            return GaussianActor(action_size, **actor_kwargs)(feature)
 
-            params = hk.data_structures.merge(pre_param, actor_param, critic_param)
-            print_haiku_model_summary(
-                print_model,
-                (preproc, observation),
-                (actor, feature),
-                (critic, feature, action),
+        def critic_forward(observation, action):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                observation
             )
-            return preproc_fn, actor_fn, critic_fn, params
-        return preproc_fn, actor_fn, critic_fn
+            return (
+                Critic(**critic_kwargs)(feature, action),
+                Critic(**critic_kwargs)(feature, action),
+            )
 
-    return _model_builder
+        actor = hk.transform(actor_forward)
+        critic = hk.transform(critic_forward)
+        if key is None:
+            return actor.apply, critic.apply
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor.init(actor_key, observation)
+        critic_params = critic.init(critic_key, observation, action)
+        print_haiku_model_summary(
+            print_model,
+            (actor, observation),
+            (critic, observation, action),
+        )
+        return actor.apply, critic.apply, policy_params, critic_params
+
+    return model_builder

--- a/model_builder/haiku/dpg/td3_builder.py
+++ b/model_builder/haiku/dpg/td3_builder.py
@@ -4,45 +4,47 @@ import numpy as np
 
 from model_builder.haiku.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
-from model_builder.utils import dummy_observation, print_haiku_model_summary
+from model_builder.utils import (
+    dummy_observation,
+    print_haiku_model_summary,
+    split_actor_critic_kwargs,
+)
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
-        )
-        actor = hk.transform(lambda x: Actor(action_size, **policy_kwargs)(x))
-        critic = hk.transform(
-            lambda x, a: (
-                Critic(**policy_kwargs)(x, a),
-                Critic(**policy_kwargs)(x, a),
+    def model_builder(key=None, print_model=False):
+        def actor_forward(observation):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(
+                observation
             )
-        )
-        preproc_fn = preproc.apply
-        actor_fn = actor.apply
-        critic_fn = critic.apply
-        if key is not None:
-            key1, key2, key3, key4 = jax.random.split(key, num=4)
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, action_size[0]))
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key2, observation)
-            actor_param = actor.init(key3, feature)
-            critic_param = critic.init(key4, feature, action)
+            return Actor(action_size, **actor_kwargs)(feature)
 
-            params = hk.data_structures.merge(pre_param, actor_param, critic_param)
-            print_haiku_model_summary(
-                print_model,
-                (preproc, observation),
-                (actor, feature),
-                (critic, feature, action),
+        def critic_forward(observation, action):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                observation
             )
-            return preproc_fn, actor_fn, critic_fn, params
-        return preproc_fn, actor_fn, critic_fn
+            return (
+                Critic(**critic_kwargs)(feature, action),
+                Critic(**critic_kwargs)(feature, action),
+            )
 
-    return _model_builder
+        actor = hk.transform(actor_forward)
+        critic = hk.transform(critic_forward)
+        if key is None:
+            return actor.apply, critic.apply
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor.init(actor_key, observation)
+        critic_params = critic.init(critic_key, observation, action)
+        print_haiku_model_summary(
+            print_model,
+            (actor, observation),
+            (critic, observation, action),
+        )
+        return actor.apply, critic.apply, policy_params, critic_params
+
+    return model_builder

--- a/model_builder/haiku/dpg/td7_builder.py
+++ b/model_builder/haiku/dpg/td7_builder.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_haiku_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -22,13 +22,13 @@ class Encoder(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures) -> jnp.ndarray:
+    def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         encoder = hk.Sequential(
             [
                 self.layer(self.node) if i % 2 == 0 else jax.nn.elu
                 for i in range(2 * self.hidden_n - 1)
             ]
-        )(features["actor"])
+        )(features)
         return avgl1norm(encoder)
 
 
@@ -57,8 +57,8 @@ class Actor(hk.Module):
         self.hidden_n = hidden_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures, zs: jnp.ndarray) -> jnp.ndarray:
-        a0 = avgl1norm(self.layer(self.node)(features["actor"]))
+    def __call__(self, features: jnp.ndarray, zs: jnp.ndarray) -> jnp.ndarray:
+        a0 = avgl1norm(self.layer(self.node)(features))
         embed_concat = jnp.concatenate([a0, zs], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
@@ -81,12 +81,12 @@ class Critic(hk.Module):
 
     def __call__(
         self,
-        features: ActorCriticFeatures,
+        features: jnp.ndarray,
         zs: jnp.ndarray,
         zsa: jnp.ndarray,
         actions: jnp.ndarray,
     ) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+        concat = jnp.concatenate([features, actions], axis=1)
         embedding = jnp.concatenate([zs, zsa], axis=1)
         q0 = avgl1norm(self.layer(self.node)(concat))
         embed_concat = jnp.concatenate([q0, embedding], axis=1)
@@ -98,64 +98,72 @@ class Critic(hk.Module):
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
+    def model_builder(key=None, print_model=False):
+        def encode_state(obs, role, node):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role=role)(obs)
+            return feature, Encoder(node=node)(feature)
+
+        actor_encoder = hk.transform(lambda obs: encode_state(obs, "actor", actor_kwargs["node"]))
+        critic_encoder = hk.transform(
+            lambda obs: encode_state(obs, "critic", critic_kwargs["node"])
         )
-        encoder = hk.transform(lambda x: Encoder()(x))
-        action_encoder = hk.transform(lambda zs, a: Action_Encoder()(zs, a))
-        actor = hk.transform(lambda x, zs: Actor(action_size, **policy_kwargs)(x, zs))
+        actor_action_encoder = hk.transform(
+            lambda zs, actions: Action_Encoder(node=actor_kwargs["node"])(zs, actions)
+        )
+        critic_action_encoder = hk.transform(
+            lambda zs, actions: Action_Encoder(node=critic_kwargs["node"])(zs, actions)
+        )
+        actor = hk.transform(lambda feature, zs: Actor(action_size, **actor_kwargs)(feature, zs))
         critic = hk.transform(
-            lambda x, zs, zsa, a: (
-                Critic(**policy_kwargs)(x, zs, zsa, a),
-                Critic(**policy_kwargs)(x, zs, zsa, a),
+            lambda feature, zs, zsa, actions: (
+                Critic(**critic_kwargs)(feature, zs, zsa, actions),
+                Critic(**critic_kwargs)(feature, zs, zsa, actions),
             )
         )
-        preproc_fn = preproc.apply
-        encoder_fn = encoder.apply
-        action_encoder_fn = action_encoder.apply
-        actor_fn = actor.apply
-        critic_fn = critic.apply
-        if key is not None:
-            keys = jax.random.split(key, num=9)
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, action_size[0]))
-            pre_param = preproc.init(keys[0], observation)
-            feature = preproc.apply(pre_param, keys[1], observation)
+        functions = (
+            actor_encoder.apply,
+            critic_encoder.apply,
+            actor_action_encoder.apply,
+            critic_action_encoder.apply,
+            actor.apply,
+            critic.apply,
+        )
+        if key is None:
+            return functions
+        keys = jax.random.split(key, 6)
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_encoder_params = actor_encoder.init(keys[0], observation)
+        critic_encoder_params = critic_encoder.init(keys[1], observation)
+        actor_feature, actor_zs = actor_encoder.apply(actor_encoder_params, None, observation)
+        critic_feature, critic_zs = critic_encoder.apply(critic_encoder_params, None, observation)
+        actor_encoder_params = hk.data_structures.merge(
+            actor_encoder_params, actor_action_encoder.init(keys[2], actor_zs, action)
+        )
+        critic_encoder_params = hk.data_structures.merge(
+            critic_encoder_params,
+            critic_action_encoder.init(keys[3], critic_zs, action),
+        )
+        critic_zsa = critic_action_encoder.apply(critic_encoder_params, None, critic_zs, action)
+        policy_params = actor.init(keys[4], actor_feature, actor_zs)
+        critic_params = critic.init(keys[5], critic_feature, critic_zs, critic_zsa, action)
+        print_haiku_model_summary(
+            print_model,
+            (actor_encoder, observation),
+            (critic_encoder, observation),
+            (actor_action_encoder, actor_zs, action),
+            (critic_action_encoder, critic_zs, action),
+            (actor, actor_feature, actor_zs),
+            (critic, critic_feature, critic_zs, critic_zsa, action),
+        )
+        return (
+            *functions,
+            actor_encoder_params,
+            critic_encoder_params,
+            policy_params,
+            critic_params,
+        )
 
-            encoder_param = encoder.init(keys[2], feature)
-            zs = encoder.apply(encoder_param, keys[3], feature)
-
-            action_encoder_param = action_encoder.init(keys[4], zs, action)
-            zsa = action_encoder.apply(action_encoder_param, keys[5], zs, action)
-
-            actor_param = actor.init(keys[6], feature, zs)
-            critic_param = critic.init(keys[7], feature, zs, zsa, action)
-
-            encoder_params = hk.data_structures.merge(
-                pre_param, encoder_param, action_encoder_param
-            )
-            params = hk.data_structures.merge(actor_param, critic_param)
-            print_haiku_model_summary(
-                print_model,
-                (preproc, observation),
-                (encoder, feature),
-                (action_encoder, zs, action),
-                (actor, feature, zs),
-                (critic, feature, zs, zsa, action),
-            )
-            return (
-                preproc_fn,
-                encoder_fn,
-                action_encoder_fn,
-                actor_fn,
-                critic_fn,
-                encoder_params,
-                params,
-            )
-        return preproc_fn, encoder_fn, action_encoder_fn, actor_fn, critic_fn
-
-    return _model_builder
+    return model_builder

--- a/model_builder/haiku/dpg/tqc_builder.py
+++ b/model_builder/haiku/dpg/tqc_builder.py
@@ -6,9 +6,9 @@ import numpy as np
 from model_builder.haiku.dpg.ddpg_td3_blocks import GaussianActor
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
-    ActorCriticFeatures,
     dummy_observation,
     print_haiku_model_summary,
+    split_actor_critic_kwargs,
 )
 
 
@@ -20,8 +20,8 @@ class Critic(hk.Module):
         self.support_n = support_n
         self.layer = hk.Linear
 
-    def __call__(self, features: ActorCriticFeatures, actions: jnp.ndarray) -> jnp.ndarray:
-        concat = jnp.concatenate([features["critic"], actions], axis=1)
+    def __call__(self, features: jnp.ndarray, actions: jnp.ndarray) -> jnp.ndarray:
+        concat = jnp.concatenate([features, actions], axis=1)
         return hk.Sequential(
             [self.layer(self.node) if i % 2 == 0 else jax.nn.relu for i in range(2 * self.hidden_n)]
             + [self.layer(self.support_n, w_init=hk.initializers.RandomUniform(-0.03, 0.03))]
@@ -30,40 +30,38 @@ class Critic(hk.Module):
 
 def model_builder_maker(observation_space, action_size, support_n, policy_kwargs):
     policy_kwargs, embedding_mode = pop_embedding_mode(policy_kwargs)
+    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=embedding_mode, paired=True
-            ).actor_critic(x)
-        )
-        actor = hk.transform(lambda x: GaussianActor(action_size, **policy_kwargs)(x))
-        critic = hk.transform(
-            lambda x, a: (
-                Critic(support_n=support_n, **policy_kwargs)(x, a),
-                Critic(support_n=support_n, **policy_kwargs)(x, a),
+    def model_builder(key=None, print_model=False):
+        def actor_forward(observation):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(
+                observation
             )
-        )
-        preproc_fn = preproc.apply
-        actor_fn = actor.apply
-        critic_fn = critic.apply
-        if key is not None:
-            key1, key2, key3, key4 = jax.random.split(key, num=4)
-            observation = dummy_observation(observation_space)
-            action = np.zeros((1, action_size[0]))
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key2, observation)
-            actor_param = actor.init(key3, feature)
-            critic_param = critic.init(key4, feature, action)
+            return GaussianActor(action_size, **actor_kwargs)(feature)
 
-            params = hk.data_structures.merge(pre_param, actor_param, critic_param)
-            print_haiku_model_summary(
-                print_model,
-                (preproc, observation),
-                (actor, feature),
-                (critic, feature, action),
+        def critic_forward(observation, action):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                observation
             )
-            return preproc_fn, actor_fn, critic_fn, params
-        return preproc_fn, actor_fn, critic_fn
+            return (
+                Critic(support_n=support_n, **critic_kwargs)(feature, action),
+                Critic(support_n=support_n, **critic_kwargs)(feature, action),
+            )
 
-    return _model_builder
+        actor = hk.transform(actor_forward)
+        critic = hk.transform(critic_forward)
+        if key is None:
+            return actor.apply, critic.apply
+        observation = dummy_observation(observation_space)
+        action = np.zeros((1, *action_size), dtype=np.float32)
+        actor_key, critic_key = jax.random.split(key)
+        policy_params = actor.init(actor_key, observation)
+        critic_params = critic.init(critic_key, observation, action)
+        print_haiku_model_summary(
+            print_model,
+            (actor, observation),
+            (critic, observation, action),
+        )
+        return actor.apply, critic.apply, policy_params, critic_params
+
+    return model_builder

--- a/model_builder/utils.py
+++ b/model_builder/utils.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping, Sequence
-from typing import Literal, TypedDict
+from typing import Literal
 
-import jax
 import numpy as np
 
 
@@ -27,27 +26,32 @@ def print_haiku_model_summary(enabled, *models):
         print(hk.experimental.tabulate(model)(*inputs))
 
 
-class ActorCriticFeatures(TypedDict):
-    actor: jax.Array
-    critic: jax.Array
-
-
 def observation_role_keys(
-    space: Mapping[str, Sequence[int]], actor_critic: bool = False
-) -> dict[str, tuple[str, ...]]:
+    space: Mapping[str, Sequence[int]], role: Literal["actor", "critic"] = "actor"
+) -> tuple[str, ...]:
     """Resolve canonical observation roles before embedding and network construction."""
+    if role not in ("actor", "critic"):
+        raise ValueError(f"Unknown observation role: {role!r}")
     for key in space:
         prefix, separator, name = key.partition("_")
         if prefix not in ("unified", "actor", "critic") or not separator or not name:
             raise ValueError(f"Observation key requires unified_, actor_, or critic_: {key!r}")
-    roles: tuple[Literal["actor", "critic"], ...] = (
-        ("actor", "critic") if actor_critic else ("actor",)
-    )
-    keys = {
-        role: tuple(key for key in space if key.startswith(("unified_", f"{role}_")))
-        for role in roles
-    }
-    for role, selected in keys.items():
-        if not selected:
-            raise ValueError(f"Observation space has no inputs for {role}")
+    keys = tuple(key for key in space if key.startswith(("unified_", f"{role}_")))
+    if not keys:
+        raise ValueError(f"Observation space has no inputs for {role}")
     return keys
+
+
+def split_actor_critic_kwargs(
+    policy_kwargs: dict | None, *, actor_node: int = 256, critic_node: int = 256
+) -> tuple[dict, dict]:
+    """Resolve independent network widths at the model-builder boundary."""
+    options = {} if policy_kwargs is None else dict(policy_kwargs)
+    if "node" in options:
+        raise ValueError("Use actor_node and critic_node to configure actor-critic networks")
+    actor_node = options.pop("actor_node", actor_node)
+    critic_node = options.pop("critic_node", critic_node)
+    for name, value in (("actor_node", actor_node), ("critic_node", critic_node)):
+        if type(value) is not int or value < 1:
+            raise ValueError(f"{name} must be a positive integer")
+    return {**options, "node": actor_node}, {**options, "node": critic_node}

--- a/tests/test_ac_observation_normalization.py
+++ b/tests/test_ac_observation_normalization.py
@@ -24,7 +24,8 @@ def _agent(enabled=True):
         if enabled
         else None
     )
-    agent.params = np.float32(2.0)
+    agent.actor_params = np.float32(2.0)
+    agent.critic_params = np.float32(3.0)
     agent._get_actions = lambda params, obs: (
         params * obs["unified_obs"],
         np.ones_like(obs["unified_obs"]),

--- a/tests/test_apex_train_step_scaffold.py
+++ b/tests/test_apex_train_step_scaffold.py
@@ -41,7 +41,7 @@ class _RecordingReplay:
         self.update_calls.append((indexes, priorities))
 
 
-def _base_fake():
+def _base_fake(dpg):
     invoked = []
     logged = []
     return (
@@ -53,7 +53,12 @@ def _base_fake():
             replay_buffer=_RecordingReplay(),
             logger_server=SimpleNamespace(log_trainer=lambda steps, d: logged.append((steps, d))),
             _invoke_train_step=lambda steps, data: (
-                invoked.append((steps, data)) or ("P", "TP", "OPT", 0.5, 1.5, [0.1, 0.2])
+                invoked.append((steps, data))
+                or (
+                    ("P", "C", "TP", "TC", "POPT", "COPT", 0.5, 1.5, [0.1, 0.2])
+                    if dpg
+                    else ("P", "TP", "OPT", 0.5, 1.5, [0.1, 0.2])
+                )
             ),
         ),
         invoked,
@@ -63,13 +68,18 @@ def _base_fake():
 
 @pytest.mark.parametrize("base_cls", BASES)
 def test_base_train_step_orchestration(base_cls):
-    obj, invoked, logged = _base_fake()
+    obj, invoked, logged = _base_fake(base_cls is Ape_X_Deteministic_Policy_Gradient_Family)
     loss = base_cls.train_step(obj, steps=10, gradient_steps=3)
 
     assert len(invoked) == 3  # one hook call per gradient step
     assert all(s == 10 for s, _ in invoked)
     assert obj.train_steps_count == 3  # counter advanced from its initialized 0
-    assert (obj.params, obj.target_params, obj.opt_state) == ("P", "TP", "OPT")
+    if base_cls is Ape_X_Deteministic_Policy_Gradient_Family:
+        assert (obj.policy_params, obj.critic_params) == ("P", "C")
+        assert (obj.target_policy_params, obj.target_critic_params) == ("TP", "TC")
+        assert (obj.opt_policy_state, obj.opt_critic_state) == ("POPT", "COPT")
+    else:
+        assert (obj.params, obj.target_params, obj.opt_state) == ("P", "TP", "OPT")
     assert obj.replay_buffer.update_calls == [([0, 1], [0.1, 0.2])] * 3
     assert loss == 0.5  # last loss returned
     assert logged == [(10, {"loss/qloss": 0.5, "loss/targets": 1.5})]
@@ -88,9 +98,16 @@ def _leaf_fake():
             params="P0",
             target_params="TP0",
             opt_state="O0",
+            policy_params="P0",
+            critic_params="C0",
+            target_policy_params="TP0",
+            target_critic_params="TC0",
+            opt_policy_state="PO0",
+            opt_critic_state="CO0",
             key_seq=iter(["K0", "K1", "K2"]),
             param_noise=False,
             _train_step=fake_train_step,
+            _compiled_train_step=fake_train_step,
         ),
         captured,
     )
@@ -100,7 +117,10 @@ def _leaf_fake():
 def test_leaf_invoke_forwards_params_and_data(cls):
     obj, captured = _leaf_fake()
     cls._invoke_train_step(obj, steps=7, data={"obses": "X"})
-    assert captured["args"][:3] == ("P0", "TP0", "O0")
+    if cls in (APE_X_DDPG, APE_X_TD3):
+        assert captured["args"][:6] == ("P0", "C0", "TP0", "TC0", "PO0", "CO0")
+    else:
+        assert captured["args"][:3] == ("P0", "TP0", "O0")
     assert captured["kwargs"] == {"obses": "X"}
 
 
@@ -111,16 +131,16 @@ def test_dqn_family_invoke_passes_steps_then_key():
         assert captured["args"] == ("P0", "TP0", "O0", 7, "K0")
 
 
-def test_ddpg_invoke_omits_steps_and_passes_none_key():
+def test_ddpg_invoke_omits_steps_and_passes_scan_key():
     obj, captured = _leaf_fake()
     APE_X_DDPG._invoke_train_step(obj, steps=7, data={})
-    assert captured["args"] == ("P0", "TP0", "O0", None)
+    assert captured["args"] == ("P0", "C0", "TP0", "TC0", "PO0", "CO0", "K0")
 
 
 def test_td3_invoke_passes_key_then_steps():
     obj, captured = _leaf_fake()
     APE_X_TD3._invoke_train_step(obj, steps=7, data={})
-    assert captured["args"] == ("P0", "TP0", "O0", "K0", 7)
+    assert captured["args"] == ("P0", "C0", "TP0", "TC0", "PO0", "CO0", "K0", 7)
 
 
 def test_iqn_invoke_gates_key_on_param_noise():
@@ -137,8 +157,11 @@ def test_iqn_invoke_gates_key_on_param_noise():
 
 @pytest.mark.parametrize("cls", APEX_ALL)
 def test_leaf_inherits_train_step_and_owns_hook(cls):
-    assert "train_step" not in cls.__dict__  # shared base owns the loop
-    assert "_invoke_train_step" in cls.__dict__  # leaf owns the divergent call
+    assert cls.train_step in (
+        Ape_X_Family.train_step,
+        Ape_X_Deteministic_Policy_Gradient_Family.train_step,
+    )
+    assert cls._invoke_train_step.__qualname__ == f"{cls.__name__}._invoke_train_step"
 
 
 @pytest.mark.parametrize("base_cls", BASES)

--- a/tests/test_checkpoint_state.py
+++ b/tests/test_checkpoint_state.py
@@ -48,11 +48,14 @@ ALGO_FIELDS = {
     CrossQ: ["policy_params", "critic_params", "log_ent_coef"],
     XQC: ["policy_params", "critic_params", "target_critic_params", "log_ent_coef"],
     TD7: [
-        "encoder_params",
+        "actor_encoder_params",
+        "critic_encoder_params",
         "policy_params",
         "critic_params",
-        "fixed_encoder_params",
-        "fixed_encoder_target_params",
+        "fixed_actor_encoder_params",
+        "fixed_critic_encoder_params",
+        "fixed_actor_encoder_target_params",
+        "fixed_critic_encoder_target_params",
         "target_policy_params",
         "target_critic_params",
     ],
@@ -119,7 +122,7 @@ def test_family_checkpoint_snapshots_use_pytree_snapshot():
 
     dpg = DDPG.__new__(DDPG)
     dpg.simba = False
-    eval_state = {"encoder": None, "policy": {"w": jnp.asarray([3.0])}}
+    eval_state = {"actor_encoder": None, "policy": {"w": jnp.asarray([3.0])}}
     dpg.get_eval_state = lambda: eval_state
 
     DDPG._checkpoint_update_snapshot(dpg)
@@ -139,7 +142,7 @@ def test_checkpoint_round_trip(cls):
     src.ckpt = _scaffold()
     src.train_steps_count = 11
     src._ckpt_update_residual = 2.5
-    src.eval_snapshot = {"encoder": _tree(7.0), "policy": _tree(8.0)}
+    src.eval_snapshot = {"actor_encoder": _tree(7.0), "policy": _tree(8.0)}
     for i, name in enumerate(fields):
         setattr(src, name, _field_value(name, i))
     # Make the schedule state non-default so the spine must carry it.

--- a/tests/test_checkpoint_store_adapter.py
+++ b/tests/test_checkpoint_store_adapter.py
@@ -2,6 +2,7 @@ import tempfile
 
 import jax.numpy as jnp
 import numpy as np
+import optax
 import pytest
 
 from experiments.checkpoint_store import FileCheckpointStore
@@ -33,15 +34,15 @@ def test_noop_checkpoint_store_does_not_write_and_cannot_restore(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("family", "sets_target"),
+    "family",
     [
-        (Actor_Critic_Policy_Gradient_Family, False),
-        (Ape_X_Family, True),
-        (Ape_X_Deteministic_Policy_Gradient_Family, True),
-        (IMPALA_Family, True),
+        Actor_Critic_Policy_Gradient_Family,
+        Ape_X_Family,
+        Ape_X_Deteministic_Policy_Gradient_Family,
+        IMPALA_Family,
     ],
 )
-def test_remaining_families_delegate_checkpoint_io(family, sets_target):
+def test_remaining_families_delegate_checkpoint_io(family):
     class MemoryStore:
         def __init__(self, restored):
             self.restored = restored
@@ -54,14 +55,37 @@ def test_remaining_families_delegate_checkpoint_io(family, sets_target):
             return self.restored
 
     agent = family.__new__(family)
-    agent.params = {"weights": 1}
-    if isinstance(agent, Actor_Critic_Policy_Gradient_Family):
-        agent.obs_rms = None
-        agent.memory_backend = "cpu"
-        agent.memory_device = None
-        saved = ACCheckpointState(params=agent.params, obs_rms_state=None)
-        restored = ACCheckpointState(params={"weights": 2}, obs_rms_state=None)
+    if family in (Actor_Critic_Policy_Gradient_Family, IMPALA_Family):
+        agent.actor_params = {"weights": 1}
+        agent.critic_params = {"weights": 2}
+        if family is Actor_Critic_Policy_Gradient_Family:
+            agent.obs_rms = None
+            agent.memory_backend = "cpu"
+            agent.memory_device = None
+        saved = ACCheckpointState(
+            actor_params=agent.actor_params, critic_params=agent.critic_params
+        )
+        restored = ACCheckpointState(actor_params={"weights": 3}, critic_params={"weights": 4})
+    elif family is Ape_X_Deteministic_Policy_Gradient_Family:
+        agent.policy_params = {"weights": 1}
+        agent.critic_params = {"weights": 2}
+        agent.target_policy_params = {"weights": 3}
+        agent.target_critic_params = {"weights": 4}
+        agent.optimizer = optax.sgd(1e-3)
+        saved = {
+            "policy": agent.policy_params,
+            "critic": agent.critic_params,
+            "target_policy": agent.target_policy_params,
+            "target_critic": agent.target_critic_params,
+        }
+        restored = {
+            "policy": {"weights": 5},
+            "critic": {"weights": 6},
+            "target_policy": {"weights": 7},
+            "target_critic": {"weights": 8},
+        }
     else:
+        agent.params = {"weights": 1}
         saved = agent.params
         restored = {"weights": 2}
     agent.checkpoint_store = MemoryStore(restored)
@@ -71,6 +95,14 @@ def test_remaining_families_delegate_checkpoint_io(family, sets_target):
 
     assert agent.checkpoint_store.saved == ("checkpoint", saved)
     assert agent.checkpoint_store.restored_path == "checkpoint"
-    assert agent.params == {"weights": 2}
-    if sets_target:
+    if family in (Actor_Critic_Policy_Gradient_Family, IMPALA_Family):
+        assert agent.actor_params == {"weights": 3}
+        assert agent.critic_params == {"weights": 4}
+    elif family is Ape_X_Deteministic_Policy_Gradient_Family:
+        assert agent.policy_params == {"weights": 5}
+        assert agent.critic_params == {"weights": 6}
+        assert agent.target_policy_params == {"weights": 7}
+        assert agent.target_critic_params == {"weights": 8}
+    else:
+        assert agent.params == {"weights": 2}
         assert agent.target_params is agent.params

--- a/tests/test_cli_dpg_registry.py
+++ b/tests/test_cli_dpg_registry.py
@@ -463,19 +463,22 @@ def test_dist_resolver_resolves_flax_base(family: str):
 
 @pytest.mark.parametrize("family", DIST_FAMILIES)
 def test_dist_policy_kwargs_uses_shared_normal_embedding(family: str):
-    """All distributed families share the Atari ``normal`` embedding policy.
-
-    Pins the consolidation of three byte-identical ``policy_kwargs`` helpers onto
-    ``_run.default_policy_kwargs`` so the embedding mode cannot silently drift per
-    family.
-    """
-    from experiments.cli._run import default_policy_kwargs
+    from experiments.cli._run import actor_critic_policy_kwargs, default_policy_kwargs
 
     runner = _dist_runner(family)
-    assert runner.policy_kwargs is default_policy_kwargs
-    args = _parse(runner, ["--algo", min(runner.algos), "--node", "128", "--hidden_n", "3"])
+    if family == "apex_qnet":
+        assert runner.policy_kwargs is default_policy_kwargs
+        widths = {"node": 128}
+    else:
+        assert runner.policy_kwargs is actor_critic_policy_kwargs
+        widths = {"actor_node": 128, "critic_node": 256}
+    args = _parse(
+        runner,
+        ["--algo", min(runner.algos), "--hidden_n", "3"]
+        + [item for name, width in widths.items() for item in (f"--{name}", str(width))],
+    )
     assert runner.policy_kwargs(args) == {
-        "node": 128,
+        **widths,
         "hidden_n": 3,
         "embedding_mode": "normal",
     }

--- a/tests/test_dict_observation_contract.py
+++ b/tests/test_dict_observation_contract.py
@@ -105,25 +105,22 @@ def test_crossq_critic_loss_concatenates_dict_observation_values():
     agent._gamma = 0.99
     seen = {}
 
-    def preproc(_params, _key, observations):
-        seen.update(observations)
-        return {
-            "actor": observations["unified_obs"],
-            "critic": observations["unified_obs"],
-        }
+    agent._get_pi_log_prob = lambda _params, observations, _key: (
+        jnp.zeros((observations["unified_obs"].shape[0], 1)),
+        jnp.zeros((observations["unified_obs"].shape[0], 1)),
+    )
 
-    agent.preproc = preproc
-    agent._get_pi_log_prob = lambda _params, features, _key: (
-        jnp.zeros((features["actor"].shape[0], 1)),
-        jnp.zeros((features["actor"].shape[0], 1)),
-    )
-    agent.critic = lambda params, _key, features, _actions, _training: (
-        (
-            jnp.zeros((features["actor"].shape[0], 1)),
-            jnp.zeros((features["actor"].shape[0], 1)),
-        ),
-        {"batch_stats": params["batch_stats"]},
-    )
+    def critic(params, _key, observations, _actions, _training):
+        seen.update(observations)
+        return (
+            (
+                jnp.zeros((observations["unified_obs"].shape[0], 1)),
+                jnp.zeros((observations["unified_obs"].shape[0], 1)),
+            ),
+            {"batch_stats": params["batch_stats"]},
+        )
+
+    agent.critic = critic
     observations = {"unified_obs": jnp.ones((2, 3))}
     next_observations = {"unified_obs": jnp.full((2, 3), 2.0)}
 

--- a/tests/test_distributed_lifecycle_cleanup.py
+++ b/tests/test_distributed_lifecycle_cleanup.py
@@ -66,7 +66,14 @@ def _make_agent(monkeypatch, module_name, class_name, kind, *, ready, stop_on_ru
     worker = Mock()
     worker.run.side_effect = lambda *a, **kw: (stop.set() if stop_on_run else None) or "job"
     agent.workers = [worker]
-    agent.params = {"weight": 1}
+    if kind == "impala":
+        agent.actor_params = {"weight": 1}
+        agent.critic_params = {"weight": 2}
+    elif kind == "apex_dpg":
+        agent.policy_params = {"weight": 1}
+        agent.critic_params = {"weight": 2}
+    else:
+        agent.params = {"weight": 1}
     agent.model_builder = object()
     agent.actor_builder = object()
     agent.worker_replay_factory = lambda *_args, **_kwargs: object()

--- a/tests/test_flax_dpg_builder_param_tree.py
+++ b/tests/test_flax_dpg_builder_param_tree.py
@@ -1,14 +1,4 @@
-"""Golden-master param-tree structure for the shared flax DPG builders.
-
-Locks the Flax param-tree keypaths + shapes that ``ddpg_builder``/``td3_builder``
-produce after their deterministic ``Actor``/``Critic`` were extracted into the
-shared ``ddpg_td3_blocks`` module, and that ``sac_builder``/``tqc_builder``
-produce after their squashed-Gaussian ``Actor`` + plain ``Critic`` were extracted
-into the shared ``gaussian_blocks`` module. Flax param keys depend on the
-enclosing module attribute names (``act``, ``crit1``, ``crit2``) and the inner
-class identifiers; a future rename or layer-count change that silently broke
-checkpoint compatibility would change this structure and fail here.
-"""
+"""Independent Flax DPG parameter trees with different actor and critic widths."""
 
 from __future__ import annotations
 
@@ -31,7 +21,7 @@ from model_builder.flax.dpg.tqc_builder import (
     model_builder_maker as tqc_model_builder_maker,
 )
 
-_POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
+_POLICY_KWARGS = {"actor_node": 16, "critic_node": 32, "hidden_n": 2, "embedding_mode": "normal"}
 _OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _SUPPORT_N = 25
@@ -63,11 +53,11 @@ _ACTOR_STRUCTURE = {
 }
 
 _CRITIC_TOWER = {
-    ("['params']['Dense_0']['kernel']", (6, 16)),
-    ("['params']['Dense_0']['bias']", (16,)),
-    ("['params']['Dense_1']['kernel']", (16, 16)),
-    ("['params']['Dense_1']['bias']", (16,)),
-    ("['params']['Dense_2']['kernel']", (16, 1)),
+    ("['params']['Dense_0']['kernel']", (6, 32)),
+    ("['params']['Dense_0']['bias']", (32,)),
+    ("['params']['Dense_1']['kernel']", (32, 32)),
+    ("['params']['Dense_1']['bias']", (32,)),
+    ("['params']['Dense_2']['kernel']", (32, 1)),
     ("['params']['Dense_2']['bias']", (1,)),
 }
 
@@ -99,11 +89,11 @@ def _quantile_critic_tower(support_n):
     # tqc's Critic mirrors the plain Critic MLP but emits ``support_n`` quantiles
     # from its final Dense instead of a single scalar.
     return {
-        ("['params']['Dense_0']['kernel']", (6, 16)),
-        ("['params']['Dense_0']['bias']", (16,)),
-        ("['params']['Dense_1']['kernel']", (16, 16)),
-        ("['params']['Dense_1']['bias']", (16,)),
-        ("['params']['Dense_2']['kernel']", (16, support_n)),
+        ("['params']['Dense_0']['kernel']", (6, 32)),
+        ("['params']['Dense_0']['bias']", (32,)),
+        ("['params']['Dense_1']['kernel']", (32, 32)),
+        ("['params']['Dense_1']['bias']", (32,)),
+        ("['params']['Dense_2']['kernel']", (32, support_n)),
         ("['params']['Dense_2']['bias']", (support_n,)),
     }
 
@@ -121,7 +111,7 @@ def _param_structure(tree):
 
 def _build(maker):
     builder = maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    _preproc, _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
     return policy_params, critic_params
 
 
@@ -134,16 +124,17 @@ def test_deterministic_builders_preserve_public_contract_and_param_roots(
     assert hasattr(module, "Critic")
 
     builder = module.model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    assert len(builder()) == 3
-    preproc, actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    assert len(builder()) == 2
+    actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
     assert set(policy_params["params"]) == {"act"}
-    assert set(critic_params["params"]) == critic_roots
+    assert set(critic_params["params"]) == (critic_roots if twin else {"crit1"})
+    if not twin:
+        assert set(critic_params["params"]["crit1"]) == critic_roots
 
     key = jax.random.PRNGKey(1)
-    feature = preproc(policy_params, key, {"unified_obs": jnp.zeros((1, 4), dtype=jnp.float32)})
-    action = actor(policy_params, key, feature)
-    values = critic(critic_params, key, feature, action)
-    assert feature["actor"].shape == feature["critic"].shape == (1, 4)
+    observations = {"unified_obs": jnp.zeros((1, 4), dtype=jnp.float32)}
+    action = actor(policy_params, key, observations)
+    values = critic(critic_params, key, observations, action)
     assert action.shape == (1, 2)
     if twin:
         assert tuple(value.shape for value in values) == ((1, 1), (1, 1))
@@ -154,7 +145,7 @@ def test_deterministic_builders_preserve_public_contract_and_param_roots(
 def test_ddpg_builder_param_tree_structure():
     policy_params, critic_params = _build(ddpg_model_builder_maker)
     assert _param_structure(policy_params) == _ACTOR_STRUCTURE
-    assert _param_structure(critic_params) == _CRITIC_TOWER
+    assert _param_structure(critic_params) == _twin_tower("crit1")
 
 
 def test_td3_builder_param_tree_structure():
@@ -173,7 +164,7 @@ def test_tqc_builder_param_tree_structure():
     builder = tqc_model_builder_maker(
         _OBSERVATION_SPACE, _ACTION_SIZE, _SUPPORT_N, dict(_POLICY_KWARGS)
     )
-    _preproc, _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
     quantile_tower = _quantile_critic_tower(_SUPPORT_N)
     assert _param_structure(policy_params) == _GAUSSIAN_ACTOR_STRUCTURE
     assert _param_structure(critic_params) == _twin_tower_from(

--- a/tests/test_haiku_dpg_builder_param_tree.py
+++ b/tests/test_haiku_dpg_builder_param_tree.py
@@ -1,13 +1,4 @@
-"""Golden-master param-tree structure for the Haiku DPG builders.
-
-Locks the Haiku param-tree keypaths + shapes that the five Haiku DPG builders
-(``ddpg``, ``td3``, ``sac``, ``tqc``, ``td7``) produce. Haiku param keys derive
-from the ``hk.Module`` subclass name (lowercased, e.g. ``actor``/``critic``) and
-the enclosing ``hk.transform`` scope, so extracting the shared ``Actor``/
-``Critic`` classes into ``ddpg_td3_blocks`` must leave these structures
-byte-identical. A future change that silently broke checkpoint compatibility
-would change this structure and fail here.
-"""
+"""Parameter shapes for independently owned Haiku DPG actor and critic models."""
 
 from __future__ import annotations
 
@@ -29,7 +20,7 @@ from model_builder.haiku.dpg.tqc_builder import (
     model_builder_maker as tqc_model_builder_maker,
 )
 
-_POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
+_POLICY_KWARGS = {"actor_node": 16, "critic_node": 16, "hidden_n": 2, "embedding_mode": "normal"}
 _OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _TQC_SUPPORT_N = 25
@@ -74,23 +65,26 @@ def _critic_tower(name, head):
 
 def test_ddpg_builder_param_tree_structure():
     builder = ddpg_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    _preproc, _actor, _critic, params = builder(jax.random.PRNGKey(0))
-    assert _param_structure(params) == _DET_ACTOR_STRUCTURE | _critic_tower("critic", 1)
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    assert _param_structure(policy_params) == _DET_ACTOR_STRUCTURE
+    assert _param_structure(critic_params) == _critic_tower("critic", 1)
 
 
 def test_td3_builder_param_tree_structure():
     builder = td3_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    _preproc, _actor, _critic, params = builder(jax.random.PRNGKey(0))
-    assert _param_structure(params) == (
-        _DET_ACTOR_STRUCTURE | _critic_tower("critic", 1) | _critic_tower("critic_1", 1)
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    assert _param_structure(policy_params) == _DET_ACTOR_STRUCTURE
+    assert _param_structure(critic_params) == _critic_tower("critic", 1) | _critic_tower(
+        "critic_1", 1
     )
 
 
 def test_sac_builder_param_tree_structure():
     builder = sac_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    _preproc, _actor, _critic, params = builder(jax.random.PRNGKey(0))
-    assert _param_structure(params) == (
-        _GAUSSIAN_ACTOR_STRUCTURE | _critic_tower("critic", 1) | _critic_tower("critic_1", 1)
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    assert _param_structure(policy_params) == _GAUSSIAN_ACTOR_STRUCTURE
+    assert _param_structure(critic_params) == _critic_tower("critic", 1) | _critic_tower(
+        "critic_1", 1
     )
 
 
@@ -98,30 +92,27 @@ def test_tqc_builder_param_tree_structure():
     builder = tqc_model_builder_maker(
         _OBSERVATION_SPACE, _ACTION_SIZE, _TQC_SUPPORT_N, dict(_POLICY_KWARGS)
     )
-    _preproc, _actor, _critic, params = builder(jax.random.PRNGKey(0))
-    assert _param_structure(params) == (
-        _GAUSSIAN_ACTOR_STRUCTURE
-        | _critic_tower("critic", _TQC_SUPPORT_N)
-        | _critic_tower("critic_1", _TQC_SUPPORT_N)
+    _actor, _critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    assert _param_structure(policy_params) == _GAUSSIAN_ACTOR_STRUCTURE
+    assert _param_structure(critic_params) == (
+        _critic_tower("critic", _TQC_SUPPORT_N) | _critic_tower("critic_1", _TQC_SUPPORT_N)
     )
 
 
-# --- td7 keeps its own Encoder/Action_Encoder/Actor/Critic (structurally
-# distinct: avgl1norm preamble, embedding concat). These trees are locked here
-# to prove the S2 extraction did not perturb td7 at all. ---
+# TD7 gives each role its own state and action encoders.
 _TD7_ENCODER_PARAMS = {
-    ("['encoder/linear']['w']", (4, 256)),
-    ("['encoder/linear']['b']", (256,)),
-    ("['encoder/linear_1']['w']", (256, 256)),
-    ("['encoder/linear_1']['b']", (256,)),
-    ("['encoder/linear_2']['w']", (256, 256)),
-    ("['encoder/linear_2']['b']", (256,)),
-    ("['action__encoder/linear']['w']", (258, 256)),
-    ("['action__encoder/linear']['b']", (256,)),
-    ("['action__encoder/linear_1']['w']", (256, 256)),
-    ("['action__encoder/linear_1']['b']", (256,)),
-    ("['action__encoder/linear_2']['w']", (256, 256)),
-    ("['action__encoder/linear_2']['b']", (256,)),
+    ("['encoder/linear']['w']", (4, 16)),
+    ("['encoder/linear']['b']", (16,)),
+    ("['encoder/linear_1']['w']", (16, 16)),
+    ("['encoder/linear_1']['b']", (16,)),
+    ("['encoder/linear_2']['w']", (16, 16)),
+    ("['encoder/linear_2']['b']", (16,)),
+    ("['action__encoder/linear']['w']", (18, 16)),
+    ("['action__encoder/linear']['b']", (16,)),
+    ("['action__encoder/linear_1']['w']", (16, 16)),
+    ("['action__encoder/linear_1']['b']", (16,)),
+    ("['action__encoder/linear_2']['w']", (16, 16)),
+    ("['action__encoder/linear_2']['b']", (16,)),
 }
 
 
@@ -129,7 +120,7 @@ def _td7_critic_tower(name):
     return {
         (f"['{name}/linear']['w']", (6, 16)),
         (f"['{name}/linear']['b']", (16,)),
-        (f"['{name}/linear_1']['w']", (528, 16)),
+        (f"['{name}/linear_1']['w']", (48, 16)),
         (f"['{name}/linear_1']['b']", (16,)),
         (f"['{name}/linear_2']['w']", (16, 16)),
         (f"['{name}/linear_2']['b']", (16,)),
@@ -141,7 +132,7 @@ def _td7_critic_tower(name):
 _TD7_ACTOR_PARAMS = {
     ("['actor/linear']['w']", (4, 16)),
     ("['actor/linear']['b']", (16,)),
-    ("['actor/linear_1']['w']", (272, 16)),
+    ("['actor/linear_1']['w']", (32, 16)),
     ("['actor/linear_1']['b']", (16,)),
     ("['actor/linear_2']['w']", (16, 16)),
     ("['actor/linear_2']['b']", (16,)),
@@ -153,15 +144,20 @@ _TD7_ACTOR_PARAMS = {
 def test_td7_builder_param_tree_structure():
     builder = td7_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
     (
-        _preproc,
-        _encoder,
-        _action_encoder,
+        _actor_encoder,
+        _critic_encoder,
+        _actor_action_encoder,
+        _critic_action_encoder,
         _actor,
         _critic,
-        encoder_params,
-        params,
+        actor_encoder_params,
+        critic_encoder_params,
+        policy_params,
+        critic_params,
     ) = builder(jax.random.PRNGKey(0))
-    assert _param_structure(encoder_params) == _TD7_ENCODER_PARAMS
-    assert _param_structure(params) == (
-        _TD7_ACTOR_PARAMS | _td7_critic_tower("critic") | _td7_critic_tower("critic_1")
+    assert _param_structure(actor_encoder_params) == _TD7_ENCODER_PARAMS
+    assert _param_structure(critic_encoder_params) == _TD7_ENCODER_PARAMS
+    assert _param_structure(policy_params) == _TD7_ACTOR_PARAMS
+    assert _param_structure(critic_params) == _td7_critic_tower("critic") | _td7_critic_tower(
+        "critic_1"
     )

--- a/tests/test_issue7_contracts.py
+++ b/tests/test_issue7_contracts.py
@@ -165,7 +165,7 @@ def test_apex_dpg_constructors_initialize_model_setup_dependencies(monkeypatch, 
 
     def _model_builder_maker(*_args, **_kwargs):
         def _builder(*_builder_args, **_builder_kwargs):
-            return "preproc", "actor", "critic", {"params": 1}
+            return "actor", "critic", {"policy": 1}, {"critic": 1}
 
         return _builder
 
@@ -212,14 +212,13 @@ def test_flax_ac_continuous_actor_initializes_log_std_param():
         {"unified_obs": [3]},
         [1],
         "continuous",
-        {"node": 8, "hidden_n": 1, "embedding_mode": "normal"},
+        {"actor_node": 8, "critic_node": 8, "hidden_n": 1, "embedding_mode": "normal"},
     )
-    preproc, actor, critic, params = builder(jax.random.PRNGKey(0))
+    actor, critic, actor_params, critic_params = builder(jax.random.PRNGKey(0))
 
     obs = {"unified_obs": np.zeros((1, 3), dtype=np.float32)}
-    feature = preproc(params, None, obs)
-    mu, log_std = actor(params, None, feature)
-    value = critic(params, None, feature)
+    mu, log_std = actor(actor_params, None, obs)
+    value = critic(critic_params, None, obs)
 
     assert mu.shape[-1] == 1
     assert log_std.shape == (1, 1)

--- a/tests/test_observation_role_isolation.py
+++ b/tests/test_observation_role_isolation.py
@@ -15,44 +15,31 @@ def test_actor_critic_observation_roles_are_isolated(backend, family):
         f"model_builder.{backend}.{family}.{'ac' if family == 'ac' else 'ddpg'}_builder"
     )
     space = {"actor_sensor": [2], "critic_privileged": [3], "unified_command": [1]}
-    kwargs = {"node": 16, "hidden_n": 1}
+    kwargs = {"actor_node": 16, "critic_node": 32, "hidden_n": 1}
     key = jax.random.PRNGKey(3)
     if family == "ac":
-        preproc, actor, critic, params = module.model_builder_maker(
+        actor, critic, params, critic_params = module.model_builder_maker(
             space, (2,), "continuous", kwargs
         )(key)
-        critic_params = params
-    elif backend == "flax":
-        preproc, actor, critic, params, critic_params = module.model_builder_maker(
-            space, (2,), kwargs
-        )(key)
     else:
-        preproc, actor, critic, params = module.model_builder_maker(space, (2,), kwargs)(key)
-        critic_params = params
+        actor, critic, params, critic_params = module.model_builder_maker(space, (2,), kwargs)(key)
 
     obs = {name: jnp.ones((2, *shape)) for name, shape in space.items()}
 
     def outputs(observations):
-        feature = preproc(params, key, observations)
-        policy = actor(params, key, feature)
+        policy = actor(params, key, observations)
         value = (
-            critic(critic_params, key, feature)
+            critic(critic_params, key, observations)
             if family == "ac"
-            else critic(critic_params, key, feature, jnp.zeros((2, 2)))
+            else critic(critic_params, key, observations, jnp.zeros((2, 2)))
         )
         return policy[0] if family == "ac" else policy, value
 
-    features = preproc(params, key, obs)
-    assert features["actor"].shape == (2, 3)
-    assert features["critic"].shape == (2, 4)
-    for role, name in (("actor", "actor_sensor"), ("critic", "critic_privileged")):
-        changed = preproc(params, key, {**obs, name: obs[name] * 7})
-        assert not np.array_equal(changed[role], features[role])
-    shared = preproc(params, key, {**obs, "unified_command": obs["unified_command"] * 7})
-    for role in ("actor", "critic"):
-        assert not np.array_equal(shared[role], features[role])
-
     policy, value = outputs(obs)
+    actor_only = actor(
+        params, key, {name: obs[name] for name in ("actor_sensor", "unified_command")}
+    )
+    np.testing.assert_array_equal(actor_only[0] if family == "ac" else actor_only, policy)
     actor_changed, critic_unchanged = outputs({**obs, "actor_sensor": obs["actor_sensor"] * 7})
     actor_unchanged, _ = outputs({**obs, "critic_privileged": obs["critic_privileged"] * 7})
     shared_actor, _ = outputs({**obs, "unified_command": obs["unified_command"] * 7})
@@ -67,16 +54,21 @@ def test_td7_encoder_and_actor_ignore_privileged_observations(backend):
     module = importlib.import_module(f"model_builder.{backend}.dpg.td7_builder")
     space = {"actor_sensor": [2], "critic_privileged": [3], "unified_command": [1]}
     key = jax.random.PRNGKey(3)
-    built = module.model_builder_maker(space, (2,), {"node": 16, "hidden_n": 1})(key)
-    preproc, encoder, _, actor, _ = built[:5]
-    encoder_params, policy_params = built[5:7]
+    built = module.model_builder_maker(
+        space, (2,), {"actor_node": 16, "critic_node": 32, "hidden_n": 1}
+    )(key)
+    encoder, _, _, _, actor, _ = built[:6]
+    encoder_params, _, policy_params, _ = built[6:]
     obs = {name: jnp.ones((2, *shape)) for name, shape in space.items()}
-    feature = preproc(encoder_params, key, obs)
-    privileged = preproc(
+    feature, zs = encoder(encoder_params, key, obs)
+    privileged, privileged_zs = encoder(
         encoder_params, key, {**obs, "critic_privileged": obs["critic_privileged"] * 7}
     )
-    zs = encoder(encoder_params, key, feature)
-    privileged_zs = encoder(encoder_params, key, privileged)
+    actor_only, actor_only_zs = encoder(
+        encoder_params, key, {name: obs[name] for name in ("actor_sensor", "unified_command")}
+    )
+    np.testing.assert_array_equal(actor_only, feature)
+    np.testing.assert_array_equal(actor_only_zs, zs)
     np.testing.assert_array_equal(privileged_zs, zs)
     np.testing.assert_array_equal(
         actor(policy_params, key, feature, zs),

--- a/tests/test_optimizer_factory_injection.py
+++ b/tests/test_optimizer_factory_injection.py
@@ -53,8 +53,10 @@ def test_a2c_prepare_run_rebuilds_optimizer_with_linear_lr_schedule_through_fact
     agent.worker_size = 2
     agent.minibatch_size = 5
     agent.epoch_num = 3
-    agent.params = {"w": 1.0}
-    agent.opt_state = {"state": "old"}
+    agent.actor_params = {"w": 1.0}
+    agent.critic_params = {"w": 2.0}
+    agent.actor_opt_state = {"state": "old"}
+    agent.critic_opt_state = {"state": "old"}
 
     agent.prepare_run(100)
 
@@ -65,7 +67,9 @@ def test_a2c_prepare_run_rebuilds_optimizer_with_linear_lr_schedule_through_fact
     assert float(schedule(30)) == pytest.approx(0.000125)
     assert float(schedule(60)) == pytest.approx(0.0)
     assert calls[1] == {"init_params": {"w": 1.0}}
-    assert agent.opt_state == {"state": "reset"}
+    assert calls[2] == {"init_params": {"w": 2.0}}
+    assert agent.actor_opt_state == {"state": "reset"}
+    assert agent.critic_opt_state == {"state": "reset"}
 
 
 def test_q_network_constructor_uses_injected_optimizer_factory(monkeypatch):

--- a/tests/test_pg_ppo2_fidelity_cli.py
+++ b/tests/test_pg_ppo2_fidelity_cli.py
@@ -126,8 +126,10 @@ def test_prepare_run_rebuilds_optimizer_with_linear_lr_schedule():
     agent.worker_size = 2
     agent.minibatch_size = 5
     agent.epoch_num = 3
-    agent.params = {"w": 1.0}
-    agent.opt_state = {"state": "old"}
+    agent.actor_params = {"w": 1.0}
+    agent.critic_params = {"w": 2.0}
+    agent.actor_opt_state = {"state": "old"}
+    agent.critic_opt_state = {"state": "old"}
 
     agent.prepare_run(100)
 
@@ -138,7 +140,9 @@ def test_prepare_run_rebuilds_optimizer_with_linear_lr_schedule():
     assert float(schedule(30)) == pytest.approx(0.000125)
     assert float(schedule(60)) == pytest.approx(0.0)
     assert calls[1] == {"init_params": {"w": 1.0}}
-    assert agent.opt_state == {"state": "reset"}
+    assert calls[2] == {"init_params": {"w": 2.0}}
+    assert agent.actor_opt_state == {"state": "reset"}
+    assert agent.critic_opt_state == {"state": "reset"}
 
 
 def test_prepare_run_skips_lr_annealing_until_params_exist():
@@ -146,7 +150,7 @@ def test_prepare_run_skips_lr_annealing_until_params_exist():
     agent = Actor_Critic_Policy_Gradient_Family.__new__(Actor_Critic_Policy_Gradient_Family)
     agent.optimizer_factory = lambda *args, **kwargs: calls.append((args, kwargs))
     agent.lr_annealing = True
-    agent.params = None
+    agent.actor_params = None
 
     agent.prepare_run(100)
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -950,7 +950,7 @@ def _dpg_action_agent():
     agent.learning_starts = 0
     agent.worker_size = 1
     agent.action_size = (1,)
-    agent._select_action_state = lambda eval, steps: {"encoder": None, "policy": None}
+    agent._select_action_state = lambda eval, steps: {"actor_encoder": None, "policy": None}
     agent._policy_action_from_state = lambda state, obs, eval, steps: np.asarray(obs["unified_obs"])
     agent._apply_action_noise = lambda actions, steps, eval: actions
     return agent
@@ -985,7 +985,7 @@ def test_dpg_eval_skips_random_warmup_and_uses_policy_action():
     agent.learning_starts = 100
     agent.worker_size = 32
     agent.action_size = (17,)
-    agent._select_action_state = lambda eval, steps: {"encoder": None, "policy": None}
+    agent._select_action_state = lambda eval, steps: {"actor_encoder": None, "policy": None}
     agent._policy_action_from_state = lambda state, obs, eval, steps: np.full((1, 17), 0.5)
     agent._apply_action_noise = lambda actions, steps, eval: actions
     env = _ShapeCheckingEvalEnv((17,))
@@ -1004,7 +1004,7 @@ def test_td3_test_action_uses_eval_action_shape_with_many_workers():
     agent.worker_size = 32
     agent.action_size = (17,)
     agent.action_noise = 0.1
-    agent._select_action_state = lambda eval, steps: {"encoder": None, "policy": None}
+    agent._select_action_state = lambda eval, steps: {"actor_encoder": None, "policy": None}
     agent._policy_action_from_state = lambda state, obs, eval, steps: np.ones((1, 17))
     env = _ShapeCheckingEvalEnv((17,))
 
@@ -1018,14 +1018,14 @@ def test_td7_eval_snapshot_waits_for_checkpoint_enabled_gate():
     agent.use_checkpointing = True
     agent.ckpt = type("Ckpt", (), {"enabled": False})()
     agent.eval_snapshot = {
-        "encoder": "checkpoint-encoder",
+        "actor_encoder": "checkpoint-encoder",
         "policy": "checkpoint-policy",
     }
-    agent.fixed_encoder_params = "live-encoder"
+    agent.fixed_actor_encoder_params = "live-encoder"
     agent.policy_params = "live-policy"
 
     assert TD7._select_action_state(agent, eval=True, steps=5) == {
-        "encoder": "live-encoder",
+        "actor_encoder": "live-encoder",
         "policy": "live-policy",
     }
 

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -35,13 +35,9 @@ def test_dpg_eval_path_uses_sac_mode_without_sampling():
     agent.learning_starts = 100
     agent.use_checkpointing = False
     agent.policy_params = None
-    agent.preproc = lambda params, key, obs: {
-        "actor": obs["unified_obs"],
-        "critic": obs["unified_obs"],
-    }
     agent.actor = lambda params, key, feature: (
-        feature["actor"],
-        jnp.full_like(feature["actor"], 10.0),
+        feature["unified_obs"],
+        jnp.full_like(feature["unified_obs"], 10.0),
     )
 
     obs = {"unified_obs": jnp.array([[0.25, -0.5]])}
@@ -52,10 +48,9 @@ def test_dpg_eval_path_uses_sac_mode_without_sampling():
 
 def test_sac_actor_loss_uses_minimum_expected_q():
     agent = object.__new__(SAC)
-    agent.preproc = lambda params, key, obs: obs
     agent._get_pi_log_prob = lambda params, feature, key: (
-        jnp.zeros((feature["actor"].shape[0], 1)),
-        jnp.zeros((feature["actor"].shape[0], 1)),
+        jnp.zeros((feature["unified_obs"].shape[0], 1)),
+        jnp.zeros((feature["unified_obs"].shape[0], 1)),
     )
     agent.critic = lambda params, key, feature, policy: (
         jnp.array([[0.0], [10.0]]),
@@ -66,7 +61,7 @@ def test_sac_actor_loss_uses_minimum_expected_q():
         agent,
         None,
         None,
-        {"actor": jnp.ones((2, 1)), "critic": jnp.ones((2, 1))},
+        {"unified_obs": jnp.ones((2, 1))},
         None,
         0.01,
     )
@@ -79,13 +74,9 @@ def test_other_stochastic_dpg_algorithms_also_use_mode_for_evaluation(cls):
     obs = {"unified_obs": jnp.array([[0.25, -0.5]])}
 
     agent = object.__new__(cls)
-    agent.preproc = lambda params, key, value: {
-        "actor": value["unified_obs"],
-        "critic": value["unified_obs"],
-    }
     agent.actor = lambda params, key, feature: (
-        feature["actor"],
-        jnp.full_like(feature["actor"], 10.0),
+        feature["unified_obs"],
+        jnp.full_like(feature["unified_obs"], 10.0),
     )
 
     np.testing.assert_allclose(agent._get_eval_actions(None, obs), jnp.tanh(obs["unified_obs"]))
@@ -96,16 +87,16 @@ def test_crossq_actors_have_no_batch_stats_but_critics_do():
         builder = make_builder(
             {"unified_obs": [4]},
             [2],
-            {"node": 16, "hidden_n": 1, "embedding_mode": "normal"},
+            {"actor_node": 16, "critic_node": 128, "hidden_n": 1, "embedding_mode": "normal"},
         )
-        preproc, actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+        actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
 
         assert "batch_stats" not in policy_params
         assert "batch_stats" in critic_params
 
-        feature = preproc(policy_params, None, {"unified_obs": jnp.zeros((2, 4))})
-        mu, log_std = actor(policy_params, None, feature)
-        (q1, q2), updates = critic(critic_params, None, feature, jnp.zeros((2, 2)), True)
+        obs = {"unified_obs": jnp.zeros((2, 4))}
+        mu, log_std = actor(policy_params, None, obs)
+        (q1, q2), updates = critic(critic_params, None, obs, jnp.zeros((2, 2)), True)
 
         assert mu.shape == log_std.shape == (2, 2)
         assert q1.shape == q2.shape == (2, 1)
@@ -126,13 +117,9 @@ def test_flashsac_entropy_target_and_defaults():
 
 def test_sac_actor_and_temperature_update_on_configured_period():
     agent = object.__new__(SAC)
-    agent.preproc = lambda params, key, obs: {
-        "actor": obs["unified_obs"],
-        "critic": obs["unified_obs"],
-    }
     agent.actor = lambda params, key, feature: (
-        jnp.full((feature["actor"].shape[0], 1), params),
-        jnp.full((feature["actor"].shape[0], 1), -1.0),
+        jnp.full((feature["unified_obs"].shape[0], 1), params),
+        jnp.full((feature["unified_obs"].shape[0], 1), -1.0),
     )
     agent.critic = lambda params, key, feature, actions: (
         params + actions,
@@ -207,7 +194,7 @@ def test_sac_actor_and_target_use_distinct_fresh_keys():
     agent._target = lambda policy, target_critic, rewards, nxtobses, done, key, alpha: (
         jax.random.uniform(key)
     )
-    agent._critic_loss = lambda critic, policy, obses, actions, targets, weights, key: (
+    agent._critic_loss = lambda critic, obses, actions, targets, weights, key: (
         targets + 0.0 * critic,
         jnp.zeros((1,)),
     )

--- a/tests/test_scaled_by_reset.py
+++ b/tests/test_scaled_by_reset.py
@@ -33,7 +33,7 @@ from model_builder.flax.dpg.td3_builder import (
     model_builder_maker as td3_model_builder_maker,
 )
 
-_POLICY_KWARGS = {"node": 16, "hidden_n": 2, "embedding_mode": "normal"}
+_POLICY_KWARGS = {"actor_node": 16, "critic_node": 16, "hidden_n": 2, "embedding_mode": "normal"}
 _OBSERVATION_SPACE = {"unified_obs": [4]}
 _ACTION_SIZE = [2]
 _BATCH_SIZE = 8
@@ -52,7 +52,7 @@ def _batch():
 def _make_ddpg():
     agent = DDPG.__new__(DDPG)
     builder = ddpg_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    agent.preproc, agent.actor, agent.critic, agent.policy_params, agent.critic_params = builder(
+    agent.actor, agent.critic, agent.policy_params, agent.critic_params = builder(
         jax.random.PRNGKey(0)
     )
     agent.optimizer = optax.adam(1e-3)
@@ -71,7 +71,7 @@ def _make_ddpg():
 def _make_td3():
     agent = TD3.__new__(TD3)
     builder = td3_model_builder_maker(_OBSERVATION_SPACE, _ACTION_SIZE, dict(_POLICY_KWARGS))
-    agent.preproc, agent.actor, agent.critic, agent.policy_params, agent.critic_params = builder(
+    agent.actor, agent.critic, agent.policy_params, agent.critic_params = builder(
         jax.random.PRNGKey(0)
     )
     agent.optimizer = optax.adam(1e-3)

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -21,13 +21,9 @@ def _continuous_agent(cls, family):
     agent.lamda = 0.95
     agent.gae_normalize = False
     agent.gae_normalize_scope = "batch"
-    agent.preproc = lambda params, key, obses: {
-        "actor": obses["unified_obs"],
-        "critic": obses["unified_obs"],
-    }
-    agent.critic = lambda params, key, feature: jnp.zeros((*feature["critic"].shape[:-1], 1))
-    agent.actor = lambda params, key, feature: (
-        jnp.zeros((*feature["actor"].shape[:-1], 2)),
+    agent.critic = lambda params, key, obses: jnp.zeros((*obses["unified_obs"].shape[:-1], 1))
+    agent.actor = lambda params, key, obses: (
+        jnp.zeros((*obses["unified_obs"].shape[:-1], 2)),
         jnp.zeros((1, 2)),
     )
     agent.get_logprob = MethodType(family.get_logprob_continuous, agent)
@@ -52,16 +48,18 @@ def _rollout(worker_count=2, timesteps=3):
 )
 def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, family, kind):
     agent = _continuous_agent(cls, family)
-    agent.params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
-    agent.critic = lambda params, key, feature: (
-        jnp.zeros((*feature["critic"].shape[:-1], 1)) + params["bias"]
+    agent.actor_params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
+    agent.critic_params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
+    agent.critic = lambda params, key, obses: (
+        jnp.zeros((*obses["unified_obs"].shape[:-1], 1)) + params["bias"]
     )
-    agent.actor = lambda params, key, feature: (
-        jnp.zeros((*feature["actor"].shape[:-1], 2)) + params["bias"],
+    agent.actor = lambda params, key, obses: (
+        jnp.zeros((*obses["unified_obs"].shape[:-1], 2)) + params["bias"],
         jnp.zeros((1, 2)),
     )
     agent.optimizer = optax.sgd(1e-3)
-    agent.opt_state = agent.optimizer.init(agent.params)
+    agent.actor_opt_state = agent.optimizer.init(agent.actor_params)
+    agent.critic_opt_state = agent.optimizer.init(agent.critic_params)
     agent.val_coef = 0.2
     agent.ent_coef = 0.01
     agent.use_entropy_adv_shaping = False
@@ -81,8 +79,10 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
         agent.value_clip = 0.3
         result = TPPO._train_step(
             agent,
-            agent.params,
-            agent.opt_state,
+            agent.actor_params,
+            agent.critic_params,
+            agent.actor_opt_state,
+            agent.critic_opt_state,
             jax.random.PRNGKey(0),
             obses,
             actions,
@@ -97,8 +97,10 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
         agent.cut_max = 1.0
         result = IMPALA_TPPO._train_step(
             agent,
-            agent.params,
-            agent.opt_state,
+            agent.actor_params,
+            agent.critic_params,
+            agent.actor_opt_state,
+            agent.critic_opt_state,
             jax.random.PRNGKey(0),
             obses,
             actions,
@@ -110,4 +112,5 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
         )
 
     assert jnp.isfinite(result[0]["bias"])
-    assert all(bool(jnp.all(jnp.isfinite(value))) for value in result[2:])
+    assert jnp.isfinite(result[1]["bias"])
+    assert all(bool(jnp.all(jnp.isfinite(value))) for value in result[4:])

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -318,11 +318,9 @@ class FakeOnPolicyAgent(Actor_Critic_Policy_Gradient_Family):
             {"unified_obs": np.array([1.0, 2.0])}
         )
         self.conv_action = "conv-action"
-        # Mirror the real base __init__ defaults (base_class.py:68,70) so the
-        # hardened prepare_run (direct attribute access) keeps its no-op
-        # semantics: lr_annealing off and params unset.
         self.lr_annealing = False
-        self.params = None
+        self.actor_params = None
+        self.critic_params = None
         self.obs_rms = None
         self.memory_backend = "cpu"
         self.memory_device = None
@@ -444,17 +442,17 @@ class _EmptyBuffer:
     [
         (
             A2C,
-            ("params", "opt-state", 1, 2, 3, 4),
+            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4),
             ["critic_loss", "actor_loss", "entropy_loss", "mean_target"],
         ),
         (
             SurrogatePolicyGradient,
-            ("params", "opt-state", 1, 2, 3, 4),
+            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4),
             ["critic_loss", "actor_loss", "entropy_loss", "mean_target"],
         ),
         (
             TPPO,
-            ("params", "opt-state", 1, 2, 3, 4, 5),
+            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4, 5),
             [
                 "critic_loss",
                 "actor_loss",
@@ -468,8 +466,10 @@ class _EmptyBuffer:
 def test_on_policy_train_logger_is_explicit_and_not_retained(algorithm, train_result, metric_names):
     agent = algorithm.__new__(algorithm)
     agent.buffer = _EmptyBuffer()
-    agent.params = "old-params"
-    agent.opt_state = "old-opt-state"
+    agent.actor_params = "old-actor-params"
+    agent.critic_params = "old-critic-params"
+    agent.actor_opt_state = "old-actor-opt-state"
+    agent.critic_opt_state = "old-critic-opt-state"
     agent.key_seq = iter(["key-1", "key-2"])
     agent._train_step = lambda *args, **kwargs: train_result
     logger_run = _MetricLoggerRun()

--- a/tests/test_xqc_model_variant.py
+++ b/tests/test_xqc_model_variant.py
@@ -8,9 +8,9 @@ def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     builder = model_builder_maker(
         {"unified_obs": [4]},
         [2],
-        {"node": 16, "hidden_n": 1, "embedding_mode": "normal"},
+        {"actor_node": 16, "critic_node": 32, "hidden_n": 1, "embedding_mode": "normal"},
     )
-    preproc, actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
+    actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
 
     actor_params = policy_params["params"]["act"]
     assert set(policy_params["batch_stats"]["act"]) == {f"BatchNorm_{index}" for index in range(5)}
@@ -27,10 +27,10 @@ def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     assert critic_one["Dense_3"]["kernel"].shape == (32, 32)
     assert critic_one["Dense_4"]["kernel"].shape == (32, 101)
 
-    feature = preproc(policy_params, None, {"unified_obs": jnp.zeros((2, 4), dtype=jnp.float32)})
-    (mu, log_std), actor_updates = actor(policy_params, None, feature, True)
+    obs = {"unified_obs": jnp.zeros((2, 4), dtype=jnp.float32)}
+    (mu, log_std), actor_updates = actor(policy_params, None, obs, True)
     (q1, q2), critic_updates = critic(
-        critic_params, None, feature, jnp.zeros((2, 2), dtype=jnp.float32), True
+        critic_params, None, obs, jnp.zeros((2, 2), dtype=jnp.float32), True
     )
     assert mu.shape == log_std.shape == (2, 2)
     assert q1.shape == q2.shape == (2, 101)

--- a/tests/test_xqc_training_rules.py
+++ b/tests/test_xqc_training_rules.py
@@ -58,10 +58,9 @@ def test_xqc_categorical_q_uses_fixed_support_expectation():
 def test_xqc_categorical_train_step_updates_online_and_target_critics():
     agent = XQC.__new__(XQC)
     builder = model_builder_maker(
-        {"unified_obs": [4]}, [2], {"node": 16, "embedding_mode": "normal"}
+        {"unified_obs": [4]}, [2], {"actor_node": 16, "critic_node": 32, "embedding_mode": "normal"}
     )
     (
-        agent.preproc,
         agent.actor,
         agent.critic,
         policy_params,


### PR DESCRIPTION
AC·DPG 계열에서 Actor와 Critic의 파라미터·optimizer·학습 가능한 전처리를 역할별로 분리합니다. 각 모델은 자기 역할의 원시 관측을 받고, 공개 너비 옵션은 `actor_node`·`critic_node`만 사용합니다.

- Flax·Haiku 모델 빌더, AC·DPG 학습, IMPALA·APE-X learner/worker, TD7의 역할별 SALE encoder와 fixed/target 상태를 함께 이전했습니다.
- CLI·기존 YAML·checkpoint 구조·테스트를 새 계약으로 옮기고 AC·DPG의 `node`를 제거했습니다. Q-Net의 `node`는 기존 계약을 유지합니다.
- 모델 빌더와 학습 코드의 호출 계약이 함께 바뀌므로 하나의 PR에서 이전합니다. 기존 AC·DPG checkpoint와 사용자 정의 빌더는 새 구조로 이전해야 합니다. TD7의 독립 SALE 표현과 AC의 역할별 gradient clipping은 학습 동작을 바꿉니다.
- 검증: 동일 구현의 관련 테스트 **457 passed, 3 skipped**. AC·DPG 모델/실제 optimizer 업데이트, TD7·APE-X 경로 및 YAML 명령 134개를 확인했습니다. 이 PR 트리에서도 CPU PPO 정규 CLI가 16/32 너비로 8 환경 step을 완료했습니다.
- 정적 검사: 기반 대비 Ruff **32→16**, ty **173→136**. 파일·진단 종류별 증가 없이 기존 진단이 남아 있습니다. GPU 장기 학습과 실제 Ray transport는 실행하지 않았습니다.

스택 3/4. 기준 브랜치는 `stack/flashsac-02-flashsac`입니다. 공통 이미지의 Actor/Critic 전처리는 이 단계에서 각각 존재하며, 다음 PR에서 Actor 소유로 통합합니다.

리뷰·머지 순서: `main` → #36 → #37 → #38 → #39. 각 PR의 Files changed는 바로 앞 단계와의 차이입니다.
