### PR TITLE
[4/4] 공통 PreProc 학습을 Actor로 이관

### DIFF
--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -71,8 +71,12 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         targets = jax.vmap(discount_with_terminated, in_axes=(0, 0, 0, 0, None))(
             rewards, terminateds, truncateds, next_value, self.gamma
         )
@@ -106,7 +110,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         )
 
     def _loss_discrete(self, actor_params, critic_params, obses, actions, targets, adv, key):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
 
         prob, log_prob = self.get_logprob(
@@ -130,7 +134,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
     def _loss_continuous(self, actor_params, critic_params, obses, actions, targets, adv, key):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
 
         prob, log_prob = self.get_logprob(

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -94,8 +94,12 @@ class IMPALA(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
@@ -168,7 +172,7 @@ class IMPALA(IMPALA_Family):
         )
 
     def _loss_discrete(self, actor_params, critic_params, obses, actions, vs, adv, key):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(vs - vals))
 
         logit = self.actor(actor_params, key, obses)
@@ -190,7 +194,7 @@ class IMPALA(IMPALA_Family):
         return total_loss, (critic_loss, actor_loss, entropy_loss)
 
     def _loss_continuous(self, actor_params, critic_params, obses, actions, vs, adv, key):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(vs - vals))
 
         prob = self.actor(actor_params, key, obses)

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -109,8 +109,12 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,

--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -355,9 +355,9 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             nxtobses,
         )
         next_policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
-        concated_actions = jnp.concatenate([actions, next_policy])
+        concated_actions = jnp.concatenate([actions, jax.lax.stop_gradient(next_policy)])
         (q1, q2), variable_updates = self.critic(
-            critic_params, key, concated_obses, concated_actions, True
+            critic_params, policy_params, key, concated_obses, concated_actions, True
         )
         critic_params = {**critic_params, **variable_updates}
         q1, next_q1 = jnp.split(q1, 2, axis=0)
@@ -373,6 +373,6 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
         policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
-        (q1_pi, q2_pi), _ = self.critic(critic_params, key, obses, policy, False)
+        (q1_pi, q2_pi), _ = self.critic(critic_params, policy_params, key, obses, policy, False)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
         return actor_loss, log_prob

--- a/jax_baselines/DDPG/apex_ddpg.py
+++ b/jax_baselines/DDPG/apex_ddpg.py
@@ -56,8 +56,10 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
             ):
                 nxtobses = convert_normalized_obs(nxtobses)
                 next_action = actor(params["policy"], key, nxtobses)
-                next_q = critic(params["critic"], key, nxtobses, next_action)
-                q_values = critic(params["critic"], key, convert_normalized_obs(obses), actions)
+                next_q = critic(params["critic"], params["policy"], key, nxtobses, next_action)
+                q_values = critic(
+                    params["critic"], params["policy"], key, convert_normalized_obs(obses), actions
+                )
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td_error = q_values - target
                 return jnp.squeeze(jnp.abs(td_error))
@@ -194,11 +196,11 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         )
 
     def _loss(self, policy_params, critic_params, obses, actions, targets, weights, key):
-        vals = self.critic(critic_params, key, obses, actions)
+        vals = self.critic(critic_params, policy_params, key, obses, actions)
         error = jnp.squeeze(vals - targets)
         critic_loss = jnp.mean(jnp.square(error) * weights)
         policy = self.actor(policy_params, key, obses)
-        vals = self.critic(jax.lax.stop_gradient(critic_params), key, obses, policy)
+        vals = self.critic(jax.lax.stop_gradient(critic_params), policy_params, key, obses, policy)
         actor_loss = jnp.mean(-vals)
         total_loss = critic_loss + actor_loss
         return total_loss, (critic_loss, -actor_loss, jnp.abs(error))
@@ -213,5 +215,5 @@ class APE_X_DDPG(Ape_X_Deteministic_Policy_Gradient_Family):
         key,
     ):
         next_action = self.actor(target_policy_params, key, nxtobses)
-        next_q = self.critic(target_critic_params, key, nxtobses, next_action)
+        next_q = self.critic(target_critic_params, target_policy_params, key, nxtobses, next_action)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -247,7 +247,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             key,
         )
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, obses, actions, targets, weights, key
+            critic_params, policy_params, obses, actions, targets, weights, key
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -300,15 +300,15 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
-        vals = self.critic(critic_params, key, obses, actions)
+    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
+        vals = self.critic(critic_params, policy_params, key, obses, actions)
         error = jnp.squeeze(vals - targets)
         critic_loss = jnp.mean(weights * jnp.square(error))
         return critic_loss, jnp.abs(error)
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
         actions = self.actor(policy_params, key, obses)
-        q = self.critic(critic_params, key, obses, actions)
+        q = self.critic(critic_params, policy_params, key, obses, actions)
         return -jnp.mean(q)
 
     def _target(
@@ -321,5 +321,5 @@ class DDPG(Deteministic_Policy_Gradient_Family):
         key,
     ):
         next_action = self.actor(target_policy_params, key, nxtobses)
-        next_q = self.critic(target_critic_params, key, nxtobses, next_action)
+        next_q = self.critic(target_critic_params, target_policy_params, key, nxtobses, next_action)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/FlashSAC/flashsac.py
+++ b/jax_baselines/FlashSAC/flashsac.py
@@ -279,7 +279,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         next_actions, log_prob = sample_policy(mean, log_std, target_key)
         joint_actions = jnp.concatenate((data["actions"], next_actions))
         (target_logits1, target_logits2), target_updates = self.critic(
-            target, None, joint_obs, joint_actions, True
+            target, policy, None, joint_obs, joint_actions, True
         )
         target_probs1 = jax.nn.softmax(target_logits1[batch_size:])
         target_probs2 = jax.nn.softmax(target_logits2[batch_size:])
@@ -299,7 +299,12 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         )
         target_probs = jax.lax.stop_gradient(target_probs)
         (critic_loss, stats), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic["params"], critic["batch_stats"], joint_obs, joint_actions, target_probs
