### PR TITLE
mjlab term·curriculum 로깅과 지연 전송 지원

### DIFF
--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 from gymnasium import spaces
 
+from env_builder.metrics import EnvMetrics, metric_leaves
 from env_builder.observations import _to_numpy, normalize_observation
 from jax_baselines.core.env_protocols import (
     EnvInfo,
@@ -19,6 +20,7 @@ from jax_baselines.core.env_protocols import (
     SingleEnv,
     VectorizedEnv,
 )
+from jax_baselines.core.runtime_adapters import MetricLogger
 
 Array: TypeAlias = np.ndarray | jax.Array
 
@@ -114,9 +116,12 @@ class MjlabVectorizedEnv(VectorizedEnv):
         if self._pending is not None:
             raise RuntimeError("reset() called while a step is in flight")
         self._frame = None
+        self._metrics = EnvMetrics(array_converter=_to_numpy)
         observation, info = self.env.reset(seed=seed)
         self._obs = self._selected(observation)
-        return self._obs, self._snapshot(info)
+        return self._obs, self._snapshot(
+            {key: value for key, value in info.items() if key != "log"}
+        )
 
     def current_obs(self) -> Observation:
         return self._obs
@@ -130,14 +135,16 @@ class MjlabVectorizedEnv(VectorizedEnv):
             raise RuntimeError("Cannot evaluate a closed environment")
         from env_builder.mjlab_state import preserve_mjlab_state
 
-        observation, frame, pending = self._obs, self._frame, self._pending
+        observation, frame, pending, metrics = self._obs, self._frame, self._pending, self._metrics
         with preserve_mjlab_state(self.env):
             # mjlab.step has finished; _pending contains copied transition data.
             self._pending = None
+            self._metrics = EnvMetrics(array_converter=_to_numpy)
             try:
                 yield
             finally:
                 self._obs, self._frame, self._pending = observation, frame, pending
+                self._metrics = metrics
 
     def get_info(self) -> EnvInfo:
         return self.env_info
@@ -155,6 +162,7 @@ class MjlabVectorizedEnv(VectorizedEnv):
             raise ValueError(f"Expected actions with shape {expected}, got {actions.shape}")
         actions = actions.to(dtype=self._torch.float32, device=self.env.device)
         observation, reward, terminated, truncated, info = self.env.step(actions)
+        self._record_metrics(info["log"])
         if self.env.render_mode == "rgb_array":
             self._frame = np.array(self.env.render(), copy=True)
         # Snapshot terminal data before partial reset mutates simulator buffers.
@@ -163,10 +171,11 @@ class MjlabVectorizedEnv(VectorizedEnv):
         reward = self._array(reward)
         terminated = self._array(terminated).astype(bool)
         truncated = self._array(truncated).astype(bool)
-        info = self._snapshot(info)
+        info = self._snapshot({key: value for key, value in info.items() if key != "log"})
         self._obs = successor
         if done_ids.numel():
-            current, _ = self.env.reset(env_ids=done_ids)
+            current, reset_info = self.env.reset(env_ids=done_ids)
+            self._record_metrics(reset_info["log"])
             # Only replace reset rows: a partial reset may recompute noisy observations.
             current = self._selected(current)
             array_module = jnp if self.jax_arrays else np
@@ -186,6 +195,38 @@ class MjlabVectorizedEnv(VectorizedEnv):
             raise RuntimeError("get_result() called without a preceding step()")
         result, self._pending = self._pending, None
         return result
+
+    def _record_metrics(self, values: Mapping[str, Any]) -> None:
+        native: dict[Any, dict[str, Any]] = {}
+        scalars = {}
+        for name, value in metric_leaves(values).items():
+            if not isinstance(value, self._torch.Tensor):
+                scalars[name] = value
+                continue
+            if not value.numel() or value.is_complex():
+                raise ValueError(f"Environment metric {name!r} must contain real numeric values")
+            if value.device not in native:
+                native[value.device] = {}
+            native[value.device][name] = (
+                value.detach() if value.ndim == 0 else value.detach().float().mean()
+            )
+        for tensors in native.values():
+            self._metrics.add_batch(tuple(tensors), self._torch.stack(tuple(tensors.values())))
+        self._metrics.add(scalars)
+
+    def log_metrics(
+        self,
+        logger: MetricLogger,
+        steps: int | None,
+        *,
+        namespace: str = "rollout",
+        active: Any = None,
+        flush: bool = True,
+    ) -> None:
+        """Average fresh native log events, already reduced over their reset cohorts."""
+        del active
+        if flush:
+            self._metrics.log(logger, steps, namespace)
 
     def real_reset_mask(self, terminateds, truncateds, infos):
         del infos
@@ -258,6 +299,17 @@ class MjlabSingleEnv(SingleEnv):
         if self._vector._frame is not None:
             return self._vector._frame
         return self._vector.env.render()
+
+    def log_metrics(
+        self,
+        logger: MetricLogger,
+        steps: int | None,
+        *,
+        namespace: str = "rollout",
+        active: Any = None,
+        flush: bool = True,
+    ) -> None:
+        self._vector.log_metrics(logger, steps, namespace=namespace, active=active, flush=flush)
 
     def close(self) -> None:
         self._vector.close()

--- a/tests/test_mjlab_env_adapter.py
+++ b/tests/test_mjlab_env_adapter.py
@@ -1,6 +1,7 @@
 import builtins
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -26,11 +27,19 @@ class FakeEnv:
         self.rewards = torch.zeros(self.num_envs)
         self.terminated = torch.zeros(self.num_envs, dtype=torch.bool)
         self.truncated = self.terminated.clone()
+        self.extras = {}
         self.resets, self.closed = [], 0
 
     def reset(self, *, seed=None, env_ids=None):
         self.resets.append((seed, env_ids))
         ids = torch.arange(self.num_envs) if env_ids is None else env_ids
+        self.extras["log"] = {
+            "Episode_Reward/action": self.rewards[ids].mean(),
+            "Episode_Termination/terminated": self.terminated[ids].count_nonzero().item(),
+            "Episode_Metrics/action": self.rewards[ids].abs().mean(),
+            "Curriculum/stage": 2.0,
+            "Metrics/twist/error": 0.25,
+        }
         self.obs[ids] = 0 if seed is None else seed
         self.critic_obs[ids] = 100 if seed is None else seed + 100
         self.rewards[ids] = 0
@@ -40,7 +49,7 @@ class FakeEnv:
             "actor": {"state": self.obs},
             "critic": self.critic_obs,
             "command": self.obs + 5,
-        }, {}
+        }, self.extras
 
     def step(self, actions):
         self.obs += 1
