### PR TITLE
Gym·EnvPool 진단 로깅을 환경 어댑터로 이관

### DIFF
--- a/env_builder/env_builder.py
+++ b/env_builder/env_builder.py
@@ -11,6 +11,7 @@ from gymnasium import spaces
 from gymnasium.vector.utils import concatenate, iterate
 from gymnasium.wrappers.utils import rescale_box
 
+from env_builder.metrics import GymEnvMetrics, GymLoggingWrapper
 from env_builder.observations import (
     flatten_observation_space,
     normalize_observation,
@@ -26,15 +27,16 @@ from jax_baselines.core.env_protocols import (
     SingleEnv,
     VectorizedEnv,
 )
+from jax_baselines.core.runtime_adapters import MetricLogger
 
 __all__ = [
     "Env",
     "EnvInfo",
+    "EnvPoolVectorizedEnv",
+    "GymVectorizedEnv",
     "PreparedEnvSpec",
     "PreparedWorkerEnvSpec",
     "VectorizedEnv",
-    "EnvPoolVectorizedEnv",
-    "GymVectorizedEnv",
     "get_env_builder",
 ]
 
@@ -196,7 +198,7 @@ def get_env_builder(
             if seed is None:
                 env.reset()
         seed_env(env, seed)
-        return env
+        return GymLoggingWrapper(env, is_atari=env_type == "atari_env")
 
     def prepare_envs(num_workers=1, seed=None):
         eval_seed = None if seed is None else seed + 1
@@ -238,8 +240,7 @@ def _get_envpool_env_id(env_name: str) -> str:
     - Classic: Same as gymnasium (e.g., "CartPole-v1")
     """
     # Handle ALE/ prefix
-    if env_name.startswith("ALE/"):
-        env_name = env_name[4:]
+    env_name = env_name.removeprefix("ALE/")
 
     # Handle NoFrameskip Atari environments
     if "NoFrameskip" in env_name:
@@ -295,6 +296,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
 
         # Determine if this is an Atari environment
         self._is_atari = self._check_atari_env(envpool_env_id)
+        self._metrics = GymEnvMetrics(worker_num, "reward" if self._is_atari else "original_reward")
 
         # Create EnvPool environment
         # EnvPool uses 'gymnasium' env_type for gymnasium compatibility
@@ -385,6 +387,7 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
         raw_obs, _, _, _, info = self.env.recv()
         order = np.argsort(info["env_id"])
         self.obs = self._process_observations(raw_obs, order)
+        self._metrics.reset()
         return self.obs, self._reorder_info(info, order)
 
     def step(self, actions):
@@ -420,16 +423,29 @@ class EnvPoolVectorizedEnv(VectorizedEnv):
         truncateds = truncateds[order]
         infos = self._reorder_info(infos, order)
 
-        if self._is_atari and "original_reward" not in infos:
-            original_reward = infos.get("reward")
-            if original_reward is not None:
-                infos["original_reward"] = original_reward
+        self._metrics.capture(
+            infos,
+            terminateds | truncateds,
+            self.real_reset_mask(terminateds, truncateds, infos),
+            self.autoreset_mask(terminateds, truncateds, infos),
+        )
 
         # EnvPool handles auto-reset internally: after a done flag, next_obs
         # already holds the new episode's first observation.
         self.obs = next_obs
 
         return next_obs, rewards, terminateds, truncateds, infos
+
+    def log_metrics(
+        self,
+        logger: MetricLogger,
+        steps: int | None,
+        *,
+        namespace: str = "rollout",
+        active: Any = None,
+        flush: bool = True,
+    ) -> None:
+        self._metrics.log(logger, steps, namespace=namespace, active=active, flush=flush)
 
     def real_reset_mask(self, terminateds, truncateds, infos):
         return _real_reset_mask(self._is_atari, terminateds, truncateds, infos)
@@ -495,6 +511,7 @@ class GymVectorizedEnv(VectorizedEnv):
         self._observation_key = observation_key
         self._reuse_for_eval = reuse_for_eval
         self._evaluation_active = False
+        self._metrics = GymEnvMetrics(worker_num)
         self._pending_result: tuple[Observation, Any, Any, Any, dict[str, Any]] | None = None
 
         # Create vectorized environment using gymnasium
@@ -594,6 +611,7 @@ class GymVectorizedEnv(VectorizedEnv):
             self.env.set_attr("was_real_done", True)
         obs, info = self.env.reset(seed=seed)
         self.obs = normalize_observation(obs, self._observation_key)
+        self._metrics.reset()
         return self.obs, info
 
     def step(self, actions):
@@ -616,13 +634,35 @@ class GymVectorizedEnv(VectorizedEnv):
         next_obs, rewards, terminateds, truncateds, infos = self.env.step_wait()
         next_obs = normalize_observation(next_obs, self._observation_key)
         self.obs = next_obs
+        self._metrics.capture(
+            infos,
+            terminateds | truncateds,
+            self.real_reset_mask(terminateds, truncateds, infos),
+            self.autoreset_mask(terminateds, truncateds, infos),
+        )
 
         return next_obs, rewards, terminateds, truncateds, infos
+
+    def log_metrics(
+        self,
+        logger: MetricLogger,
+        steps: int | None,
+        *,
+        namespace: str = "rollout",
+        active: Any = None,
+        flush: bool = True,
+    ) -> None:
+        self._metrics.log(logger, steps, namespace=namespace, active=active, flush=flush)
 
     @contextmanager
     def evaluation_context(self) -> Iterator[None]:
         if not self._reuse_for_eval:
-            yield
+            metrics = self._metrics
+            self._metrics = GymEnvMetrics(self.worker_num)
+            try:
+                yield
+            finally:
+                self._metrics = metrics
             return
         if self._evaluation_active:
             raise RuntimeError("Training environment is already borrowed for evaluation")
@@ -631,6 +671,7 @@ class GymVectorizedEnv(VectorizedEnv):
         observation = self.obs
         awaiting = self._awaiting_result
         pending = self.get_result() if awaiting else None
+        metrics = self._metrics
         vector_observation = deepcopy(self.env.observations)
         global_rng = random.getstate(), np.random.get_state()
         with preserve_gym_spaces(self.env.action_space, self.env.observation_space):
@@ -638,6 +679,7 @@ class GymVectorizedEnv(VectorizedEnv):
             try:
                 self.env.call("save_training_state")
                 try:
+                    self._metrics = GymEnvMetrics(self.worker_num)
                     yield
                 finally:
                     # Finish an evaluation step even when its action callback raises.
@@ -653,6 +695,7 @@ class GymVectorizedEnv(VectorizedEnv):
                 self.obs = observation
                 self._pending_result = pending
                 self._awaiting_result = awaiting
+                self._metrics = metrics
                 self._evaluation_active = False
                 random.setstate(global_rng[0])
                 np.random.set_state(global_rng[1])

--- a/experiments/runtime_adapters.py
+++ b/experiments/runtime_adapters.py
@@ -170,7 +170,14 @@ def record_and_test(env_builder, logger_run, actions_eval_fn, episode, conv_acti
             test_env.close()
             raise
         with closing(render_env):
-            return run_test_episodes(render_env, actions_eval_fn, episode, conv_action)
+            return run_test_episodes(
+                render_env,
+                actions_eval_fn,
+                episode,
+                conv_action,
+                logger_run=logger_run,
+                logging_env=test_env,
+            )
 
     from gymnasium.wrappers import RecordEpisodeStatistics, RecordVideo
 
@@ -181,9 +188,18 @@ def record_and_test(env_builder, logger_run, actions_eval_fn, episode, conv_acti
         test_env.close()
         raise
     with render_env:
-        return run_test_episodes(render_env, actions_eval_fn, episode, conv_action)
+        return run_test_episodes(
+            render_env,
+            actions_eval_fn,
+            episode,
+            conv_action,
+            logger_run=logger_run,
+            logging_env=test_env,
+        )
 
 
 def headless_test(env_builder, logger_run, actions_eval_fn, episode, conv_action=None):
     with closing(env_builder(1)) as test_env:
-        return run_test_episodes(test_env, actions_eval_fn, episode, conv_action)
+        return run_test_episodes(
+            test_env, actions_eval_fn, episode, conv_action, logger_run=logger_run
+        )

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -17,16 +17,13 @@ from jax_baselines.core.checkpoint_store import (
 from jax_baselines.core.env_info import get_local_env_info, infer_action_meta
 from jax_baselines.core.env_protocols import (
     batch_observation,
-    single_real_episode_end,
+    log_environment_metrics,
     vector_autoreset_mask,
-    vector_real_reset_mask,
 )
 from jax_baselines.core.epoch_buffer import EpochBuffer
 from jax_baselines.core.eval import (
     _normalize_action_for_step,
     evaluate_policy,
-    extract_original_reward,
-    extract_vector_original_rewards,
     record_and_test,
 )
 from jax_baselines.core.normalization import (
@@ -394,7 +391,7 @@ class Actor_Critic_Policy_Gradient_Family:
         )
 
     def learn_SingleEnv(self, ctx):
-        obs, info = self.env.reset() if self._initial_reset is None else self._initial_reset
+        obs, _ = self.env.reset() if self._initial_reset is None else self._initial_reset
         self._initial_reset = None
         obs = normalize_empirical_observation(
             batch_observation(obs), self.obs_rms, on_device=self.memory_backend == "gpu"
@@ -404,16 +401,18 @@ class Actor_Critic_Policy_Gradient_Family:
         eval_result = None
         score = 0.0
         eplen = 0
-        original = 0.0
-        have_original = False
+        steps = 0
+        last_log_step = 0
         for steps in ctx.pbar:
             actions = self.actions(obs)
             step_action = _normalize_action_for_step(self.conv_action(actions))
-            next_obs, reward, terminated, truncated, info = self.env.step(step_action)
+            next_obs, reward, terminated, truncated, _ = self.env.step(step_action)
+            log_due = steps - last_log_step >= ctx.log_interval
+            log_environment_metrics(self.env, ctx.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
             next_obs = batch_observation(next_obs)
-            step_original = extract_original_reward(info)
             if terminated or truncated:
-                real_episode_end = single_real_episode_end(terminated, truncated, info)
                 next_obs = {key: value.copy() for key, value in next_obs.items()}
                 action_observation, _ = self.env.reset()
                 action_observation = batch_observation(action_observation)
@@ -435,27 +434,19 @@ class Actor_Critic_Policy_Gradient_Family:
             )
             score += float(reward)
             eplen += 1
-            if step_original is not None:
-                have_original = True
-                original += float(step_original)
             obs = normalize_empirical_observation(
                 action_observation, self.obs_rms, on_device=self.memory_backend == "gpu"
             )
 
             if terminated or truncated:
-                emit_original = have_original and real_episode_end
                 self.rollout_tracker.record(
                     steps,
                     episode_reward=score,
                     episode_length=eplen,
                     timeout=float(truncated),
-                    original_reward=original if emit_original else None,
                 )
                 score = 0.0
                 eplen = 0
-                if emit_original:
-                    original = 0.0
-                    have_original = False
 
             if (steps + 1) % self.batch_size == 0:
                 loss = self.train_step(steps, logger_run=ctx.logger_run)
@@ -464,8 +455,9 @@ class Actor_Critic_Policy_Gradient_Family:
             if steps % ctx.eval_freq == 0:
                 eval_result = self.eval(ctx, steps)
 
-            if steps % ctx.log_interval == 0 and eval_result is not None and len(self.lossque) > 0:
+            if log_due and eval_result is not None and len(self.lossque) > 0:
                 ctx.pbar.set_description(self.description(eval_result))
+        log_environment_metrics(self.env, ctx.logger_run, steps)
 
     def learn_VectorizedEnv(self, ctx):
         raw_obs = self.env.current_obs()
@@ -476,8 +468,6 @@ class Actor_Critic_Policy_Gradient_Family:
             device_state = (
                 jnp.zeros(self.worker_size),
                 jnp.zeros(self.worker_size, dtype=jnp.int32),
-                jnp.zeros(self.worker_size),
-                jnp.zeros(self.worker_size, dtype=bool),
                 jnp.zeros(self.worker_size, dtype=bool),
             )
         completed_steps = []
@@ -487,8 +477,6 @@ class Actor_Critic_Policy_Gradient_Family:
         eval_result = None
         scores = np.zeros([self.worker_size], dtype=np.float64)
         eplens = np.zeros([self.worker_size], dtype=np.int32)
-        originals = np.zeros([self.worker_size], dtype=np.float64)
-        original_present = np.zeros([self.worker_size], dtype=bool)
         # Workers that ended an episode last step emit an autoreset dummy step
         # (action ignored, reward 0, fresh obs). On-policy rollouts have a fixed
         # per-worker length, so the dummy can't be dropped; instead flag it
@@ -511,6 +499,8 @@ class Actor_Critic_Policy_Gradient_Family:
         actions = self.actions(obs)
         end = object()
         first = True
+        steps = 0
+        last_log_step = 0
         for steps, next_step in pairwise(chain(ctx.pbar, (end,))):
             if first:
                 send(actions)
@@ -522,6 +512,15 @@ class Actor_Critic_Policy_Gradient_Family:
                 truncateds,
                 infos,
             ) = self.env.get_result()
+            log_due = steps - last_log_step >= ctx.log_interval
+            log_environment_metrics(
+                self.env,
+                ctx.logger_run,
+                steps,
+                flush=log_due,
+            )
+            if log_due:
+                last_log_step = steps
             action_observation = self.env.current_obs()
             # Autoreset observations belong to the next action, not this successor.
             next_obses = normalize_empirical_observation(
@@ -540,30 +539,12 @@ class Actor_Critic_Policy_Gradient_Family:
                 send(next_actions)
 
             if device_rollout:
-                if isinstance(infos, dict):
-                    original = (
-                        jnp.broadcast_to(jnp.asarray(infos["original_reward"]), (self.worker_size,))
-                        if "original_reward" in infos
-                        else jnp.zeros_like(rewards)
-                    )
-                    present = (
-                        jnp.broadcast_to(
-                            jnp.asarray(infos["_original_reward"], dtype=bool), (self.worker_size,)
-                        )
-                        if "_original_reward" in infos
-                        else jnp.full_like(terminateds, "original_reward" in infos)
-                    )
-                else:
-                    original, present = extract_vector_original_rewards(infos, self.worker_size)
                 device_state, rewards, terminateds, completed = device_episode_step(
                     device_state,
                     rewards,
                     terminateds,
                     truncateds,
-                    vector_real_reset_mask(self.env, terminateds, truncateds, infos),
                     vector_autoreset_mask(self.env, terminateds, truncateds, infos),
-                    original,
-                    present,
                 )
                 self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
                 completed_steps.append(steps)
@@ -579,23 +560,15 @@ class Actor_Critic_Policy_Gradient_Family:
                             episode_reward=float(row[1]),
                             episode_length=int(row[2]),
                             timeout=float(row[3]),
-                            original_reward=float(row[4]) if row[5] else None,
                         )
                     completed_steps.clear()
                     completed_rows.clear()
             else:
                 done = np.logical_or(terminateds, truncateds)
-                real_reset = vector_real_reset_mask(self.env, terminateds, truncateds, infos)
                 autoreset = vector_autoreset_mask(self.env, terminateds, truncateds, infos)
                 active = ~prev_done
                 scores[active] += rewards[active]
                 eplens[active] += 1
-                step_original, step_original_present = extract_vector_original_rewards(
-                    infos, self.worker_size
-                )
-                active_original = active & step_original_present
-                originals[active_original] += step_original[active_original]
-                original_present[active_original] = True
 
                 if prev_done.any():
                     # Flag the dummy step terminal AND zero its reward so it is fully
@@ -606,19 +579,14 @@ class Actor_Critic_Policy_Gradient_Family:
                 self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
 
                 for idx in np.where(done & active)[0]:
-                    emit_original = original_present[idx] and real_reset[idx]
                     self.rollout_tracker.record(
                         steps,
                         episode_reward=float(scores[idx]),
                         episode_length=int(eplens[idx]),
                         timeout=float(truncateds[idx]),
-                        original_reward=float(originals[idx]) if emit_original else None,
                     )
                     scores[idx] = 0.0
                     eplens[idx] = 0
-                    if emit_original:
-                        originals[idx] = 0.0
-                        original_present[idx] = False
 
                 prev_done = done & autoreset & active
 
@@ -638,8 +606,9 @@ class Actor_Critic_Policy_Gradient_Family:
             if steps % ctx.eval_freq == 0:
                 eval_result = self.eval(ctx, steps)
 
-            if steps % ctx.log_interval == 0 and eval_result is not None and len(self.lossque) > 0:
+            if log_due and eval_result is not None and len(self.lossque) > 0:
                 ctx.pbar.set_description(self.description(eval_result))
+        log_environment_metrics(self.env, ctx.logger_run, steps)
 
     def eval(self, ctx, steps):
         return evaluate_policy(

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -549,6 +549,7 @@ class Deteministic_Policy_Gradient_Family:
         )
         spec = RolloutSpec(
             env=self.env,
+            logger_run=ctx.logger_run,
             replay_buffer=self.replay_buffer,
             learning_starts=self.learning_starts,
             train_freq=self.train_freq,

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -554,6 +554,7 @@ class Q_Network_Family:
         )
         spec = RolloutSpec(
             env=self.env,
+            logger_run=ctx.logger_run,
             replay_buffer=self.replay_buffer,
             learning_starts=self.learning_starts,
             train_freq=self.train_freq,

--- a/jax_baselines/core/env_protocols.py
+++ b/jax_baselines/core/env_protocols.py
@@ -184,16 +184,6 @@ def _done_mask(terminateds: Any, truncateds: Any) -> np.ndarray | jax.Array:
     )
 
 
-def vector_real_reset_mask(
-    env: Any, terminateds: Any, truncateds: Any, infos: Any
-) -> np.ndarray | jax.Array:
-    real_reset_mask = getattr(env, "real_reset_mask", None)
-    if callable(real_reset_mask):
-        mask = real_reset_mask(terminateds, truncateds, infos)
-        return mask.astype(bool) if isinstance(mask, jax.Array) else np.asarray(mask, dtype=bool)
-    return _done_mask(terminateds, truncateds)
-
-
 def vector_autoreset_mask(
     env: Any, terminateds: Any, truncateds: Any, infos: Any
 ) -> np.ndarray | jax.Array:
@@ -202,13 +192,6 @@ def vector_autoreset_mask(
         mask = autoreset_mask(terminateds, truncateds, infos)
         return mask.astype(bool) if isinstance(mask, jax.Array) else np.asarray(mask, dtype=bool)
     return _done_mask(terminateds, truncateds)
-
-
-def single_real_episode_end(terminated: Any, truncated: Any, info: Any) -> bool:
-    """Return the adapter-normalized real episode boundary for one environment."""
-    if isinstance(info, dict) and "real_episode_end" in info:
-        return bool(info["real_episode_end"])
-    return bool(terminated or truncated)
 
 
 def reset_for_evaluation(env: Any) -> Any:

--- a/jax_baselines/core/eval.py
+++ b/jax_baselines/core/eval.py
@@ -8,50 +8,10 @@ from jax_baselines.core.env_protocols import (
     EvaluationContextEnv,
     VectorizedEvalEnv,
     batch_observation,
+    log_environment_metrics,
     reset_for_evaluation,
-    single_real_episode_end,
     vector_autoreset_mask,
-    vector_real_reset_mask,
 )
-
-
-def extract_original_reward(info):
-    """Return a single-step original reward from an env info dict, if present."""
-    if isinstance(info, dict):
-        return info.get("original_reward")
-    return None
-
-
-def extract_vector_original_rewards(infos, worker_size):
-    """Return per-worker original rewards and a presence mask from vector infos.
-
-    Gymnasium vector envs usually return a dict of arrays, while some wrappers
-    expose one info dict per worker. Supporting both shapes keeps rollout
-    logging independent from the vector backend.
-    """
-    values = np.zeros(worker_size, dtype=np.float64)
-    present = np.zeros(worker_size, dtype=bool)
-    if isinstance(infos, (list, tuple)):
-        for idx, info in enumerate(infos[:worker_size]):
-            if not isinstance(info, dict) or "original_reward" not in info:
-                continue
-            values[idx] = info["original_reward"]
-            present[idx] = True
-        return values, present
-    if not isinstance(infos, dict) or "original_reward" not in infos:
-        return values, present
-    raw = np.asarray(infos["original_reward"], dtype=np.float64)
-    if raw.shape == ():
-        raw = np.full(worker_size, raw.item(), dtype=np.float64)
-    else:
-        raw = raw.reshape(-1)
-    count = min(worker_size, raw.shape[0])
-    values[:count] = raw[:count]
-    if "_original_reward" not in infos or infos["_original_reward"] is None:
-        present[:count] = True
-        return values, present
-    present[:count] = np.asarray(infos["_original_reward"], dtype=bool).reshape(-1)[:count]
-    return values, present
 
 
 def log_measurement(
@@ -62,18 +22,8 @@ def log_measurement(
     episode_reward,
     episode_length,
     timeout_rate,
-    original_reward=None,
 ):
-    """Write the canonical four measurement leaves under a namespace prefix.
-
-    The single tag-writer for both the ``eval/`` (frozen policy measured on a
-    separate ``eval_env``) and ``rollout/`` (behavior policy's own training
-    episodes) namespaces, so their leaf names can never drift apart again.
-    ``original_reward`` is logged only when an Atari wrapper supplied an
-    unclipped score.
-    """
-    if original_reward is not None:
-        log_metric(f"{namespace}/original_reward", original_reward, steps)
+    """Write algorithm-level episode statistics under a namespace prefix."""
     log_metric(f"{namespace}/episode_reward", episode_reward, steps)
     log_metric(f"{namespace}/episode_length", episode_length, steps)
     log_metric(f"{namespace}/timeout_rate", timeout_rate, steps)
@@ -96,17 +46,13 @@ def _normalize_action_for_step(step_action):
     return arr.reshape(-1)
 
 
-def _evaluate_single_episodes(eval_env, eval_eps, act_eval_fn, conv_action):
-    original_rewards = []
+def _evaluate_single_episodes(eval_env, eval_eps, act_eval_fn, conv_action, logger_run, steps):
     total_reward = np.zeros(eval_eps)
     total_ep_len = np.zeros(eval_eps)
     total_truncated = np.zeros(eval_eps)
 
-    obs, info = reset_for_evaluation(eval_env)
+    obs, _ = reset_for_evaluation(eval_env)
     obs = batch_observation(obs)
-    have_original_reward = "original_reward" in info
-    if have_original_reward:
-        original_reward = info["original_reward"]
     terminated = False
     truncated = False
     eplen = 0
@@ -119,29 +65,26 @@ def _evaluate_single_episodes(eval_env, eval_eps, act_eval_fn, conv_action):
             # Normalize action so env.step receives a proper scalar when applicable
             action_to_step = _normalize_action_for_step(step_action)
 
-            observation, reward, terminated, truncated, info = eval_env.step(action_to_step)
+            observation, reward, terminated, truncated, _ = eval_env.step(action_to_step)
+            log_environment_metrics(eval_env, logger_run, steps, namespace="eval", flush=False)
             obs = batch_observation(observation)
-            if have_original_reward and "original_reward" in info:
-                original_reward += info["original_reward"]
             total_reward[ep] += reward
             eplen += 1
 
         total_ep_len[ep] = eplen
         total_truncated[ep] = float(truncated)
-        if have_original_reward and single_real_episode_end(terminated, truncated, info):
-            original_rewards.append(original_reward)
-            original_reward = 0
-
-        obs, info = eval_env.reset()
+        obs, _ = eval_env.reset()
         obs = batch_observation(obs)
         terminated = False
         truncated = False
         eplen = 0
 
-    return total_reward, total_ep_len, total_truncated, original_rewards
+    return total_reward, total_ep_len, total_truncated
 
 
-def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn, conv_action):
+def _evaluate_vector_episodes(
+    eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn, conv_action, logger_run, steps
+):
     workers = eval_env.get_info()["worker_num"]
     if workers < 1:
         raise ValueError("Evaluation worker count must be positive")
@@ -151,13 +94,11 @@ def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn
     counts = np.zeros(workers, dtype=np.int64)
     rewards_sum = np.zeros(workers)
     lengths = np.zeros(workers, dtype=np.int64)
-    _, info = eval_env.reset()
-    originals, original_present = extract_vector_original_rewards(info, workers)
+    eval_env.reset()
     prev_done = np.zeros(workers, dtype=bool)
     total_reward = np.zeros(eval_eps)
     total_ep_len = np.zeros(eval_eps)
     total_truncated = np.zeros(eval_eps)
-    original_rewards = []
     completed = 0
 
     while completed < eval_eps:
@@ -165,40 +106,22 @@ def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn
         actions = act_eval_fn(eval_env.current_obs())
         eval_env.step(conv_action(actions) if conv_action is not None else actions)
         _, rewards, terminateds, truncateds, infos = eval_env.get_result()
-        reward_infos = {}
-        if isinstance(infos, dict):
-            reward_infos = {
-                key: infos[key] for key in ("original_reward", "_original_reward") if key in infos
-            }
-        elif isinstance(infos, (list, tuple)):
-            reward_infos = [
-                {"original_reward": info["original_reward"]}
-                if isinstance(info, dict) and "original_reward" in info
-                else {}
-                for info in infos
-            ]
-        rewards, terminateds, truncateds, real_reset, autoreset, reward_infos = jax.device_get(
+        rewards, terminateds, truncateds, autoreset = jax.device_get(
             (
                 rewards,
                 terminateds,
                 truncateds,
-                vector_real_reset_mask(eval_env, terminateds, truncateds, infos),
                 vector_autoreset_mask(eval_env, terminateds, truncateds, infos),
-                reward_infos,
             )
         )
         done = np.logical_or(terminateds, truncateds)
         active = ~prev_done & (counts < targets)
+        log_environment_metrics(
+            eval_env, logger_run, steps, namespace="eval", active=active, flush=False
+        )
         rewards_sum[active] += rewards[active]
         lengths[active] += 1
-        original, present = extract_vector_original_rewards(reward_infos, workers)
-        originals[active & present] += original[active & present]
-        original_present[active & present] = True
         finished = done & active
-        emit_original = finished & real_reset & original_present
-        original_rewards.extend(originals[emit_original].tolist())
-        originals[emit_original] = 0
-        original_present[emit_original] = False
         end = completed + int(finished.sum())
         total_reward[completed:end] = rewards_sum[finished]
         total_ep_len[completed:end] = lengths[finished]
@@ -209,7 +132,7 @@ def _evaluate_vector_episodes(eval_env: VectorizedEvalEnv, eval_eps, act_eval_fn
         lengths[finished] = 0
         prev_done = done & autoreset & active
 
-    return total_reward, total_ep_len, total_truncated, original_rewards
+    return total_reward, total_ep_len, total_truncated
 
 
 def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, conv_action=None):
@@ -226,17 +149,14 @@ def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, c
         if isinstance(eval_env, EvaluationContextEnv)
         else nullcontext()
     ):
-        total_reward, total_ep_len, total_truncated, original_rewards = collect(
-            eval_env, eval_eps, act_eval_fn, conv_action
+        total_reward, total_ep_len, total_truncated = collect(
+            eval_env, eval_eps, act_eval_fn, conv_action, logger_run, steps
         )
+        log_environment_metrics(eval_env, logger_run, steps, namespace="eval")
     mean_reward = np.mean(total_reward)
     mean_ep_len = np.mean(total_ep_len)
 
-    mean_original_score = None
-    if original_rewards:
-        mean_original_score = np.mean(original_rewards)
-
-    if logger_run:
+    if logger_run is not None:
         log_measurement(
             logger_run.log_metric,
             "eval",
@@ -244,22 +164,19 @@ def evaluate_policy(eval_env, eval_eps, act_eval_fn, logger_run=None, steps=0, c
             episode_reward=mean_reward,
             episode_length=mean_ep_len,
             timeout_rate=np.mean(total_truncated),
-            original_reward=mean_original_score,
         )
 
-    if mean_original_score is not None:
-        return {
-            "mean_reward": mean_reward,
-            "mean_ep_len": mean_ep_len,
-            "mean_original_score": mean_original_score,
-        }
-    else:
-        return {"mean_reward": mean_reward, "mean_ep_len": mean_ep_len}
+    return {"mean_reward": mean_reward, "mean_ep_len": mean_ep_len}
 
 
-def run_test_episodes(test_env, actions_eval_fn, episode, conv_action=None):
+def run_test_episodes(
+    test_env, actions_eval_fn, episode, conv_action=None, *, logger_run=None, logging_env=None
+):
     """Run evaluation episodes on an already-constructed test environment."""
-
+    if episode < 1:
+        raise ValueError("episode must be positive")
+    # Recording wrappers step the same environment but need not expose its diagnostics.
+    logging_env = test_env if logging_env is None else logging_env
     total_rewards = []
     for _ in range(episode):
         obs, _ = test_env.reset()
@@ -274,12 +191,14 @@ def run_test_episodes(test_env, actions_eval_fn, episode, conv_action=None):
             action_to_step = _normalize_action_for_step(step_action)
 
             observation, reward, terminated, truncated, _ = test_env.step(action_to_step)
+            log_environment_metrics(logging_env, logger_run, None, namespace="test", flush=False)
             obs = batch_observation(observation)
             episode_rew += reward
             eplen += 1
         print("episod reward :", episode_rew, "episod len :", eplen)
         total_rewards.append(episode_rew)
 
+    log_environment_metrics(logging_env, logger_run, None, namespace="test")
     avg_reward = np.mean(total_rewards)
     std_reward = np.std(total_rewards)
     print(f"reward : {avg_reward} +- {std_reward}(std)")
@@ -297,8 +216,8 @@ def record_and_test(env_builder, logger_run, actions_eval_fn, episode, conv_acti
 
     test_env, _ = prepare_worker_env(env_builder)
     try:
-        return run_test_episodes(test_env, actions_eval_fn, episode, conv_action)
+        return run_test_episodes(
+            test_env, actions_eval_fn, episode, conv_action, logger_run=logger_run
+        )
     finally:
-        close = getattr(test_env, "close", None)
-        if callable(close):
-            close()
+        test_env.close()

--- a/jax_baselines/core/rollout.py
+++ b/jax_baselines/core/rollout.py
@@ -32,16 +32,12 @@ import numpy as np
 from jax_baselines.core.env_protocols import (
     VectorizedEnv,
     batch_observation,
-    single_real_episode_end,
+    log_environment_metrics,
     vector_autoreset_mask,
-    vector_real_reset_mask,
-)
-from jax_baselines.core.eval import (
-    extract_original_reward,
-    extract_vector_original_rewards,
 )
 from jax_baselines.core.replay_protocol import ReplayWriter
 from jax_baselines.core.rollout_stats import device_episode_step
+from jax_baselines.core.runtime_adapters import MetricLogger
 
 
 @dataclass(frozen=True)
@@ -122,8 +118,7 @@ class RolloutSpec:
     evaluate: Callable[[int], object]
     describe: Callable[[object], str]
     bind_loss_window: Callable[[deque], None]
-    # rollout-measurement seam: hands each completed training episode to the
-    # agent's EpisodeTracker (the engine stays logger-free).
+    # Algorithm-level episode statistics remain separate from environment metrics.
     record_rollout_episode: Callable[..., None]
     # checkpoint seam
     checkpoint_on_episode_end: Callable[..., bool]
@@ -134,6 +129,7 @@ class RolloutSpec:
     memory_device: jax.Device | None = None
     autoreset_steps: bool = True
     initial_reset: tuple | None = None
+    logger_run: MetricLogger | None = None
 
 
 class RolloutEngine:
@@ -149,48 +145,41 @@ class RolloutEngine:
 
     def learn_single_env(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
-        obs, info = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
+        obs, _ = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
         obs = batch_observation(obs)
         lossque = self._begin()
         eval_result = None
 
         score = 0.0
         eplen = 0
-        original = 0.0
-        have_original = False
+        steps = 0
+        last_log_step = 0
 
         for steps in pbar:
             sel = spec.single_action(obs, steps)
-            next_obs, reward, terminated, truncated, info = spec.env.step(sel.env_action)
+            next_obs, reward, terminated, truncated, _ = spec.env.step(sel.env_action)
+            log_due = steps - last_log_step >= log_interval
+            log_environment_metrics(spec.env, spec.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
             next_obs = batch_observation(next_obs)
             if spec.reward_normalization and spec.record_transition is not None:
                 spec.record_transition(reward, np.logical_or(terminated, truncated))
             spec.replay_buffer.add(obs, sel.store_action, reward, next_obs, terminated, truncated)
             score += float(reward)
             eplen += 1
-            step_original = extract_original_reward(info)
-            if step_original is not None:
-                have_original = True
-                original += float(step_original)
             obs = next_obs
 
             if terminated or truncated:
-                emit_original = have_original and single_real_episode_end(
-                    terminated, truncated, info
-                )
                 spec.record_rollout_episode(
                     steps,
                     episode_reward=score,
                     episode_length=eplen,
                     timeout=float(truncated),
-                    original_reward=original if emit_original else None,
                 )
                 score = 0.0
                 eplen = 0
-                if emit_original:
-                    original = 0.0
-                    have_original = False
-                obs, info = spec.env.reset()
+                obs, _ = spec.env.reset()
                 obs = batch_observation(obs)
 
             if steps > spec.learning_starts and steps % spec.train_freq == 0:
@@ -201,8 +190,9 @@ class RolloutEngine:
             if steps % spec.eval_freq == 0:
                 eval_result = spec.evaluate(steps)
 
-            if steps % log_interval == 0 and eval_result is not None and len(lossque) > 0:
+            if log_due and eval_result is not None and len(lossque) > 0:
                 pbar.set_description(spec.describe(eval_result))
+        log_environment_metrics(spec.env, spec.logger_run, steps)
 
     def learn_vectorized_env(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
@@ -212,12 +202,11 @@ class RolloutEngine:
         eval_result = None
         scores = np.zeros([spec.worker_size], dtype=np.float64)
         eplens = np.zeros([spec.worker_size], dtype=np.int32)
-        originals = np.zeros([spec.worker_size], dtype=np.float64)
-        original_present = np.zeros([spec.worker_size], dtype=bool)
-        # Adapters classify two backend quirks separately: whether this done row
-        # is a real game reset, and whether the next row is an autoreset dummy.
+        # Only adapters know which done rows are followed by an autoreset dummy.
         prev_done = None
         train_residual = 0
+        steps = 0
+        last_log_step = 0
 
         for steps in pbar:
             spec.refresh_exploration(steps)
@@ -228,18 +217,15 @@ class RolloutEngine:
             next_obses, rewards, terminateds, truncateds, infos = spec.env.get_result()
             done = np.logical_or(terminateds, truncateds)
             active = np.ones(spec.worker_size, dtype=bool) if prev_done is None else ~prev_done
+            log_due = steps - last_log_step >= log_interval
+            log_environment_metrics(spec.env, spec.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
             if spec.reward_normalization and spec.record_transition is not None:
                 spec.record_transition(rewards, done, active)
             scores[active] += rewards[active]
             eplens[active] += 1
-            step_original, step_original_present = extract_vector_original_rewards(
-                infos, spec.worker_size
-            )
-            real_reset = vector_real_reset_mask(spec.env, terminateds, truncateds, infos)
             autoreset = vector_autoreset_mask(spec.env, terminateds, truncateds, infos)
-            active_original = active & step_original_present
-            originals[active_original] += step_original[active_original]
-            original_present[active_original] = True
 
             if steps > spec.learning_starts:
                 train_residual += int(active.sum())
@@ -260,60 +246,53 @@ class RolloutEngine:
             )
 
             for idx in np.where(done & active)[0]:
-                emit_original = original_present[idx] and real_reset[idx]
                 spec.record_rollout_episode(
                     steps,
                     episode_reward=float(scores[idx]),
                     episode_length=int(eplens[idx]),
                     timeout=float(truncateds[idx]),
-                    original_reward=float(originals[idx]) if emit_original else None,
                 )
                 scores[idx] = 0.0
                 eplens[idx] = 0
-                if emit_original:
-                    originals[idx] = 0.0
-                    original_present[idx] = False
 
             prev_done = done & autoreset & active
 
             if steps % spec.eval_freq == 0:
                 eval_result = spec.evaluate(steps)
 
-            if steps % log_interval == 0 and eval_result is not None and len(lossque) > 0:
+            if log_due and eval_result is not None and len(lossque) > 0:
                 pbar.set_description(spec.describe(eval_result))
+        log_environment_metrics(spec.env, spec.logger_run, steps)
 
     def learn_single_env_checkpointing(self, pbar, callback=None, log_interval=1000, obs=None):
         spec = self.spec
         if obs is None:
-            obs, info = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
+            obs, _ = spec.env.reset() if spec.initial_reset is None else spec.initial_reset
             obs = batch_observation(obs)
         lossque = self._begin()
         eval_result = None
 
         score = 0.0
         eplen = 0
-        original = 0.0
-        have_original = False
+        steps = 0
+        last_log_step = 0
 
         for steps in pbar:
             eplen += 1
             sel = spec.single_action(obs, steps)
-            next_obs, reward, terminated, truncated, info = spec.env.step(sel.env_action)
+            next_obs, reward, terminated, truncated, _ = spec.env.step(sel.env_action)
+            log_due = steps - last_log_step >= log_interval
+            log_environment_metrics(spec.env, spec.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
             next_obs = batch_observation(next_obs)
             if spec.reward_normalization and spec.record_transition is not None:
                 spec.record_transition(reward, np.logical_or(terminated, truncated))
             spec.replay_buffer.add(obs, sel.store_action, reward, next_obs, terminated, truncated)
             score += float(reward)
-            step_original = extract_original_reward(info)
-            if step_original is not None:
-                have_original = True
-                original += float(step_original)
             obs = next_obs
 
             if terminated or truncated:
-                emit_original = have_original and single_real_episode_end(
-                    terminated, truncated, info
-                )
                 if steps > spec.learning_starts:
                     ckpt_success = spec.checkpoint_on_episode_end(
                         steps,
@@ -326,20 +305,16 @@ class RolloutEngine:
                         episode_reward=score,
                         episode_length=eplen,
                         timeout=float(truncated),
-                        original_reward=original if emit_original else None,
                     )
                 else:
                     ckpt_success = True
                 score = 0.0
                 eplen = 0
-                if emit_original:
-                    original = 0.0
-                    have_original = False
 
                 if not ckpt_success and spec.force_reset is not None:
-                    obs, info = spec.force_reset()
+                    obs, _ = spec.force_reset()
                 else:
-                    obs, info = spec.env.reset()
+                    obs, _ = spec.env.reset()
                 obs = batch_observation(obs)
 
             if steps > spec.learning_starts and steps % spec.train_freq == 0:
@@ -348,8 +323,9 @@ class RolloutEngine:
             if steps % spec.eval_freq == 0:
                 eval_result = spec.evaluate(steps)
 
-            if steps % log_interval == 0 and eval_result is not None and len(lossque) > 0:
+            if log_due and eval_result is not None and len(lossque) > 0:
                 pbar.set_description(spec.describe(eval_result))
+        log_environment_metrics(spec.env, spec.logger_run, steps)
 
     def learn_vectorized_env_checkpointing(self, pbar, callback=None, log_interval=1000):
         spec = self.spec
@@ -360,14 +336,13 @@ class RolloutEngine:
 
         scores = np.zeros([spec.worker_size], dtype=np.float64)
         eplens = np.zeros([spec.worker_size], dtype=np.int32)
-        originals = np.zeros([spec.worker_size], dtype=np.float64)
-        original_present = np.zeros([spec.worker_size], dtype=bool)
-        # Adapters classify two backend quirks separately: whether this done row
-        # is a real game reset, and whether the next row is an autoreset dummy.
+        # Only adapters know which done rows are followed by an autoreset dummy.
         prev_done = None
         defer_checkpoint_pulses = spec.force_reset is None
         pending_checkpoint_pulses = deque()
         pending_eval_steps = deque()
+        steps = 0
+        last_log_step = 0
 
         def checkpoint_pulse_callback(pulse_steps, accumulated_timesteps):
             if defer_checkpoint_pulses:
@@ -389,8 +364,6 @@ class RolloutEngine:
             while pending_checkpoint_pulses:
                 pulse_steps, accumulated_timesteps = pending_checkpoint_pulses.popleft()
                 spec.checkpoint_pulse(pulse_steps, accumulated_timesteps)
-            while pending_eval_steps:
-                run_eval(pending_eval_steps.popleft())
 
         for steps in pbar:
             spec.refresh_exploration(steps)
@@ -402,18 +375,17 @@ class RolloutEngine:
             next_obses, rewards, terminateds, truncateds, infos = spec.env.get_result()
             done = np.logical_or(terminateds, truncateds)
             active = np.ones(spec.worker_size, dtype=bool) if prev_done is None else ~prev_done
+            log_due = steps - last_log_step >= log_interval
+            log_environment_metrics(spec.env, spec.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
+            while pending_eval_steps:
+                run_eval(pending_eval_steps.popleft())
             if spec.reward_normalization and spec.record_transition is not None:
                 spec.record_transition(rewards, done, active)
             scores[active] += rewards[active]
             eplens[active] += 1
-            step_original, step_original_present = extract_vector_original_rewards(
-                infos, spec.worker_size
-            )
-            real_reset = vector_real_reset_mask(spec.env, terminateds, truncateds, infos)
             autoreset = vector_autoreset_mask(spec.env, terminateds, truncateds, infos)
-            active_original = active & step_original_present
-            originals[active_original] += step_original[active_original]
-            original_present[active_original] = True
 
             store_mask = None if prev_done is None or not prev_done.any() else ~prev_done
             spec.replay_buffer.add(
@@ -446,19 +418,14 @@ class RolloutEngine:
                     )
                     if advance and not ckpt_success:
                         monitor_failed = True
-                    emit_original = original_present[idx] and real_reset[idx]
                     spec.record_rollout_episode(
                         steps,
                         episode_reward=float(scores[idx]),
                         episode_length=int(eplens[idx]),
                         timeout=float(truncateds[idx]),
-                        original_reward=(float(originals[idx]) if emit_original else None),
                     )
                     scores[idx] = 0.0
                     eplens[idx] = 0
-                    if emit_original:
-                        originals[idx] = 0.0
-                        original_present[idx] = False
 
                 if spec.force_reset is not None and monitor_failed:
                     spec.force_reset()
@@ -468,10 +435,13 @@ class RolloutEngine:
             if steps % spec.eval_freq == 0:
                 schedule_eval(steps)
 
-            if steps % log_interval == 0 and eval_result is not None and len(lossque) > 0:
+            if log_due and eval_result is not None and len(lossque) > 0:
                 pbar.set_description(spec.describe(eval_result))
 
         flush_checkpoint_pulses()
+        log_environment_metrics(spec.env, spec.logger_run, steps)
+        while pending_eval_steps:
+            run_eval(pending_eval_steps.popleft())
 
     def _learn_vectorized_device(self, pbar, log_interval, *, checkpointing):
         """Keep same-step autoreset rollouts resident; copy only episode reports."""
@@ -485,21 +455,22 @@ class RolloutEngine:
         eval_result = None
         train_residual = 0
         with jax.default_device(spec.memory_device):
-            zeros = jnp.zeros(spec.worker_size)
             false = jnp.zeros(spec.worker_size, dtype=bool)
-            true = jnp.ones(spec.worker_size, dtype=bool)
-            state = (zeros, jnp.zeros(spec.worker_size, dtype=jnp.int32), zeros, false, false)
+            state = (
+                jnp.zeros(spec.worker_size),
+                jnp.zeros(spec.worker_size, dtype=jnp.int32),
+                false,
+            )
         completed_steps = []
         completed_rows = []
         pending_pulses = deque()
         pending_evals = deque()
+        steps = 0
+        last_log_step = 0
 
         def flush_checkpoint_pulses():
-            nonlocal eval_result
             while pending_pulses:
                 spec.checkpoint_pulse(*pending_pulses.popleft())
-            while pending_evals:
-                eval_result = spec.evaluate(pending_evals.popleft())
 
         def flush_reports():
             if not completed_rows:
@@ -513,7 +484,6 @@ class RolloutEngine:
                     episode_reward=float(row[1]),
                     episode_length=int(row[2]),
                     timeout=float(row[3]),
-                    original_reward=float(row[4]) if row[5] else None,
                 )
             completed_steps.clear()
             completed_rows.clear()
@@ -524,27 +494,21 @@ class RolloutEngine:
             sel = spec.vector_action(obs, steps)
             env.step(sel.env_action)
             flush_checkpoint_pulses()
-            next_obs, rewards, terminated, truncated, infos = env.get_result()
+            next_obs, rewards, terminated, truncated, _ = env.get_result()
+            log_due = steps - last_log_step >= log_interval
+            log_environment_metrics(env, spec.logger_run, steps, flush=log_due)
+            if log_due:
+                last_log_step = steps
+            while pending_evals:
+                eval_result = spec.evaluate(pending_evals.popleft())
             if spec.reward_normalization and spec.record_transition is not None:
                 spec.record_transition(rewards, jnp.logical_or(terminated, truncated))
-            if isinstance(infos, dict):
-                original = zeros
-                if "original_reward" in infos:
-                    original = infos["original_reward"]
-                present = true if "original_reward" in infos else false
-                if "_original_reward" in infos:
-                    present = infos["_original_reward"]
-            else:
-                original, present = extract_vector_original_rewards(infos, spec.worker_size)
             state, _, _, completed = device_episode_step(
                 state,
                 rewards,
                 terminated if not checkpointing or steps > spec.learning_starts else false,
                 truncated if not checkpointing or steps > spec.learning_starts else false,
-                vector_real_reset_mask(env, terminated, truncated, infos),
                 false,
-                original,
-                present,
             )
             if not checkpointing and steps > spec.learning_starts:
                 train_residual += spec.worker_size
@@ -574,7 +538,6 @@ class RolloutEngine:
                         episode_reward=float(rows[worker, 1]),
                         episode_length=int(rows[worker, 2]),
                         timeout=float(rows[worker, 3]),
-                        original_reward=float(rows[worker, 4]) if rows[worker, 5] else None,
                     )
             if not checkpointing:
                 completed_steps.append(steps)
@@ -585,9 +548,12 @@ class RolloutEngine:
                     pending_evals.append(steps)
                 else:
                     eval_result = spec.evaluate(steps)
-            if steps % log_interval == 0:
+            if log_due:
                 flush_reports()
                 if eval_result is not None and lossque:
                     pbar.set_description(spec.describe(eval_result))
         flush_checkpoint_pulses()
         flush_reports()
+        log_environment_metrics(env, spec.logger_run, steps)
+        while pending_evals:
+            eval_result = spec.evaluate(pending_evals.popleft())

--- a/jax_baselines/core/rollout_stats.py
+++ b/jax_baselines/core/rollout_stats.py
@@ -6,9 +6,9 @@ per ``eval_freq``, rollout episodes finish at irregular and (vectorized)
 parallel times, so completed episodes are pushed into a fixed window and the
 window mean is logged periodically.
 
-The tracker is the only ``rollout/`` writer for these families; it reuses the
-shared :func:`jax_baselines.core.eval.log_measurement` tag-writer so the
-``rollout/`` leaves can never drift from the ``eval/`` leaves. The distributed
+The tracker writes algorithm-level episode statistics; environment adapters
+write their own measurements. It reuses the shared
+:func:`jax_baselines.core.eval.log_measurement` tag-writer. The distributed
 families keep their own server-side aggregation and do not use this tracker
 (documented inconsistency, see ADR 0003).
 """
@@ -23,29 +23,22 @@ from jax_baselines.core.eval import log_measurement
 
 
 @jax.jit
-def device_episode_step(
-    state, rewards, terminateds, truncateds, real_reset, autoreset, original, original_present
-):
+def device_episode_step(state, rewards, terminateds, truncateds, autoreset):
     """Accumulate one vector step without transferring episode state to the host.
 
-    State is ``(scores, lengths, originals, seen_original, prev_done)``. Completed
-    rows retain worker order: ``(done, score, length, timeout, original, emit_original)``.
+    State is ``(scores, lengths, prev_done)``. Completed rows retain worker order:
+    ``(done, score, length, timeout)``.
     """
-    scores, lengths, originals, seen_original, prev_done = state
+    scores, lengths, prev_done = state
     active = ~prev_done
     done = (terminateds | truncateds) & active
     scores = scores + jnp.where(active, rewards, 0)
     lengths = lengths + active.astype(lengths.dtype)
-    originals = originals + jnp.where(active & original_present, original, 0)
-    seen_original = seen_original | (active & original_present)
-    emit_original = done & real_reset & seen_original
-    completed = jnp.stack((done, scores, lengths, truncateds, originals, emit_original), axis=-1)
+    completed = jnp.stack((done, scores, lengths, truncateds), axis=-1)
     return (
         (
             jnp.where(done, 0, scores),
             jnp.where(done, 0, lengths),
-            jnp.where(emit_original, 0, originals),
-            seen_original & ~emit_original,
             done & autoreset,
         ),
         jnp.where(prev_done, 0, rewards),
@@ -62,10 +55,8 @@ class EpisodeTracker:
     boundary, so an empty window is never logged). ``K=10`` matches the loss
     ``deque`` convention, trading smoothness for responsiveness.
 
-    The engine that drives the rollout stays logger-free: it only calls
-    :meth:`record`. The ``log_metric`` callable is bound to the active run and
-    the training session releases the tracker before that run's logger leaves
-    scope.
+    The ``log_metric`` callable is bound to the active run and the training
+    session releases the tracker before that run's logger leaves scope.
     """
 
     def __init__(self, log_metric, log_interval, window=10):
@@ -74,26 +65,17 @@ class EpisodeTracker:
         self._reward = deque(maxlen=window)
         self._length = deque(maxlen=window)
         self._timeout = deque(maxlen=window)
-        self._original = deque(maxlen=window)
         self._last_log_step = 0
 
-    def record(self, steps, *, episode_reward, episode_length, timeout, original_reward=None):
+    def record(self, steps, *, episode_reward, episode_length, timeout):
         """Push one completed episode and flush the window if due.
 
-        ``original_reward`` is recorded only when present (Atari unclipped
-        score); ``timeout`` is the per-episode truncation flag (0/1) whose
-        window mean is the truncation rate. Presence is assumed all-or-nothing
-        per run (``ClipRewardEnv`` injects it on every Atari step and never
-        otherwise), so the reward and original-reward windows stay aligned; an
-        intermittently-present ``original_reward`` would let the two windows
-        cover different episode spans.
+        ``timeout`` is the per-episode truncation flag (0/1) whose window mean
+        is the truncation rate.
         """
         self._reward.append(float(episode_reward))
         self._length.append(float(episode_length))
         self._timeout.append(float(timeout))
-        if original_reward is not None:
-            self._original.append(float(original_reward))
-
         if steps - self._last_log_step >= self._log_interval:
             self._flush(steps)
             self._last_log_step = steps
@@ -101,7 +83,6 @@ class EpisodeTracker:
     def _flush(self, steps):
         if not self._reward:
             return
-        original = float(np.mean(self._original)) if self._original else None
         log_measurement(
             self._log_metric,
             "rollout",
@@ -109,7 +90,6 @@ class EpisodeTracker:
             episode_reward=float(np.mean(self._reward)),
             episode_length=float(np.mean(self._length)),
             timeout_rate=float(np.mean(self._timeout)),
-            original_reward=original,
         )
 
     def describe(self):

--- a/tests/test_device_rollout_stats.py
+++ b/tests/test_device_rollout_stats.py
@@ -9,23 +9,14 @@ def test_device_episode_stats_preserve_lifeloss_dummy_steps_and_batched_logging(
     state = (
         jnp.zeros(2),
         jnp.zeros(2, dtype=jnp.int32),
-        jnp.zeros(2),
-        jnp.zeros(2, dtype=bool),
         jnp.zeros(2, dtype=bool),
     )
     # A life loss, real episode ends, poisoned reset dummies, then same-step resets.
     rewards = jnp.array([[1, 10], [2, 20], [999, 888], [3, 30], [4, 40]], dtype=jnp.float32)
     terminated = jnp.array([[1, 0], [1, 0], [1, 0], [1, 1], [1, 1]], dtype=bool)
     truncated = jnp.array([[0, 0], [0, 1], [0, 1], [0, 0], [0, 0]], dtype=bool)
-    real_reset = jnp.array([[0, 0], [1, 1], [1, 1], [1, 1], [1, 1]], dtype=bool)
     autoreset = jnp.array([[0, 0], [1, 1], [1, 1], [0, 0], [0, 0]], dtype=bool)
-    original = jnp.array(
-        [[100, 1000], [200, 2000], [99999, 88888], [300, 0], [0, 0]], dtype=jnp.float32
-    )
-    original_present = jnp.array([[1, 1], [1, 1], [1, 1], [1, 0], [0, 0]], dtype=bool)
-    step_inputs = list(
-        zip(rewards, terminated, truncated, real_reset, autoreset, original, original_present)
-    )
+    step_inputs = list(zip(rewards, terminated, truncated, autoreset))
     completed_steps = []
     corrected_rewards = []
     corrected_terminated = []
@@ -46,38 +37,34 @@ def test_device_episode_stats_preserve_lifeloss_dummy_steps_and_batched_logging(
     logs = []
     tracker = EpisodeTracker(lambda *args: logs.append(args), log_interval=2, window=3)
     for step, completed in enumerate(jax.device_get(completed_batch)):
-        for done, score, length, timeout, original_score, emit_original in completed:
+        for done, score, length, timeout in completed:
             if not done:
                 continue
-            observed.append(
-                (step * 2, score, length, timeout, original_score if emit_original else None)
-            )
+            observed.append((step * 2, score, length, timeout))
             tracker.record(
                 step * 2,
                 episode_reward=score,
                 episode_length=length,
                 timeout=timeout,
-                original_reward=original_score if emit_original else None,
             )
     expected = [
-        (0, 1, 1, 0, None),
-        (2, 2, 1, 0, 300),
-        (2, 30, 2, 1, 3000),
-        (6, 3, 1, 0, 300),
-        (6, 30, 1, 0, None),
-        (8, 4, 1, 0, None),
-        (8, 40, 1, 0, None),
+        (0, 1, 1, 0),
+        (2, 2, 1, 0),
+        (2, 30, 2, 1),
+        (6, 3, 1, 0),
+        (6, 30, 1, 0),
+        (8, 4, 1, 0),
+        (8, 40, 1, 0),
     ]
     assert observed == expected
     reference_logs = []
     reference = EpisodeTracker(lambda *args: reference_logs.append(args), log_interval=2, window=3)
-    for step, score, length, timeout, original_score in expected:
+    for step, score, length, timeout in expected:
         reference.record(
             step,
             episode_reward=score,
             episode_length=length,
             timeout=timeout,
-            original_reward=original_score,
         )
     assert logs == reference_logs
     assert tracker.describe() == reference.describe()

--- a/tests/test_experiment_env_lifecycle.py
+++ b/tests/test_experiment_env_lifecycle.py
@@ -23,6 +23,7 @@ class _MjlabEnv(MjlabSingleEnv):
         self.steps = steps
         self.frame = 0
         self.closed = False
+        self.log_calls = []
 
     def reset(self):
         self.frame = 0
@@ -36,6 +37,9 @@ class _MjlabEnv(MjlabSingleEnv):
     def render(self):
         return np.full((16, 16, 3), self.frame, dtype=np.uint8)
 
+    def log_metrics(self, logger, steps, *, namespace="rollout", active=None, flush=True):
+        self.log_calls.append((logger, namespace, flush))
+
     def close(self):
         self.closed = True
 
@@ -48,12 +52,14 @@ def test_headless_test_never_requests_rendering_and_always_closes(monkeypatch):
         calls.append((worker, kwargs))
         return env
 
-    monkeypatch.setattr(adapters, "run_test_episodes", lambda *args: calls.append("run") or 3)
+    monkeypatch.setattr(
+        adapters, "run_test_episodes", lambda *args, **kwargs: calls.append("run") or 3
+    )
     assert adapters.headless_test(builder, None, object(), 2) == 3
     assert calls == [(1, {}), "run", "close"]
 
     monkeypatch.setattr(
-        adapters, "run_test_episodes", lambda *args: (_ for _ in ()).throw(ValueError())
+        adapters, "run_test_episodes", lambda *args, **kwargs: (_ for _ in ()).throw(ValueError())
     )
     with pytest.raises(ValueError):
         adapters.headless_test(builder, None, object(), 2)
@@ -79,6 +85,7 @@ def test_record_and_test_writes_one_mjlab_video_per_episode(tmp_path):
         "rl-video-episode-1.mp4",
     ]
     assert [imageio_ffmpeg.count_frames_and_secs(video)[0] for video in videos] == [3, 3]
+    assert env.log_calls == [(logger, "test", False)] * 4 + [(logger, "test", True)]
     assert env.closed
 
 
@@ -87,7 +94,7 @@ def test_record_and_test_closes_mjlab_env_when_evaluation_fails(monkeypatch, tmp
     env = _MjlabEnv()
     logger = type("Logger", (), {"get_local_path": lambda self, path: str(tmp_path / path)})()
 
-    def fail_after_reset(test_env, *args):
+    def fail_after_reset(test_env, *args, **kwargs):
         test_env.reset()
         raise RuntimeError("evaluation failed")
 

--- a/tests/test_review_replay_env_regressions.py
+++ b/tests/test_review_replay_env_regressions.py
@@ -1,3 +1,4 @@
+import gymnasium as gym
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -132,15 +133,18 @@ def test_gym_vector_fast_path_honors_seed():
 def test_single_gym_env_exposes_normalized_continuous_actions():
     builder, _ = get_env_builder("Pendulum-v1")
     env = builder(worker=1, seed=7)
+    reference = gym.make("Pendulum-v1")
     try:
         assert np.array_equal(env.action_space.low, np.array([-1.0], dtype=np.float32))
         assert np.array_equal(env.action_space.high, np.array([1.0], dtype=np.float32))
-        assert np.array_equal(
-            env.action(np.array([1.0], dtype=np.float32)),
-            np.array([2.0], dtype=np.float32),
-        )
+        reference.reset(seed=7)
+        observation, reward, *_ = env.step(np.array([1.0], dtype=np.float32))
+        expected, expected_reward, *_ = reference.step(np.array([2.0], dtype=np.float32))
+        assert np.array_equal(observation["unified_obs"], expected)
+        assert reward == expected_reward
     finally:
         env.close()
+        reference.close()
 
 
 def test_gym_vector_env_exposes_normalized_continuous_actions():

--- a/tests/test_rollout_stats.py
+++ b/tests/test_rollout_stats.py
@@ -4,8 +4,7 @@ Two layers:
 
 - :class:`jax_baselines.core.rollout_stats.EpisodeTracker` windowing: the
   window mean is logged under the ``rollout/`` prefix, throttled to
-  ``log_interval`` and skipping an empty window, with ``original_reward`` only
-  when supplied.
+  ``log_interval`` and skipping an empty window.
 - The :class:`jax_baselines.core.rollout.RolloutEngine` episode-end emit: the
   four loops hand each *completed* training episode to the
   ``record_rollout_episode`` callback, and the autoreset dummy step is never
@@ -13,9 +12,11 @@ Two layers:
 """
 
 import inspect
+from dataclasses import replace
 
 import numpy as np
 
+from env_builder.metrics import GymEnvMetrics
 from jax_baselines.core.rollout import ActionSelection, RolloutEngine, RolloutSpec
 from jax_baselines.core.rollout_stats import EpisodeTracker
 
@@ -25,8 +26,10 @@ class _RecordingLog:
     def __init__(self):
         self.calls = []
 
-    def __call__(self, key, value, step):
+    def __call__(self, key, value, step=None):
         self.calls.append((key, round(float(value), 4), step))
+
+    log_metric = __call__
 
     def keyed(self, key):
         return [(c[1], c[2]) for c in self.calls if c[0] == key]
@@ -71,28 +74,6 @@ def test_tracker_windows_last_k_only():
     assert log.keyed("rollout/episode_reward")[-1] == (30.0, 4)
 
 
-def test_tracker_original_reward_only_when_present():
-    log = _RecordingLog()
-    tracker = EpisodeTracker(log, log_interval=1)
-    tracker.record(1, episode_reward=1.0, episode_length=1, timeout=0.0)
-    assert log.keyed("rollout/original_reward") == []
-
-    tracker.record(2, episode_reward=1.0, episode_length=1, timeout=0.0, original_reward=42.0)
-    assert log.keyed("rollout/original_reward") == [(42.0, 2)]
-
-
-def test_tracker_throttles_original_reward_with_other_rollout_metrics():
-    log = _RecordingLog()
-    tracker = EpisodeTracker(log, log_interval=100)
-
-    tracker.record(150, episode_reward=1.0, episode_length=1, timeout=0.0, original_reward=10.0)
-    tracker.record(160, episode_reward=1.0, episode_length=1, timeout=0.0, original_reward=42.0)
-    tracker.record(260, episode_reward=1.0, episode_length=1, timeout=0.0, original_reward=62.0)
-
-    assert log.keyed("rollout/episode_reward") == [(1.0, 150), (1.0, 260)]
-    assert log.keyed("rollout/original_reward") == [(10.0, 150), (38.0, 260)]
-
-
 def test_tracker_describe_is_empty_until_first_episode():
     log = _RecordingLog()
     tracker = EpisodeTracker(log, log_interval=100)
@@ -109,6 +90,8 @@ class _ScriptedSingleEnv:
         self.script = script  # list of (reward, terminated, truncated)
         self.infos = infos if infos is not None else [{}] * len(script)
         self.t = 0
+        self.metrics = GymEnvMetrics(1)
+        self.log = _RecordingLog()
 
     def reset(self):
         return {"unified_obs": np.zeros(1, dtype=np.float32)}, {}
@@ -117,7 +100,25 @@ class _ScriptedSingleEnv:
         reward, terminated, truncated = self.script[self.t]
         info = self.infos[self.t]
         self.t += 1
-        return {"unified_obs": np.zeros(1, dtype=np.float32)}, reward, terminated, truncated, info
+        real_reset = terminated or truncated
+        if "real_episode_end" in info:
+            real_reset = bool(info["real_episode_end"])
+        self.metrics.capture(
+            info,
+            terminated or truncated,
+            real_reset,
+            False,
+        )
+        return (
+            {"unified_obs": np.zeros(1, dtype=np.float32)},
+            reward,
+            terminated,
+            truncated,
+            info,
+        )
+
+    def log_metrics(self, logger, steps, *, namespace="rollout", active=None, flush=True):
+        self.metrics.log(logger, steps, namespace=namespace, active=active, flush=flush)
 
 
 class _ScriptedVecEnv:
@@ -126,6 +127,8 @@ class _ScriptedVecEnv:
         self.infos = infos if infos is not None else [{}] * len(script)
         self.ws = worker_size
         self.i = 0
+        self.metrics = GymEnvMetrics(worker_size)
+        self.log = _RecordingLog()
 
     def current_obs(self):
         return {"unified_obs": np.zeros((self.ws, 1), dtype=np.float32)}
@@ -137,6 +140,12 @@ class _ScriptedVecEnv:
         rewards, terminateds, truncateds = self.script[self.i]
         infos = self.infos[self.i]
         self.i += 1
+        self.metrics.capture(
+            infos,
+            terminateds | truncateds,
+            self.real_reset_mask(terminateds, truncateds, infos),
+            self.autoreset_mask(terminateds, truncateds, infos),
+        )
         return (
             {"unified_obs": np.zeros((self.ws, 1), dtype=np.float32)},
             rewards,
@@ -155,6 +164,9 @@ class _ScriptedVecEnv:
 
     def autoreset_mask(self, terminateds, truncateds, infos):
         return self.real_reset_mask(terminateds, truncateds, infos)
+
+    def log_metrics(self, logger, steps, *, namespace="rollout", active=None, flush=True):
+        self.metrics.log(logger, steps, namespace=namespace, active=active, flush=flush)
 
 
 class _NoopBuffer:
@@ -179,14 +191,13 @@ def test_rollout_engine_keeps_legacy_callback_signature():
 def _episode_recorder():
     records = []
 
-    def record(steps, *, episode_reward, episode_length, timeout, original_reward=None):
+    def record(steps, *, episode_reward, episode_length, timeout):
         records.append(
             {
                 "steps": steps,
                 "reward": round(float(episode_reward), 4),
                 "length": int(episode_length),
                 "timeout": float(timeout),
-                "original": original_reward,
             }
         )
 
@@ -196,28 +207,30 @@ def _episode_recorder():
 def _spec(env, record, **overrides):
     """Minimal RolloutSpec whose train/eval cadence never fires, isolating the
     episode-record emit."""
-    base = dict(
-        env=env,
-        replay_buffer=_NoopBuffer(),
-        learning_starts=10**9,
-        train_freq=1,
-        gradient_steps=1,
-        eval_freq=10**9,
-        worker_size=env.ws,
-        single_action=lambda obs, steps: ActionSelection(0, 0),
-        vector_action=lambda obs, steps: ActionSelection(0, 0),
-        refresh_exploration=lambda steps: None,
-        force_reset=None,
-        train=lambda steps, gs: 0.0,
-        evaluate=lambda steps: None,
-        describe=lambda eval_result: "desc",
-        bind_loss_window=lambda window: None,
-        record_rollout_episode=record,
-        checkpoint_on_episode_end=lambda *a, **k: True,
-        checkpoint_pulse=lambda *a, **k: None,
+    return replace(
+        RolloutSpec(
+            env=env,
+            logger_run=env.log,
+            replay_buffer=_NoopBuffer(),
+            learning_starts=10**9,
+            train_freq=1,
+            gradient_steps=1,
+            eval_freq=10**9,
+            worker_size=env.ws,
+            single_action=lambda obs, steps: ActionSelection(0, 0),
+            vector_action=lambda obs, steps: ActionSelection(0, 0),
+            refresh_exploration=lambda steps: None,
+            force_reset=None,
+            train=lambda steps, gs: 0.0,
+            evaluate=lambda steps: None,
+            describe=lambda eval_result: "desc",
+            bind_loss_window=lambda window: None,
+            record_rollout_episode=record,
+            checkpoint_on_episode_end=lambda *a, **k: True,
+            checkpoint_pulse=lambda *a, **k: None,
+        ),
+        **overrides,
     )
-    base.update(overrides)
-    return RolloutSpec(**base)
 
 
 def test_single_env_emits_completed_episode_records():
@@ -239,7 +252,7 @@ def test_single_env_emits_completed_episode_records():
     ]
 
 
-def test_single_env_accumulates_original_reward():
+def test_single_env_logs_adapter_original_reward():
     env = _ScriptedSingleEnv(
         [(1.0, False, False), (1.0, True, False)],
         infos=[{"original_reward": 10.0}, {"original_reward": 20.0}],
@@ -248,7 +261,7 @@ def test_single_env_accumulates_original_reward():
     RolloutEngine(_spec(env, record)).learn_single_env(range(2), log_interval=10**9)
 
     assert len(records) == 1
-    assert records[0]["original"] == 30.0
+    assert env.log.keyed("rollout/original_reward") == [(30.0, 1)]
 
 
 def test_single_env_original_reward_waits_for_real_episode_end():
@@ -262,10 +275,8 @@ def test_single_env_original_reward_waits_for_real_episode_end():
     records, record = _episode_recorder()
     RolloutEngine(_spec(env, record)).learn_single_env(range(2), log_interval=10**9)
 
-    assert [(r["reward"], r["original"]) for r in records] == [
-        (1.0, None),
-        (1.0, 30.0),
-    ]
+    assert [r["reward"] for r in records] == [1.0, 1.0]
+    assert env.log.keyed("rollout/original_reward") == [(30.0, 1)]
 
 
 def test_vectorized_env_excludes_autoreset_dummy_step():
@@ -351,7 +362,8 @@ def test_vectorized_env_accumulates_original_reward_from_dict_infos():
     records, record = _episode_recorder()
     RolloutEngine(_spec(env, record)).learn_vectorized_env(range(2), log_interval=10**9)
 
-    assert [(r["reward"], r["original"]) for r in records] == [(2.0, 40.0), (4.0, 60.0)]
+    assert [r["reward"] for r in records] == [2.0, 4.0]
+    assert env.log.keyed("rollout/original_reward") == [(50.0, 1)]
 
 
 def test_vectorized_env_respects_original_reward_presence_mask():
@@ -384,7 +396,8 @@ def test_vectorized_env_respects_original_reward_presence_mask():
     records, record = _episode_recorder()
     RolloutEngine(_spec(env, record)).learn_vectorized_env(range(2), log_interval=10**9)
 
-    assert [(r["reward"], r["original"]) for r in records] == [(2.0, 40.0), (4.0, None)]
+    assert [r["reward"] for r in records] == [2.0, 4.0]
+    assert env.log.keyed("rollout/original_reward") == [(40.0, 1)]
 
 
 def test_vectorized_env_original_reward_waits_for_zero_lives():
@@ -425,10 +438,8 @@ def test_vectorized_env_original_reward_waits_for_zero_lives():
     records, record = _episode_recorder()
     RolloutEngine(_spec(env, record)).learn_vectorized_env(range(3), log_interval=10**9)
 
-    assert [(r["reward"], r["original"]) for r in records] == [
-        (1.0, None),
-        (6.0, 530.0),
-    ]
+    assert [r["reward"] for r in records] == [1.0, 6.0]
+    assert env.log.keyed("rollout/original_reward") == [(530.0, 2)]
 
 
 def test_single_env_checkpointing_emits_after_learning_starts():
@@ -555,4 +566,5 @@ def test_vectorized_checkpointing_accumulates_original_reward_from_per_worker_in
         range(4), log_interval=10**9
     )
 
-    assert [(r["reward"], r["original"]) for r in records] == [(2.0, 30.0), (1.0, 30.0)]
+    assert [r["reward"] for r in records] == [2.0, 1.0]
+    assert env.log.keyed("rollout/original_reward") == [(30.0, 3)]

--- a/tests/test_vectorized_env_fixes.py
+++ b/tests/test_vectorized_env_fixes.py
@@ -191,6 +191,7 @@ def _fake_recv_env(is_atari):
     env._is_atari = is_atari
     env._observation_key = None
     env.worker_num = 2
+    env._metrics = eb.GymEnvMetrics(2, "reward" if is_atari else "original_reward")
     env.obs = None
     env._awaiting_recv = True
     next_obs = np.zeros((2, 4), dtype=np.float32)
@@ -205,12 +206,15 @@ def _fake_recv_env(is_atari):
     return env, infos
 
 
-def test_envpool_atari_exposes_info_reward_as_original_reward():
+def test_envpool_atari_logs_backend_reward_as_original_reward():
     env, infos = _fake_recv_env(is_atari=True)
 
     _, _, _, _, result_infos = env.get_result()
+    logged = []
+    env.log_metrics(SimpleNamespace(log_metric=lambda *args: logged.append(args)), 10)
 
-    assert np.array_equal(result_infos["original_reward"], infos["reward"])
+    assert logged == [("rollout/original_reward", -2.0, 10)]
+    assert "original_reward" not in result_infos
     assert "original_reward" not in infos
 
 
@@ -270,6 +274,7 @@ def test_envpool_get_result_resorts_recv_into_canonical_env_order():
     env._is_atari = False
     env._observation_key = None
     env.worker_num = 3
+    env._metrics = eb.GymEnvMetrics(3)
     env.obs = None
     env._awaiting_recv = True
     # Row r belongs to env env_id[r]; values encode the owning env so the


### PR DESCRIPTION
Gym·EnvPool의 Atari 원본 보상 처리를 환경 어댑터로 옮기고, rollout·평가·test·video가 공통 환경 로깅 계약을 사용하도록 변경합니다. 알고리즘 코어의 원본 보상 및 실제 에피소드 종료 판별 경로를 제거하고 기존 테스트를 새 계약으로 이관합니다.

검증: 관련 테스트 127개 통과. 실제 Atari Gym 단일·벡터 환경과 EnvPool 실행에서 rollout/eval/test 원본 보상 기록을 확인했습니다. 변경 파일 lint/type 진단은 기준 커밋 대비 새 오류 없이 감소했습니다.

선행 PR: https://github.com/tinker495/jax-baseline/pull/41. 이 PR은 선행 브랜치를 base로 사용하므로 이번 단계의 변경만 표시됩니다.