+            critic["params"],
+            critic["batch_stats"],
+            policy,
+            joint_obs,
+            joint_actions,
+            target_probs,
         )
         updates, critic_opt = self.optimizer.update(grad, critic_opt, critic["params"])
         critic = {
@@ -326,7 +331,12 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         actions, log_prob = sample_policy(mean, log_std, key)
         size = actions.shape[0] // 2
         (logits1, logits2), _ = self.critic(
-            critic, None, jax.tree.map(lambda value: value[:size], joint_obs), actions[:size], False
+            critic,
+            variables,
+            None,
+            jax.tree.map(lambda value: value[:size], joint_obs),
+            actions[:size],
+            False,
         )
         minimum = jnp.minimum(
             jnp.sum(jax.nn.softmax(logits1) * self.value_support, axis=-1),
@@ -337,9 +347,9 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             updates["batch_stats"],
         )
 
-    def _critic_loss(self, params, stats, obses, actions, target_probs):
+    def _critic_loss(self, params, stats, policy, obses, actions, target_probs):
         (logits1, logits2), updates = self.critic(
-            {"params": params, "batch_stats": stats}, None, obses, actions, True
+            {"params": params, "batch_stats": stats}, policy, None, obses, actions, True
         )
         size = target_probs.shape[0]
         loss = -jnp.mean(

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -157,8 +157,12 @@ class SurrogateIMPALA(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,

--- a/jax_baselines/PPO/impala_ppo.py
+++ b/jax_baselines/PPO/impala_ppo.py
@@ -11,7 +11,7 @@ class IMPALA_PPO(SurrogateIMPALA):
     def _loss_discrete(
         self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
         logit = self.actor(actor_params, key, obses)
@@ -43,7 +43,7 @@ class IMPALA_PPO(SurrogateIMPALA):
     ):
         # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
         prob = self.actor(actor_params, key, obses)

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -10,7 +10,7 @@ class PPO(SurrogatePolicyGradient):
     def _loss_discrete(
         self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
@@ -43,7 +43,7 @@ class PPO(SurrogatePolicyGradient):
     def _loss_continuous(
         self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(jnp.squeeze(vals - targets))
         vf2 = jnp.square(jnp.squeeze(vals_clip - targets))

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -261,7 +261,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
         )
 
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, obses, actions, targets, weights, key2
+            critic_params, policy_params, obses, actions, targets, weights, key2
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -341,8 +341,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
-        q1, q2 = self.critic(critic_params, key, obses, actions)
+    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
+        q1, q2 = self.critic(critic_params, policy_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
@@ -352,7 +352,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
         policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
-        q1_pi, q2_pi = self.critic(critic_params, key, obses, policy)
+        q1_pi, q2_pi = self.critic(critic_params, policy_params, key, obses, policy)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
         return actor_loss, log_prob
 
@@ -367,6 +367,6 @@ class SAC(Deteministic_Policy_Gradient_Family):
         ent_coef,
     ):
         policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
-        q1_pi, q2_pi = self.critic(target_critic_params, key, nxtobses, policy)
+        q1_pi, q2_pi = self.critic(target_critic_params, policy_params, key, nxtobses, policy)
         next_q = jnp.minimum(q1_pi, q2_pi) - ent_coef * log_prob
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/SPO/impala_spo.py
+++ b/jax_baselines/SPO/impala_spo.py
@@ -11,7 +11,7 @@ class IMPALA_SPO(SurrogateIMPALA):
     def _loss_discrete(
         self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
         logit = self.actor(actor_params, key, obses)
@@ -44,7 +44,7 @@ class IMPALA_SPO(SurrogateIMPALA):
     ):
         # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
 
         prob = self.actor(actor_params, key, obses)

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -36,7 +36,7 @@ class SPO(SurrogatePolicyGradient):
     def _loss_discrete(
         self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
@@ -70,7 +70,7 @@ class SPO(SurrogatePolicyGradient):
     def _loss_continuous(
         self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)

--- a/jax_baselines/TD3/apex_td3.py
+++ b/jax_baselines/TD3/apex_td3.py
@@ -148,9 +148,11 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
                     -1.0,
                     1.0,
                 )
-                q1, q2 = critic(params["critic"], key, nxtobses, next_action)
+                q1, q2 = critic(params["critic"], params["policy"], key, nxtobses, next_action)
                 next_q = jnp.minimum(q1, q2)
-                q_values1, _ = critic(params["critic"], key, convert_normalized_obs(obses), actions)
+                q_values1, _ = critic(
+                    params["critic"], params["policy"], key, convert_normalized_obs(obses), actions
+                )
                 target = rewards + gamma * (1.0 - terminateds) * next_q
                 td1_error = jnp.abs(q_values1 - target)
                 return jnp.squeeze(td1_error)
@@ -321,14 +323,16 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
         )
 
     def _loss(self, policy_params, critic_params, obses, actions, targets, weights, key, step):
-        q1, q2 = self.critic(critic_params, key, obses, actions)
+        q1, q2 = self.critic(critic_params, policy_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
             weights * jnp.square(error2)
         )
         policy = self.actor(policy_params, key, obses)
-        vals, _ = self.critic(jax.lax.stop_gradient(critic_params), key, obses, policy)
+        vals, _ = self.critic(
+            jax.lax.stop_gradient(critic_params), policy_params, key, obses, policy
+        )
         actor_loss = jnp.mean(-vals)
         total_loss = jax.lax.select(
             step % self.policy_delay == 0, critic_loss + actor_loss, critic_loss
@@ -355,6 +359,6 @@ class APE_X_TD3(Ape_X_Deteministic_Policy_Gradient_Family):
             -1.0,
             1.0,
         )
-        q1, q2 = self.critic(target_critic_params, key, nxtobses, next_action)
+        q1, q2 = self.critic(target_critic_params, target_policy_params, key, nxtobses, next_action)
         next_q = jnp.minimum(q1, q2)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -226,7 +226,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
             key,
         )
         (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, obses, actions, targets, weights, key
+            critic_params, policy_params, obses, actions, targets, weights, key
         )
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
@@ -316,8 +316,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
             new_priorities,
         )
 
-    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
-        q1, q2 = self.critic(critic_params, key, obses, actions)
+    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
+        q1, q2 = self.critic(critic_params, policy_params, key, obses, actions)
         error1 = jnp.squeeze(q1 - targets)
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
@@ -327,7 +327,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
         actions = self.actor(policy_params, key, obses)
-        q1, _ = self.critic(critic_params, key, obses, actions)
+        q1, _ = self.critic(critic_params, policy_params, key, obses, actions)
         return -jnp.mean(q1)
 
     def _target(
@@ -350,6 +350,6 @@ class TD3(Deteministic_Policy_Gradient_Family):
             -1.0,
             1.0,
         )
-        q1, q2 = self.critic(target_critic_params, key, nxtobses, next_action)
+        q1, q2 = self.critic(target_critic_params, target_policy_params, key, nxtobses, next_action)
         next_q = jnp.minimum(q1, q2)
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -410,7 +410,9 @@ class TD7(Deteministic_Policy_Gradient_Family):
             jnp.max(targets), critic_params["values"]["max_value"]
         )
         actor_feature, actor_zs = self.actor_encoder(fixed_actor_encoder_params, key, obses)
-        critic_feature, critic_zs = self.critic_encoder(fixed_critic_encoder_params, key, obses)
+        critic_feature, critic_zs = self.critic_encoder(
+            fixed_critic_encoder_params, fixed_actor_encoder_params, key, obses
+        )
         (critic_loss, priority), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
             critic_params,
             fixed_critic_encoder_params,
@@ -527,16 +529,17 @@ class TD7(Deteministic_Policy_Gradient_Family):
         actions,
         key,
     ):
-        losses = []
-        for encoder, action_encoder, params in (
-            (self.actor_encoder, self.actor_action_encoder, actor_encoder_params),
-            (self.critic_encoder, self.critic_action_encoder, critic_encoder_params),
-        ):
-            _, next_zs = encoder(params, key, next_obses)
-            _, zs = encoder(params, key, obses)
-            pred_zs = action_encoder(params, key, zs, actions)
-            losses.append(jnp.mean(jnp.square(jax.lax.stop_gradient(next_zs) - pred_zs)))
-        return losses[0] + losses[1]
+        _, next_actor_zs = self.actor_encoder(actor_encoder_params, key, next_obses)
+        _, actor_zs = self.actor_encoder(actor_encoder_params, key, obses)
+        pred_actor_zs = self.actor_action_encoder(actor_encoder_params, key, actor_zs, actions)
+        _, next_critic_zs = self.critic_encoder(
+            critic_encoder_params, actor_encoder_params, key, next_obses
+        )
+        _, critic_zs = self.critic_encoder(critic_encoder_params, actor_encoder_params, key, obses)
+        pred_critic_zs = self.critic_action_encoder(critic_encoder_params, key, critic_zs, actions)
+        return jnp.mean(
+            jnp.square(jax.lax.stop_gradient(next_actor_zs) - pred_actor_zs)
+        ) + jnp.mean(jnp.square(jax.lax.stop_gradient(next_critic_zs) - pred_critic_zs))
 
     def _actor_loss(
         self,
@@ -587,7 +590,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
             fixed_actor_encoder_target_params, key, nxtobses
         )
         critic_feature, critic_zs = self.critic_encoder(
-            fixed_critic_encoder_target_params, key, nxtobses
+            fixed_critic_encoder_target_params, fixed_actor_encoder_target_params, key, nxtobses
         )
         next_action = jnp.clip(
             self.actor(target_policy_params, key, actor_feature, actor_zs)

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -160,8 +160,12 @@ class IMPALA_TPPO(IMPALA_Family):
         truncateds = jnp.stack(truncateds)
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         prob, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
@@ -335,7 +339,7 @@ class IMPALA_TPPO(IMPALA_Family):
         adv,
         key,
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
 
         prob, log_prob = self.get_logprob(
@@ -379,7 +383,7 @@ class IMPALA_TPPO(IMPALA_Family):
         adv,
         key,
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
 
         prob, log_prob = self.get_logprob(

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -111,8 +111,12 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
-        value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, obses)
-        next_value = jax.vmap(self.critic, in_axes=(None, None, 0))(critic_params, key, nxtobses)
+        value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, obses
+        )
+        next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
+            critic_params, actor_params, key, nxtobses
+        )
         prob, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