@@ -48,12 +57,14 @@ class FakeEnv:
         self.rewards[:] = actions[:, 0]
         self.terminated[:] = actions[:, 0] < 0
         self.truncated[:] = actions[:, 0] > 1
+        self.extras["metric"] = self.rewards
+        self.extras["log"] = {"Metrics/action_mean": self.rewards.mean()}
         return (
             {"actor": {"state": self.obs}, "critic": self.critic_obs, "command": self.obs + 5},
             self.rewards,
             self.terminated,
             self.truncated,
-            {"metric": self.rewards},
+            self.extras,
         )
 
     def render(self):
@@ -122,6 +133,16 @@ def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch
     np.testing.assert_array_equal(env.current_obs()["unified_command"], [[5], [5], [13]])
     np.testing.assert_array_equal(reward, [-1, 2, 1])
     np.testing.assert_array_equal(info["metric"], reward)
+    assert "log" not in info
+    logged = {}
+
+    class Logger:
+        def log_metric(self, key: str, value: Any, step: int | None = None) -> None:
+            logged[key] = (value, step)
+
+    logger = Logger()
+    env.log_metrics(logger, 3, flush=False)
+    assert not logged
     np.testing.assert_array_equal(terminated, [True, False, False])
     np.testing.assert_array_equal(truncated, [False, True, False])
     np.testing.assert_array_equal(env.env.resets[-1][1], [0, 1])
@@ -131,6 +152,18 @@ def test_vector_factory_and_terminal_snapshots_survive_partial_reset(monkeypatch
     assert not env.autoreset_mask(terminated, truncated, {}).any()
     env.step(jnp.zeros((3, 1)) if jax_arrays else np.zeros((3, 1)))
     env.get_result()
+    env.log_metrics(logger, 6)
+    assert logged == {
+        "rollout/Metrics/action_mean": (pytest.approx(1 / 3), 6),
+        "rollout/Episode_Reward/action": (pytest.approx(0.5), 6),
+        "rollout/Episode_Metrics/action": (pytest.approx(1.5), 6),
+        "rollout/Episode_Termination/terminated": (1, 6),
+        "rollout/Curriculum/stage": (2, 6),
+        "rollout/Metrics/twist/error": (0.25, 6),
+    }
+    logged.clear()
+    env.log_metrics(logger, 7)
+    assert not logged
     np.testing.assert_array_equal(obs["actor_state"], [[8], [8], [8]])
     np.testing.assert_array_equal(reward, [-1, 2, 1])
     np.testing.assert_array_equal(info["metric"], [-1, 2, 1])


### PR DESCRIPTION
mjlab이 step/reset에서 제공하는 숫자형 `info.log` 항목을 공통 환경 로깅 경로에 수집해 reward term·curriculum 등 환경 지표를 기록합니다. 장치 위에서 누적한 값을 flush 시점에 묶어 전송하고, 평가에 환경을 재사용할 때 학습 지표가 섞이지 않게 처리합니다.

검증: mjlab 어댑터 테스트 12개 및 변경 파일 lint/type 검사 통과. 실제 CPU Go1 PPO 실행에서 지표 7개가 88개로 늘었고, 기존 7개 시계열은 동일하며 모든 값이 유한했습니다. CUDA 실행 성능은 이 CLI 검증에 포함하지 않았습니다.

선행 PR: https://github.com/tinker495/jax-baseline/pull/42. 이 PR은 선행 브랜치를 base로 사용하므로 이번 단계의 변경만 표시됩니다.