@@ -308,7 +312,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         adv,
         key,
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)
@@ -358,7 +362,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         adv,
         key,
     ):
-        vals = self.critic(critic_params, key, obses)
+        vals = self.critic(critic_params, actor_params, key, obses)
         vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
         vf1 = jnp.square(vals - targets)
         vf2 = jnp.square(vals_clip - targets)

--- a/jax_baselines/TQC/tqc.py
+++ b/jax_baselines/TQC/tqc.py
@@ -73,8 +73,8 @@ class TQC(SAC):
         self._train_ent_coef = jax.jit(self._train_ent_coef)
         self._bulk_scan = jax.jit(self._bulk_scan)
 
-    def _critic_loss(self, critic_params, obses, actions, targets, weights, key):
-        qnets = self.critic(critic_params, key, obses, actions)
+    def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
+        qnets = self.critic(critic_params, policy_params, key, obses, actions)
         logit_valid_tile = jnp.expand_dims(targets, axis=2)  # batch x support x 1
         huber0 = QuantileHuberLosses(
             logit_valid_tile,
@@ -97,7 +97,7 @@ class TQC(SAC):
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
         policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
-        qnets_pi = self.critic(critic_params, key, obses, policy)
+        qnets_pi = self.critic(critic_params, policy_params, key, obses, policy)
         actor_loss = jnp.mean(
             ent_coef * log_prob - jnp.mean(jnp.concatenate(qnets_pi, axis=1), axis=1)
         )
@@ -114,7 +114,7 @@ class TQC(SAC):
         ent_coef,
     ):
         policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
-        qnets_pi = self.critic(target_critic_params, key, nxtobses, policy)
+        qnets_pi = self.critic(target_critic_params, policy_params, key, nxtobses, policy)
         if self.mixture_type == "min":
             next_q = jnp.min(jnp.stack(qnets_pi, axis=-1), axis=-1) - ent_coef * log_prob
         else:

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -290,6 +290,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
             self._critic_loss, has_aux=True
         )(
             critic_params,
+            policy_params,
             obses,
             actions,
             nxtobses,
@@ -396,6 +397,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
     def _critic_loss(
         self,
         critic_params,
+        policy_params,
         obses,
         actions,
         nxtobses,
@@ -409,7 +411,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
         }
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), variable_updates = self.critic(
-            critic_params, key, concated_obses, concated_actions, True
+            critic_params, policy_params, key, concated_obses, concated_actions, True
         )
         critic_params = {**critic_params, **variable_updates}
         logits1 = jnp.split(logits1, 2, axis=0)[0]
@@ -430,7 +432,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
         policy, log_prob, policy_params = self._get_pi_log_prob(policy_params, obses, key)
-        (logits1, logits2), _ = self.critic(critic_params, key, obses, policy, False)
+        (logits1, logits2), _ = self.critic(critic_params, policy_params, key, obses, policy, False)
         q1_pi = self._categorical_q(logits1)
         q2_pi = self._categorical_q(logits2)
         actor_loss = jnp.mean(ent_coef * jnp.squeeze(log_prob, axis=-1) - jnp.minimum(q1_pi, q2_pi))
@@ -454,7 +456,12 @@ class XQC(Deteministic_Policy_Gradient_Family):
         next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key, False)
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), _ = self.critic(
-            target_critic_params, key, concated_obses, concated_actions, True
+            target_critic_params,
+            policy_params,
+            key,
+            concated_obses,
+            concated_actions,
+            True,
         )
         next_logits1 = jnp.split(logits1, 2, axis=0)[1]
         next_logits2 = jnp.split(logits2, 2, axis=0)[1]

--- a/model_builder/flax/Module.py
+++ b/model_builder/flax/Module.py
@@ -141,23 +141,26 @@ class PreProcess(nn.Module):
                 else lambda x: x
             )
             for key, st in self.states_size.items()
-            if key in self.observation_keys
+            if key in self.observation_keys and (self.role == "actor" or key.startswith("critic_"))
         }
 
     @nn.compact
-    def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
+    def __call__(self, obses: dict[str, jnp.ndarray], shared_features=None) -> jnp.ndarray:
+        features = {key: embed(obses[key]) for key, embed in self.embedding.items()}
+        if self.role == "critic":
+            if shared_features is None:
+                raise ValueError("Critic preprocessing requires Actor-owned unified features")
+            features.update(shared_features)
         return self.pre_postprocess(
-            jnp.concatenate(
-                [self.embedding[key](obses[key]) for key in self.observation_keys], axis=1
-            )
+            jnp.concatenate([features[key] for key in self.observation_keys], axis=1)
         )
 
-    @property
-    def output_size(self):
-        return sum(
-            pre(jnp.zeros((1, *self.states_size[key]))).shape[1]
-            for key, pre in self.embedding.items()
-        )
+    def shared_features(self, obses: dict[str, jnp.ndarray]):
+        return {
+            key: embed(obses[key])
+            for key, embed in self.embedding.items()
+            if key.startswith("unified_")
+        }
 
 
 PRNGKey = Any

--- a/model_builder/flax/ac/ac_builder.py
+++ b/model_builder/flax/ac/ac_builder.py
@@ -8,6 +8,7 @@ from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -61,29 +62,44 @@ def model_builder_maker(observation_space, action_size, action_type, policy_kwar
 
     def _model_builder(key=None, print_model=False):
         class ActorModel(nn.Module):
-            @nn.compact
-            def __call__(self, x):
-                return Actor(action_size, action_type, **actor_kwargs)(
-                    PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(x)
+            def setup(self):
+                self.preproc = PreProcess(
+                    observation_space,
+                    embedding_mode=embedding_mode,
+                    role="actor",
+                    name="PreProcess_0",
                 )
+                self.act = Actor(action_size, action_type, **actor_kwargs, name="Actor_0")
+
+            def __call__(self, x):
+                return self.act(self.preproc(x))
+
+            def shared_features(self, x):
+                return self.preproc.shared_features(x)
 
         class CriticModel(nn.Module):
             @nn.compact
-            def __call__(self, x):
+            def __call__(self, x, shared_features):
                 return Critic(**critic_kwargs)(
-                    PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(x)
+                    PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                        x, shared_features
+                    )
                 )
 
         actor = ActorModel()
         critic = CriticModel()
         actor_fn = get_apply_fn_flax_module(actor)
-        critic_fn = get_apply_fn_flax_module(critic)
+        shared_fn = get_apply_fn_flax_module(actor, method=actor.shared_features)
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic), shared_fn)
         if key is not None:
             actor_key, critic_key = jax.random.split(key)
             observation = dummy_observation(observation_space)
             actor_params = actor.init(actor_key, observation)
-            critic_params = critic.init(critic_key, observation)
-            print_flax_model_summary(print_model, key, (actor, observation), (critic, observation))
+            shared_features = shared_fn(actor_params, None, observation)
+            critic_params = critic.init(critic_key, observation, shared_features)
+            print_flax_model_summary(
+                print_model, key, (actor, observation), (critic, observation, shared_features)
+            )
             return actor_fn, critic_fn, actor_params, critic_params
         return actor_fn, critic_fn
 

--- a/model_builder/flax/dpg/crossq_builder.py
+++ b/model_builder/flax/dpg/crossq_builder.py
@@ -9,6 +9,7 @@ from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -70,6 +71,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -78,26 +82,33 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action, training: bool = True):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action, training: bool = True):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(
+            get_apply_fn_flax_module(critic_model, mutable=["batch_stats"]),
+            shared_preproc_fn,
+        )
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action, True)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action, True)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action, True),
+            (critic_model, observation, shared_features, action, True),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/ddpg_builder.py
+++ b/model_builder/flax/dpg/ddpg_builder.py
@@ -7,6 +7,7 @@ from model_builder.flax.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -35,6 +36,9 @@ def _make_model_builder(
             def __call__(self, x):
                 return self.act(self.preproc(x))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -44,8 +48,8 @@ def _make_model_builder(
                 if twin_critic:
                     self.crit2 = critic_cls(**critic_kwargs)
 
-            def __call__(self, x, a):
-                feature = self.preproc(x)
+            def __call__(self, x, shared_features, a):
+                feature = self.preproc(x, shared_features)
                 if twin_critic:
                     return self.crit1(feature, a), self.crit2(feature, a)
                 return self.crit1(feature, a)
@@ -53,18 +57,22 @@ def _make_model_builder(
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is not None:
             observation = dummy_observation(observation_space)
             action = np.zeros((1, *action_size), dtype=np.float32)
             actor_key, critic_key = jax.random.split(key)
             policy_params = actor_model.init(actor_key, observation)
-            critic_params = critic_model.init(critic_key, observation, action)
+            shared_features = shared_preproc_fn(policy_params, None, observation)
+            critic_params = critic_model.init(critic_key, observation, shared_features, action)
             print_flax_model_summary(
                 print_model,
                 key,
                 (actor_model, observation),
-                (critic_model, observation, action),
+                (critic_model, observation, shared_features, action),
             )
             return actor_fn, critic_fn, policy_params, critic_params
         return actor_fn, critic_fn

--- a/model_builder/flax/dpg/flashsac_builder.py
+++ b/model_builder/flax/dpg/flashsac_builder.py
@@ -9,6 +9,7 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -143,14 +144,17 @@ def model_builder_maker(
             def __call__(self, observation, training: bool = False):
                 return self.act(self.preproc(observation), training)
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(observation_space, role="critic")
                 self.crit1 = Critic(hidden_n=hidden_n, n_atoms=n_atoms, **critic_kwargs)
                 self.crit2 = Critic(hidden_n=hidden_n, n_atoms=n_atoms, **critic_kwargs)
 
-            def __call__(self, observation, actions, training: bool = False):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, actions, training: bool = False):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, actions, training), self.crit2(
                     feature, actions, training
                 )
@@ -158,7 +162,13 @@ def model_builder_maker(
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model, mutable=["batch_stats"])
-        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(
+            get_apply_fn_flax_module(critic_model, mutable=["batch_stats"]),
+            shared_preproc_fn,
+        )
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
@@ -166,13 +176,16 @@ def model_builder_maker(
         actor_key, critic_key = jax.random.split(key)
         policy_variables = actor_model.init(actor_key, observation, False)
         policy_variables["params"] = project_unit_norm_params(policy_variables["params"])
-        critic_variables = critic_model.init(critic_key, observation, action, False)
+        shared_features = shared_preproc_fn(policy_variables, None, observation)
+        critic_variables = critic_model.init(
+            critic_key, observation, shared_features, action, False
+        )
         critic_variables["params"] = project_unit_norm_params(critic_variables["params"])
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation, False),
-            (critic_model, observation, action, False),
+            (critic_model, observation, shared_features, action, False),
         )
         return actor_fn, critic_fn, policy_variables, critic_variables
 

--- a/model_builder/flax/dpg/sac_builder.py
+++ b/model_builder/flax/dpg/sac_builder.py
@@ -7,6 +7,7 @@ from model_builder.flax.dpg.gaussian_blocks import Actor, Critic
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -27,6 +28,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -35,26 +39,30 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simba_crossq_builder.py
+++ b/model_builder/flax/dpg/simba_crossq_builder.py
@@ -9,6 +9,7 @@ from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense
 from model_builder.flax.Module import BatchReNorm, PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -71,6 +72,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -79,26 +83,33 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action, training: bool = True):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action, training: bool = True):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(
+            get_apply_fn_flax_module(critic_model, mutable=["batch_stats"]),
+            shared_preproc_fn,
+        )
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action, True)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action, True)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action, True),
+            (critic_model, observation, shared_features, action, True),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simba_sac_builder.py
+++ b/model_builder/flax/dpg/simba_sac_builder.py
@@ -9,6 +9,7 @@ from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, Residu
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -70,6 +71,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -78,26 +82,30 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simba_td7_builder.py
+++ b/model_builder/flax/dpg/simba_td7_builder.py
@@ -11,6 +11,7 @@ from model_builder.flax.layers import Dense, ResidualBlock, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -111,13 +112,16 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
                 self.act_enc = Action_Encoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, obs, actions):
-                feature, zs = self.encode_state(obs)
+            def __call__(self, obs, actions, shared_features=None):
+                feature, zs = self.encode_state(obs, shared_features)
                 return feature, zs, self.encode_action(zs, actions)
 
-            def encode_state(self, obs):
-                feature = self.preproc(obs)
+            def encode_state(self, obs, shared_features=None):
+                feature = self.preproc(obs, shared_features)
                 return feature, self.enc(feature)
+
+            def shared_features(self, obs):
+                return self.preproc.shared_features(obs)
 
             def encode_action(self, zs, actions):
                 return self.act_enc(zs, actions)
@@ -134,9 +138,15 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         critic_encoder_model = RoleEncoder("critic", critic_kwargs["node"], 3)
         policy_model = Actor(action_size=action_size, **actor_kwargs)
         critic_model = TwinCritic()
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_encoder_model, method=actor_encoder_model.shared_features
+        )
         functions = (
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
-            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_critic_apply_fn(
+                get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+                shared_preproc_fn,
+            ),
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
             get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
             get_apply_fn_flax_module(policy_model),
@@ -148,9 +158,14 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
-        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        shared_features = shared_preproc_fn(actor_encoder_params, None, observation)
+        critic_encoder_params = critic_encoder_model.init(
+            critic_encoder_key, observation, action, shared_features
+        )
         actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
-        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](
+            critic_encoder_params, actor_encoder_params, None, observation
+        )
         critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
         policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
         critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
@@ -158,7 +173,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             print_model,
             key,
             (actor_encoder_model, observation, action),
-            (critic_encoder_model, observation, action),
+            (critic_encoder_model, observation, action, shared_features),
             (policy_model, actor_feature, actor_zs),
             (critic_model, critic_feature, critic_zs, critic_zsa, action),
         )

--- a/model_builder/flax/dpg/simba_tqc_builder.py
+++ b/model_builder/flax/dpg/simba_tqc_builder.py
@@ -9,6 +9,7 @@ from model_builder.flax.layers import LOG_STD_MEAN, LOG_STD_SCALE, Dense, Residu
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -77,6 +78,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -85,26 +89,30 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 self.crit1 = Critic(support_n=support_n, **critic_kwargs)
                 self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simbav2_crossq_builder.py
+++ b/model_builder/flax/dpg/simbav2_crossq_builder.py
@@ -15,6 +15,7 @@ from model_builder.flax.layers import (
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -78,6 +79,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -86,26 +90,33 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action, training: bool = True):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action, training: bool = True):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(
+            get_apply_fn_flax_module(critic_model, mutable=["batch_stats"]),
+            shared_preproc_fn,
+        )
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action, True)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action, True)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action, True),
+            (critic_model, observation, shared_features, action, True),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simbav2_sac_builder.py
+++ b/model_builder/flax/dpg/simbav2_sac_builder.py
@@ -14,6 +14,7 @@ from model_builder.flax.layers import (
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -70,6 +71,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -78,26 +82,30 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/simbav2_td7_builder.py
+++ b/model_builder/flax/dpg/simbav2_td7_builder.py
@@ -10,6 +10,7 @@ from model_builder.flax.layers import SimbaV2Block, SimbaV2Embedding, SimbaV2Hea
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -99,13 +100,16 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
                 self.act_enc = ActionEncoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, obs, actions):
-                feature, zs = self.encode_state(obs)
+            def __call__(self, obs, actions, shared_features=None):
+                feature, zs = self.encode_state(obs, shared_features)
                 return feature, zs, self.encode_action(zs, actions)
 
-            def encode_state(self, obs):
-                feature = self.preproc(obs)
+            def encode_state(self, obs, shared_features=None):
+                feature = self.preproc(obs, shared_features)
                 return feature, self.enc(feature)
+
+            def shared_features(self, obs):
+                return self.preproc.shared_features(obs)
 
             def encode_action(self, zs, actions):
                 return self.act_enc(zs, actions)
@@ -130,9 +134,15 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         )
         policy_model = Actor(action_size=action_size, **actor_kwargs)
         critic_model = TwinCritic()
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_encoder_model, method=actor_encoder_model.shared_features
+        )
         functions = (
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
-            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_critic_apply_fn(
+                get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+                shared_preproc_fn,
+            ),
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
             get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
             get_apply_fn_flax_module(policy_model),
@@ -144,9 +154,14 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
-        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        shared_features = shared_preproc_fn(actor_encoder_params, None, observation)
+        critic_encoder_params = critic_encoder_model.init(
+            critic_encoder_key, observation, action, shared_features
+        )
         actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
-        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](
+            critic_encoder_params, actor_encoder_params, None, observation
+        )
         critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
         policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
         critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
@@ -154,7 +169,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             print_model,
             key,
             (actor_encoder_model, observation, action),
-            (critic_encoder_model, observation, action),
+            (critic_encoder_model, observation, action, shared_features),
             (policy_model, actor_feature, actor_zs),
             (critic_model, critic_feature, critic_zs, critic_zsa, action),
         )

--- a/model_builder/flax/dpg/simbav2_tqc_builder.py
+++ b/model_builder/flax/dpg/simbav2_tqc_builder.py
@@ -14,6 +14,7 @@ from model_builder.flax.layers import (
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -74,6 +75,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -82,26 +86,30 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 self.crit1 = Critic(support_n=support_n, **critic_kwargs)
                 self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/td7_builder.py
+++ b/model_builder/flax/dpg/td7_builder.py
@@ -11,6 +11,7 @@ from model_builder.flax.layers import Dense, avgl1norm
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -110,13 +111,16 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.enc = Encoder(node=self.node, hidden_n=self.hidden_n)
                 self.act_enc = Action_Encoder(node=self.node, hidden_n=self.hidden_n)
 
-            def __call__(self, obs, actions):
-                feature, zs = self.encode_state(obs)
+            def __call__(self, obs, actions, shared_features=None):
+                feature, zs = self.encode_state(obs, shared_features)
                 return feature, zs, self.encode_action(zs, actions)
 
-            def encode_state(self, obs):
-                feature = self.preproc(obs)
+            def encode_state(self, obs, shared_features=None):
+                feature = self.preproc(obs, shared_features)
                 return feature, self.enc(feature)
+
+            def shared_features(self, obs):
+                return self.preproc.shared_features(obs)
 
             def encode_action(self, zs, actions):
                 return self.act_enc(zs, actions)
@@ -133,9 +137,15 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         critic_encoder_model = RoleEncoder("critic", critic_kwargs["node"], 3)
         policy_model = Actor(action_size=action_size, **actor_kwargs)
         critic_model = TwinCritic()
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_encoder_model, method=actor_encoder_model.shared_features
+        )
         functions = (
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_state),
-            get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+            get_critic_apply_fn(
+                get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_state),
+                shared_preproc_fn,
+            ),
             get_apply_fn_flax_module(actor_encoder_model, actor_encoder_model.encode_action),
             get_apply_fn_flax_module(critic_encoder_model, critic_encoder_model.encode_action),
             get_apply_fn_flax_module(policy_model),
@@ -147,9 +157,14 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_encoder_params = actor_encoder_model.init(actor_encoder_key, observation, action)
-        critic_encoder_params = critic_encoder_model.init(critic_encoder_key, observation, action)
+        shared_features = shared_preproc_fn(actor_encoder_params, None, observation)
+        critic_encoder_params = critic_encoder_model.init(
+            critic_encoder_key, observation, action, shared_features
+        )
         actor_feature, actor_zs = functions[0](actor_encoder_params, None, observation)
-        critic_feature, critic_zs = functions[1](critic_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](
+            critic_encoder_params, actor_encoder_params, None, observation
+        )
         critic_zsa = functions[3](critic_encoder_params, None, critic_zs, action)
         policy_params = policy_model.init(actor_key, actor_feature, actor_zs)
         critic_params = critic_model.init(critic_key, critic_feature, critic_zs, critic_zsa, action)
@@ -157,7 +172,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             print_model,
             key,
             (actor_encoder_model, observation, action),
-            (critic_encoder_model, observation, action),
+            (critic_encoder_model, observation, action, shared_features),
             (policy_model, actor_feature, actor_zs),
             (critic_model, critic_feature, critic_zs, critic_zsa, action),
         )

--- a/model_builder/flax/dpg/tqc_builder.py
+++ b/model_builder/flax/dpg/tqc_builder.py
@@ -10,6 +10,7 @@ from model_builder.flax.layers import Dense
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -51,6 +52,9 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
             def __call__(self, observation):
                 return self.act(self.preproc(observation))
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -59,26 +63,30 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
                 self.crit1 = Critic(support_n=support_n, **critic_kwargs)
                 self.crit2 = Critic(support_n=support_n, **critic_kwargs)
 
-            def __call__(self, observation, action):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action), self.crit2(feature, action)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model)
-        critic_fn = get_apply_fn_flax_module(critic_model)
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(get_apply_fn_flax_module(critic_model), shared_preproc_fn)
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation)
-        critic_params = critic_model.init(critic_key, observation, action)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation),
-            (critic_model, observation, action),
+            (critic_model, observation, shared_features, action),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/flax/dpg/xqc_builder.py
+++ b/model_builder/flax/dpg/xqc_builder.py
@@ -7,6 +7,7 @@ from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_flax_model_summary,
     split_actor_critic_kwargs,
 )
@@ -88,6 +89,9 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             def __call__(self, observation, training: bool = True):
                 return self.act(self.preproc(observation), training)
 
+            def shared_features(self, observation):
+                return self.preproc.shared_features(observation)
+
         class Merged_Critic(nn.Module):
             def setup(self):
                 self.preproc = PreProcess(
@@ -96,26 +100,33 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 self.crit1 = Critic(**critic_kwargs)
                 self.crit2 = Critic(**critic_kwargs)
 
-            def __call__(self, observation, action, training: bool = True):
-                feature = self.preproc(observation)
+            def __call__(self, observation, shared_features, action, training: bool = True):
+                feature = self.preproc(observation, shared_features)
                 return self.crit1(feature, action, training), self.crit2(feature, action, training)
 
         actor_model = Merged_Actor()
         critic_model = Merged_Critic()
         actor_fn = get_apply_fn_flax_module(actor_model, mutable=["batch_stats"])
-        critic_fn = get_apply_fn_flax_module(critic_model, mutable=["batch_stats"])
+        shared_preproc_fn = get_apply_fn_flax_module(
+            actor_model, method=actor_model.shared_features
+        )
+        critic_fn = get_critic_apply_fn(
+            get_apply_fn_flax_module(critic_model, mutable=["batch_stats"]),
+            shared_preproc_fn,
+        )
         if key is None:
             return actor_fn, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor_model.init(actor_key, observation, True)
-        critic_params = critic_model.init(critic_key, observation, action, True)
+        shared_features = shared_preproc_fn(policy_params, None, observation)
+        critic_params = critic_model.init(critic_key, observation, shared_features, action, True)
         print_flax_model_summary(
             print_model,
             key,
             (actor_model, observation, True),
-            (critic_model, observation, action, True),
+            (critic_model, observation, shared_features, action, True),
         )
         return actor_fn, critic_fn, policy_params, critic_params
 

--- a/model_builder/haiku/Module.py
+++ b/model_builder/haiku/Module.py
@@ -16,10 +16,10 @@ def pop_embedding_mode(policy_kwargs: dict | None, default: str = "normal") -> t
     return policy_kwargs, embedding_mode
 
 
-def visual_embedding(mode="normal"):
+def _visual_embedding_constructor(mode="normal"):
     if mode == "normal":
 
-        def net_fn(x):
+        def net_fn():
             return hk.Sequential(
                 [
                     hk.Conv2D(
@@ -48,24 +48,41 @@ def visual_embedding(mode="normal"):
                     jax.nn.relu,
                     hk.Flatten(),
                 ]
-            )(x)
+            )
 
     else:
         raise ValueError(f"Unknown visual_embedding mode: {mode!r}")
     return net_fn
 
 
+def visual_embedding(mode="normal"):
+    constructor = _visual_embedding_constructor(mode)
+    return lambda x: constructor()(x)
+
+
 class PreProcess(hk.Module):
+    @hk.name_like("__call__")
     def __init__(self, state_size, embedding_mode="normal", *, role="actor"):
         super().__init__()
+        self.role = role
         self.observation_keys = observation_role_keys(state_size, role)
         self.embedding = {
-            key: visual_embedding(embedding_mode) if len(st) == 3 else lambda x: x
+            key: (_visual_embedding_constructor(embedding_mode)() if len(st) == 3 else lambda x: x)
             for key, st in state_size.items()
-            if key in self.observation_keys
+            if key in self.observation_keys and (role == "actor" or key.startswith("critic_"))
         }
 
-    def __call__(self, obses: dict[str, jnp.ndarray]) -> jnp.ndarray:
-        return jnp.concatenate(
-            [self.embedding[key](obses[key]) for key in self.observation_keys], axis=1
-        )
+    def __call__(self, obses: dict[str, jnp.ndarray], shared_features=None) -> jnp.ndarray:
+        features = {key: embed(obses[key]) for key, embed in self.embedding.items()}
+        if self.role == "critic":
+            if shared_features is None:
+                raise ValueError("Critic preprocessing requires Actor-owned unified features")
+            features.update(shared_features)
+        return jnp.concatenate([features[key] for key in self.observation_keys], axis=1)
+
+    def shared_features(self, obses: dict[str, jnp.ndarray]):
+        return {
+            key: embed(obses[key])
+            for key, embed in self.embedding.items()
+            if key.startswith("unified_")
+        }

--- a/model_builder/haiku/ac/ac_builder.py
+++ b/model_builder/haiku/ac/ac_builder.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -62,22 +63,30 @@ def model_builder_maker(observation_space, action_size, action_type, policy_kwar
                 PreProcess(observation_space, embedding_mode=embedding_mode, role="actor")(x)
             )
         )
+        shared = hk.transform(
+            lambda x: PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(x)
+        )
         critic = hk.transform(
-            lambda x: Critic(**critic_kwargs)(
-                PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(x)
+            lambda x, shared_features: Critic(**critic_kwargs)(
+                PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
+                    x, shared_features
+                )
             )
         )
         actor_fn = actor.apply
-        critic_fn = critic.apply
+        critic_fn = get_critic_apply_fn(critic.apply, shared.apply)
         if key is not None:
             actor_key, critic_key = jax.random.split(key)
             observation = dummy_observation(observation_space)
             actor_params = actor.init(actor_key, observation)
-            critic_params = critic.init(critic_key, observation)
+            shared_features = shared.apply(actor_params, None, observation)
+            critic_params = critic.init(critic_key, observation, shared_features)
             print_haiku_model_summary(
                 print_model,
                 (actor, observation),
-                (critic, observation),
+                (critic, observation, shared_features),
             )
             return actor_fn, critic_fn, actor_params, critic_params
         return actor_fn, critic_fn

--- a/model_builder/haiku/dpg/ddpg_builder.py
+++ b/model_builder/haiku/dpg/ddpg_builder.py
@@ -6,6 +6,7 @@ from model_builder.haiku.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -22,26 +23,34 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             )
             return Actor(action_size, **actor_kwargs)(feature)
 
-        def critic_forward(observation, action):
+        def shared_forward(observation):
+            return PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(observation)
+
+        def critic_forward(observation, shared_features, action):
             feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
-                observation
+                observation, shared_features
             )
             return Critic(**critic_kwargs)(feature, action)
 
         actor = hk.transform(actor_forward)
         critic = hk.transform(critic_forward)
+        shared_preproc = hk.transform(shared_forward)
+        critic_fn = get_critic_apply_fn(critic.apply, shared_preproc.apply)
         if key is None:
-            return actor.apply, critic.apply
+            return actor.apply, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor.init(actor_key, observation)
-        critic_params = critic.init(critic_key, observation, action)
+        shared_features = shared_preproc.apply(policy_params, None, observation)
+        critic_params = critic.init(critic_key, observation, shared_features, action)
         print_haiku_model_summary(
             print_model,
             (actor, observation),
-            (critic, observation, action),
+            (critic, observation, shared_features, action),
         )
-        return actor.apply, critic.apply, policy_params, critic_params
+        return actor.apply, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/haiku/dpg/sac_builder.py
+++ b/model_builder/haiku/dpg/sac_builder.py
@@ -6,6 +6,7 @@ from model_builder.haiku.dpg.ddpg_td3_blocks import Critic, GaussianActor
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -22,9 +23,14 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             )
             return GaussianActor(action_size, **actor_kwargs)(feature)
 
-        def critic_forward(observation, action):
+        def shared_forward(observation):
+            return PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(observation)
+
+        def critic_forward(observation, shared_features, action):
             feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
-                observation
+                observation, shared_features
             )
             return (
                 Critic(**critic_kwargs)(feature, action),
@@ -33,18 +39,21 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
         actor = hk.transform(actor_forward)
         critic = hk.transform(critic_forward)
+        shared_preproc = hk.transform(shared_forward)
+        critic_fn = get_critic_apply_fn(critic.apply, shared_preproc.apply)
         if key is None:
-            return actor.apply, critic.apply
+            return actor.apply, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor.init(actor_key, observation)
-        critic_params = critic.init(critic_key, observation, action)
+        shared_features = shared_preproc.apply(policy_params, None, observation)
+        critic_params = critic.init(critic_key, observation, shared_features, action)
         print_haiku_model_summary(
             print_model,
             (actor, observation),
-            (critic, observation, action),
+            (critic, observation, shared_features, action),
         )
-        return actor.apply, critic.apply, policy_params, critic_params
+        return actor.apply, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/haiku/dpg/td3_builder.py
+++ b/model_builder/haiku/dpg/td3_builder.py
@@ -6,6 +6,7 @@ from model_builder.haiku.dpg.ddpg_td3_blocks import Actor, Critic
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -22,9 +23,14 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
             )
             return Actor(action_size, **actor_kwargs)(feature)
 
-        def critic_forward(observation, action):
+        def shared_forward(observation):
+            return PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(observation)
+
+        def critic_forward(observation, shared_features, action):
             feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
-                observation
+                observation, shared_features
             )
             return (
                 Critic(**critic_kwargs)(feature, action),
@@ -33,18 +39,21 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
 
         actor = hk.transform(actor_forward)
         critic = hk.transform(critic_forward)
+        shared_preproc = hk.transform(shared_forward)
+        critic_fn = get_critic_apply_fn(critic.apply, shared_preproc.apply)
         if key is None:
-            return actor.apply, critic.apply
+            return actor.apply, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor.init(actor_key, observation)
-        critic_params = critic.init(critic_key, observation, action)
+        shared_features = shared_preproc.apply(policy_params, None, observation)
+        critic_params = critic.init(critic_key, observation, shared_features, action)
         print_haiku_model_summary(
             print_model,
             (actor, observation),
-            (critic, observation, action),
+            (critic, observation, shared_features, action),
         )
-        return actor.apply, critic.apply, policy_params, critic_params
+        return actor.apply, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/haiku/dpg/td7_builder.py
+++ b/model_builder/haiku/dpg/td7_builder.py
@@ -6,6 +6,7 @@ import numpy as np
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -101,13 +102,22 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
     actor_kwargs, critic_kwargs = split_actor_critic_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
-        def encode_state(obs, role, node):
-            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role=role)(obs)
+        def encode_state(obs, role, node, shared_features=None):
+            feature = PreProcess(observation_space, embedding_mode=embedding_mode, role=role)(
+                obs, shared_features
+            )
             return feature, Encoder(node=node)(feature)
 
         actor_encoder = hk.transform(lambda obs: encode_state(obs, "actor", actor_kwargs["node"]))
         critic_encoder = hk.transform(
-            lambda obs: encode_state(obs, "critic", critic_kwargs["node"])
+            lambda obs, shared_features: encode_state(
+                obs, "critic", critic_kwargs["node"], shared_features
+            )
+        )
+        shared_preproc = hk.transform(
+            lambda obs: PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(obs)
         )
         actor_action_encoder = hk.transform(
             lambda zs, actions: Action_Encoder(node=actor_kwargs["node"])(zs, actions)
@@ -124,7 +134,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         )
         functions = (
             actor_encoder.apply,
-            critic_encoder.apply,
+            get_critic_apply_fn(critic_encoder.apply, shared_preproc.apply),
             actor_action_encoder.apply,
             critic_action_encoder.apply,
             actor.apply,
@@ -136,9 +146,12 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_encoder_params = actor_encoder.init(keys[0], observation)
-        critic_encoder_params = critic_encoder.init(keys[1], observation)
+        shared_features = shared_preproc.apply(actor_encoder_params, None, observation)
+        critic_encoder_params = critic_encoder.init(keys[1], observation, shared_features)
         actor_feature, actor_zs = actor_encoder.apply(actor_encoder_params, None, observation)
-        critic_feature, critic_zs = critic_encoder.apply(critic_encoder_params, None, observation)
+        critic_feature, critic_zs = functions[1](
+            critic_encoder_params, actor_encoder_params, None, observation
+        )
         actor_encoder_params = hk.data_structures.merge(
             actor_encoder_params, actor_action_encoder.init(keys[2], actor_zs, action)
         )
@@ -152,7 +165,7 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         print_haiku_model_summary(
             print_model,
             (actor_encoder, observation),
-            (critic_encoder, observation),
+            (critic_encoder, observation, shared_features),
             (actor_action_encoder, actor_zs, action),
             (critic_action_encoder, critic_zs, action),
             (actor, actor_feature, actor_zs),

--- a/model_builder/haiku/dpg/tqc_builder.py
+++ b/model_builder/haiku/dpg/tqc_builder.py
@@ -7,6 +7,7 @@ from model_builder.haiku.dpg.ddpg_td3_blocks import GaussianActor
 from model_builder.haiku.Module import PreProcess, pop_embedding_mode
 from model_builder.utils import (
     dummy_observation,
+    get_critic_apply_fn,
     print_haiku_model_summary,
     split_actor_critic_kwargs,
 )
@@ -39,9 +40,14 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
             )
             return GaussianActor(action_size, **actor_kwargs)(feature)
 
-        def critic_forward(observation, action):
+        def shared_forward(observation):
+            return PreProcess(
+                observation_space, embedding_mode=embedding_mode, role="actor"
+            ).shared_features(observation)
+
+        def critic_forward(observation, shared_features, action):
             feature = PreProcess(observation_space, embedding_mode=embedding_mode, role="critic")(
-                observation
+                observation, shared_features
             )
             return (
                 Critic(support_n=support_n, **critic_kwargs)(feature, action),
@@ -50,18 +56,21 @@ def model_builder_maker(observation_space, action_size, support_n, policy_kwargs
 
         actor = hk.transform(actor_forward)
         critic = hk.transform(critic_forward)
+        shared_preproc = hk.transform(shared_forward)
+        critic_fn = get_critic_apply_fn(critic.apply, shared_preproc.apply)
         if key is None:
-            return actor.apply, critic.apply
+            return actor.apply, critic_fn
         observation = dummy_observation(observation_space)
         action = np.zeros((1, *action_size), dtype=np.float32)
         actor_key, critic_key = jax.random.split(key)
         policy_params = actor.init(actor_key, observation)
-        critic_params = critic.init(critic_key, observation, action)
+        shared_features = shared_preproc.apply(policy_params, None, observation)
+        critic_params = critic.init(critic_key, observation, shared_features, action)
         print_haiku_model_summary(
             print_model,
             (actor, observation),
-            (critic, observation, action),
+            (critic, observation, shared_features, action),
         )
-        return actor.apply, critic.apply, policy_params, critic_params
+        return actor.apply, critic_fn, policy_params, critic_params
 
     return model_builder

--- a/model_builder/utils.py
+++ b/model_builder/utils.py
@@ -1,11 +1,22 @@
 from collections.abc import Mapping, Sequence
 from typing import Literal
 
+import jax
 import numpy as np
 
 
 def dummy_observation(space):
     return {key: np.zeros((1, *shape), dtype=np.float32) for key, shape in space.items()}
+
+
+def get_critic_apply_fn(critic_apply, shared_preproc_apply):
+    def apply_fn(critic_params, actor_params, key, observations, *args):
+        shared_features = jax.lax.stop_gradient(
+            shared_preproc_apply(actor_params, key, observations)
+        )
+        return critic_apply(critic_params, key, observations, shared_features, *args)
+
+    return apply_fn
 
 
 def print_flax_model_summary(enabled, key, *models):

--- a/tests/test_dict_observation_contract.py
+++ b/tests/test_dict_observation_contract.py
@@ -110,7 +110,7 @@ def test_crossq_critic_loss_concatenates_dict_observation_values():
         jnp.zeros((observations["unified_obs"].shape[0], 1)),
     )
 
-    def critic(params, _key, observations, _actions, _training):
+    def critic(params, _actor_params, _key, observations, _actions, _training):
         seen.update(observations)
         return (
             (

--- a/tests/test_flax_dpg_builder_param_tree.py
+++ b/tests/test_flax_dpg_builder_param_tree.py
@@ -134,7 +134,7 @@ def test_deterministic_builders_preserve_public_contract_and_param_roots(
     key = jax.random.PRNGKey(1)
     observations = {"unified_obs": jnp.zeros((1, 4), dtype=jnp.float32)}
     action = actor(policy_params, key, observations)
-    values = critic(critic_params, key, observations, action)
+    values = critic(critic_params, policy_params, key, observations, action)
     assert action.shape == (1, 2)
     if twin:
         assert tuple(value.shape for value in values) == ((1, 1), (1, 1))

--- a/tests/test_issue7_contracts.py
+++ b/tests/test_issue7_contracts.py
@@ -218,7 +218,7 @@ def test_flax_ac_continuous_actor_initializes_log_std_param():
 
     obs = {"unified_obs": np.zeros((1, 3), dtype=np.float32)}
     mu, log_std = actor(actor_params, None, obs)
-    value = critic(critic_params, None, obs)
+    value = critic(critic_params, actor_params, None, obs)
 
     assert mu.shape[-1] == 1
     assert log_std.shape == (1, 1)

--- a/tests/test_observation_role_isolation.py
+++ b/tests/test_observation_role_isolation.py
@@ -29,9 +29,9 @@ def test_actor_critic_observation_roles_are_isolated(backend, family):
     def outputs(observations):
         policy = actor(params, key, observations)
         value = (
-            critic(critic_params, key, observations)
+            critic(critic_params, params, key, observations)
             if family == "ac"
-            else critic(critic_params, key, observations, jnp.zeros((2, 2)))
+            else critic(critic_params, params, key, observations, jnp.zeros((2, 2)))
         )
         return policy[0] if family == "ac" else policy, value
 

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -52,7 +52,7 @@ def test_sac_actor_loss_uses_minimum_expected_q():
         jnp.zeros((feature["unified_obs"].shape[0], 1)),
         jnp.zeros((feature["unified_obs"].shape[0], 1)),
     )
-    agent.critic = lambda params, key, feature, policy: (
+    agent.critic = lambda params, policy_params, key, feature, policy: (
         jnp.array([[0.0], [10.0]]),
         jnp.array([[4.0], [2.0]]),
     )
@@ -87,7 +87,12 @@ def test_crossq_actors_have_no_batch_stats_but_critics_do():
         builder = make_builder(
             {"unified_obs": [4]},
             [2],
-            {"actor_node": 16, "critic_node": 128, "hidden_n": 1, "embedding_mode": "normal"},
+            {
+                "actor_node": 16,
+                "critic_node": 128,
+                "hidden_n": 1,
+                "embedding_mode": "normal",
+            },
         )
         actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
 
@@ -96,7 +101,7 @@ def test_crossq_actors_have_no_batch_stats_but_critics_do():
 
         obs = {"unified_obs": jnp.zeros((2, 4))}
         mu, log_std = actor(policy_params, None, obs)
-        (q1, q2), updates = critic(critic_params, None, obs, jnp.zeros((2, 2)), True)
+        (q1, q2), updates = critic(critic_params, policy_params, None, obs, jnp.zeros((2, 2)), True)
 
         assert mu.shape == log_std.shape == (2, 2)
         assert q1.shape == q2.shape == (2, 1)
@@ -121,7 +126,7 @@ def test_sac_actor_and_temperature_update_on_configured_period():
         jnp.full((feature["unified_obs"].shape[0], 1), params),
         jnp.full((feature["unified_obs"].shape[0], 1), -1.0),
     )
-    agent.critic = lambda params, key, feature, actions: (
+    agent.critic = lambda params, policy_params, key, feature, actions: (
         params + actions,
         params + 2.0 * actions,
     )
@@ -194,7 +199,7 @@ def test_sac_actor_and_target_use_distinct_fresh_keys():
     agent._target = lambda policy, target_critic, rewards, nxtobses, done, key, alpha: (
         jax.random.uniform(key)
     )
-    agent._critic_loss = lambda critic, obses, actions, targets, weights, key: (
+    agent._critic_loss = lambda critic, policy, obses, actions, targets, weights, key: (
         targets + 0.0 * critic,
         jnp.zeros((1,)),
     )

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -21,7 +21,9 @@ def _continuous_agent(cls, family):
     agent.lamda = 0.95
     agent.gae_normalize = False
     agent.gae_normalize_scope = "batch"
-    agent.critic = lambda params, key, obses: jnp.zeros((*obses["unified_obs"].shape[:-1], 1))
+    agent.critic = lambda params, actor_params, key, obses: jnp.zeros(
+        (*obses["unified_obs"].shape[:-1], 1)
+    )
     agent.actor = lambda params, key, obses: (
         jnp.zeros((*obses["unified_obs"].shape[:-1], 2)),
         jnp.zeros((1, 2)),
@@ -50,7 +52,7 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
     agent = _continuous_agent(cls, family)
     agent.actor_params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
     agent.critic_params = {"bias": jnp.asarray(0.0, dtype=jnp.float32)}
-    agent.critic = lambda params, key, obses: (
+    agent.critic = lambda params, actor_params, key, obses: (
         jnp.zeros((*obses["unified_obs"].shape[:-1], 1)) + params["bias"]
     )
     agent.actor = lambda params, key, obses: (

--- a/tests/test_xqc_model_variant.py
+++ b/tests/test_xqc_model_variant.py
@@ -8,7 +8,12 @@ def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     builder = model_builder_maker(
         {"unified_obs": [4]},
         [2],
-        {"actor_node": 16, "critic_node": 32, "hidden_n": 1, "embedding_mode": "normal"},
+        {
+            "actor_node": 16,
+            "critic_node": 32,
+            "hidden_n": 1,
+            "embedding_mode": "normal",
+        },
     )
     actor, critic, policy_params, critic_params = builder(jax.random.PRNGKey(0))
 
@@ -30,7 +35,12 @@ def test_xqc_builder_uses_four_layer_batchnorm_mlp():
     obs = {"unified_obs": jnp.zeros((2, 4), dtype=jnp.float32)}
     (mu, log_std), actor_updates = actor(policy_params, None, obs, True)
     (q1, q2), critic_updates = critic(
-        critic_params, None, obs, jnp.zeros((2, 2), dtype=jnp.float32), True
+        critic_params,
+        policy_params,
+        None,
+        obs,
+        jnp.zeros((2, 2), dtype=jnp.float32),
+        True,
     )
     assert mu.shape == log_std.shape == (2, 2)
     assert q1.shape == q2.shape == (2, 101)


### PR DESCRIPTION
`unified_*` 관측의 학습 가능한 PreProc을 Actor가 소유하도록 바꿉니다. Critic은 Actor의 공통 feature를 gradient가 차단된 상태로 사용하고, `critic_*` 전용 PreProc과 Critic head를 학습합니다.

- Critic 호출에 Actor 파라미터를 명시적으로 전달하고, AC·DPG·IMPALA·APE-X·TD7의 current/fixed/target 경로에 대응하는 Actor 상태를 연결했습니다. CrossQ의 target action도 Critic 손실에서 분리했습니다.
- Flax·Haiku의 Actor/Critic 파라미터·optimizer 분리를 유지합니다. Haiku Q-Net의 이미지 파라미터 이름과 추론 결과도 보존했습니다.
- 검증: 동일 최종 코드의 관련 테스트 **359 passed, 3 skipped**, Haiku 최종 변경 후 해당 테스트 **12 passed**. Critic→Actor gradient 0, Actor의 action을 통한 Q gradient 및 Critic 전용 CNN gradient가 양수임을 확인했습니다.
- 실제 PPO CarRacing CLI에서 Actor는 **141,542개**를 유지하고 Critic은 **207,073→131,137개**로 줄었습니다. 공통 CNN **75,936개**가 Critic에서 제거되었고 학습·평가·저장을 완료했습니다. CPU SAC CLI와 target/snapshot 경로도 확인했습니다.
- 정적 검사: 기존 Ruff `N999` 2건과 ty 113건이 그대로 남아 있으며 신규 진단은 없습니다. AC·DPG 이미지 checkpoint의 Critic 구조가 변경됩니다. 장기 수렴 성능·GPU 학습·실제 Ray transport는 실행하지 않았습니다.

스택 4/4. 기준 브랜치는 `stack/flashsac-03-actor-critic-params`입니다. 이 PR의 최종 트리는 게시 요청 시 스테이징되어 있던 코드와 정확히 같습니다.

리뷰·머지 순서: `main` → #36 → #37 → #38 → #39. 각 PR의 Files changed는 바로 앞 단계와의 차이입니다.
