### PR TITLE
APE-X·IMPALA worker 환경 지표 로깅 통합

### DIFF
--- a/jax_baselines/APE_X/common_servers.py
+++ b/jax_baselines/APE_X/common_servers.py
@@ -16,6 +16,17 @@ class Param_server:
         self.params = params
 
 
+class WorkerMetricLogger:
+    """Collect environment metrics for one worker's next episode report."""
+
+    def __init__(self, suffix: str = "") -> None:
+        self.suffix = suffix
+        self.metrics: dict[str, float] = {}
+
+    def log_metric(self, key: str, value: float, step: int | None = None) -> None:
+        self.metrics[f"{key}{self.suffix}"] = float(value)
+
+
 class Logger_server:
     def __init__(
         self, log_dir, log_name, experiment_name="experiment", logger_factory=None
@@ -27,7 +38,7 @@ class Logger_server:
         self.logger = logger_factory(log_name, experiment_name, log_dir, None)
         self.step = 0
         self.old_step = 0
-        self.save_dict = dict()
+        self.save_dict = {}
         with self.logger as run:
             self.save_path = os.path.normpath(run.get_local_path(""))
 
@@ -49,7 +60,7 @@ class Logger_server:
             with self.logger as run:
                 for key, value in self.save_dict.items():
                     run.log_metric(key, np.mean(value), self.step)
-                self.save_dict = dict()
+                self.save_dict = {}
                 self.old_step = self.step
         for key, value in log_dict.items():
             if key in self.save_dict:

--- a/jax_baselines/APE_X/dpg_worker.py
+++ b/jax_baselines/APE_X/dpg_worker.py
@@ -2,8 +2,9 @@ from functools import partial
 
 import jax
 
+from jax_baselines.APE_X.common_servers import WorkerMetricLogger
 from jax_baselines.core.env_info import prepare_worker_env
-from jax_baselines.core.env_protocols import batch_observation
+from jax_baselines.core.env_protocols import batch_observation, log_environment_metrics
 from jax_baselines.core.replay_protocol import make_worker_local_replay_buffer
 from jax_baselines.core.seeding import seed_prngs
 
@@ -65,6 +66,7 @@ class Ape_X_Worker:
             params = jax.device_put(param_server.get_params())
             eplen = 0
             episode = 0
+            environment_logger = WorkerMetricLogger("" if eps is None else f"/eps{eps:.2f}")
             if eps is None:
                 rw_label = "rollout/episode_reward"
                 len_label = "rollout/episode_length"
@@ -85,6 +87,13 @@ class Ape_X_Worker:
                 next_obs, reward, terminated, truncated, _info = self.env.step(actions)
                 next_obs = batch_observation(next_obs)
                 local_buffer.add(obs, actions, reward, next_obs, terminated, truncated)
+                if logger_server is not None:
+                    log_environment_metrics(
+                        self.env,
+                        environment_logger,
+                        episode,
+                        flush=bool(terminated or truncated),
+                    )
                 score += reward
                 obs = next_obs
 
@@ -94,11 +103,13 @@ class Ape_X_Worker:
                     obs = batch_observation(obs)
                     if logger_server is not None:
                         log_dict = {
+                            **environment_logger.metrics,
                             rw_label: score,
                             len_label: eplen,
                             to_label: float(truncated),
                         }
                         logger_server.log_worker(log_dict, episode)
+                        environment_logger.metrics.clear()
                     score = 0
                     eplen = 0
                     episode += 1
@@ -113,6 +124,10 @@ class Ape_X_Worker:
                         key=next(key_seq),
                     )
                     global_buffer.add(**transition, priorities=abs_td_error)
+            if logger_server is not None:
+                log_environment_metrics(self.env, environment_logger, episode)
+                if environment_logger.metrics:
+                    logger_server.log_worker(environment_logger.metrics, episode)
         finally:
             if stop.is_set():
                 print("worker stopped")

--- a/jax_baselines/APE_X/worker.py
+++ b/jax_baselines/APE_X/worker.py
@@ -2,13 +2,14 @@ from functools import partial
 
 import jax
 
+from jax_baselines.APE_X.common_servers import WorkerMetricLogger
 from jax_baselines.core.env_info import prepare_worker_env
-from jax_baselines.core.env_protocols import batch_observation
+from jax_baselines.core.env_protocols import batch_observation, log_environment_metrics
 from jax_baselines.core.replay_protocol import make_worker_local_replay_buffer
 from jax_baselines.core.seeding import seed_prngs
 
 
-class Ape_X_Worker(object):
+class Ape_X_Worker:
     def __init__(self, env_builder, seed=None) -> None:
         seed_prngs(seed)
         # env_builder is the repo-local Environment Adapter callable injected by
@@ -54,30 +55,23 @@ class Ape_X_Worker(object):
 
             if seed is not None:
                 try:
-                    obs, info = self.env.reset(seed=seed)
+                    obs, _info = self.env.reset(seed=seed)
                 except TypeError:
-                    obs, info = self.env.reset()
+                    obs, _info = self.env.reset()
             else:
-                obs, info = self.env.reset()
-            have_original_reward = "original_reward" in info.keys()
-            have_lives = "lives" in info.keys()
-            if have_original_reward:
-                original_score = 0
+                obs, _info = self.env.reset()
             score = 0
             obs = batch_observation(obs)
             params = jax.device_put(param_server.get_params())
             eplen = 0
             episode = 0
+            environment_logger = WorkerMetricLogger("" if eps is None else f"/eps{eps:.2f}")
             if eps is None:
                 rw_label = "rollout/episode_reward"
-                if have_original_reward:
-                    original_rw_label = "rollout/original_reward"
                 len_label = "rollout/episode_length"
                 to_label = "rollout/timeout_rate"
             else:
                 rw_label = f"rollout/episode_reward/eps{eps:.2f}"
-                if have_original_reward:
-                    original_rw_label = f"rollout/original_reward/eps{eps:.2f}"
                 len_label = f"rollout/episode_length/eps{eps:.2f}"
                 to_label = f"rollout/timeout_rate/eps{eps:.2f}"
 
@@ -89,11 +83,16 @@ class Ape_X_Worker(object):
 
                 eplen += 1
                 actions = get_action(params, obs, eps, next(key_seq))
-                next_obs, reward, terminated, truncated, info = self.env.step(actions)
+                next_obs, reward, terminated, truncated, _info = self.env.step(actions)
                 next_obs = batch_observation(next_obs)
                 local_buffer.add(obs, actions, reward, next_obs, terminated, truncated)
-                if have_original_reward:
-                    original_score += info["original_reward"]
+                if logger_server is not None:
+                    log_environment_metrics(
+                        self.env,
+                        environment_logger,
+                        episode,
+                        flush=bool(terminated or truncated),
+                    )
                 score += reward
                 obs = next_obs
 
@@ -101,18 +100,17 @@ class Ape_X_Worker(object):
                     local_buffer.episode_end()
                     if logger_server is not None:
                         log_dict = {
+                            **environment_logger.metrics,
                             rw_label: score,
                             len_label: eplen,
                             to_label: float(truncated),
                         }
-                        if have_original_reward and (not have_lives or info["lives"] == 0):
-                            log_dict[original_rw_label] = original_score
-                            original_score = 0
                         logger_server.log_worker(log_dict, episode)
+                        environment_logger.metrics.clear()
                     score = 0
                     eplen = 0
                     episode += 1
-                    obs, info = self.env.reset()
+                    obs, _info = self.env.reset()
                     obs = batch_observation(obs)
 
                 if len(local_buffer) >= local_size:
@@ -124,9 +122,12 @@ class Ape_X_Worker(object):
                         key=next(key_seq),
                     )
                     global_buffer.add(**transition, priorities=abs_td_error)
+            if logger_server is not None:
+                log_environment_metrics(self.env, environment_logger, episode)
+                if environment_logger.metrics:
+                    logger_server.log_worker(environment_logger.metrics, episode)
         finally:
             if stop.is_set():
                 print("worker stopped")
             else:
                 stop.set()
-        return None

--- a/jax_baselines/IMPALA/worker.py
+++ b/jax_baselines/IMPALA/worker.py
@@ -2,8 +2,9 @@ from functools import partial
 
 import jax
 
+from jax_baselines.APE_X.common_servers import WorkerMetricLogger
 from jax_baselines.core.env_info import prepare_worker_env
-from jax_baselines.core.env_protocols import batch_observation
+from jax_baselines.core.env_protocols import batch_observation, log_environment_metrics
 from jax_baselines.core.replay_protocol import make_worker_local_replay_buffer
 from jax_baselines.core.seeding import seed_prngs
 
@@ -45,22 +46,17 @@ class Impala_Worker:
 
             if seed is not None:
                 try:
-                    obs, info = self.env.reset(seed=seed)
+                    obs, _info = self.env.reset(seed=seed)
                 except TypeError:
-                    obs, info = self.env.reset()
+                    obs, _info = self.env.reset()
             else:
-                obs, info = self.env.reset()
-            have_original_reward = "original_reward" in info
-            have_lives = "lives" in info
-            if have_original_reward:
-                original_score = 0
+                obs, _info = self.env.reset()
             score = 0
             obs = batch_observation(obs)
             eplen = 0
             episode = 0
+            environment_logger = WorkerMetricLogger()
             rw_label = "rollout/episode_reward"
-            if have_original_reward:
-                original_rw_label = "rollout/original_reward"
             len_label = "rollout/episode_length"
             to_label = "rollout/timeout_rate"
 
@@ -74,7 +70,7 @@ class Impala_Worker:
                 for _ in range(local_size):
                     eplen += 1
                     actions, log_prob = get_action_prob(actor_params, obs)
-                    next_obs, reward, terminated, truncated, info = self.env.step(
+                    next_obs, reward, terminated, truncated, _info = self.env.step(
                         convert_action(actions)
                     )
                     next_obs = batch_observation(next_obs)
@@ -87,28 +83,36 @@ class Impala_Worker:
                         terminated,
                         truncated,
                     )
-                    if have_original_reward:
-                        original_score += info["original_reward"]
+                    if logger_server is not None:
+                        log_environment_metrics(
+                            self.env,
+                            environment_logger,
+                            episode,
+                            flush=bool(terminated or truncated),
+                        )
                     score += reward
                     obs = next_obs
 
                     if terminated or truncated:
                         if logger_server is not None:
                             log_dict = {
+                                **environment_logger.metrics,
                                 rw_label: score,
                                 len_label: eplen,
                                 to_label: float(truncated),
                             }
-                            if have_original_reward and (not have_lives or info["lives"] == 0):
-                                log_dict[original_rw_label] = original_score
-                                original_score = 0
                             logger_server.log_worker(log_dict, episode)
+                            environment_logger.metrics.clear()
                         score = 0
                         eplen = 0
                         episode += 1
-                        obs, info = self.env.reset()
+                        obs, _info = self.env.reset()
                         obs = batch_observation(obs)
                 queue.put(local_buffer.get_buffer())
+            if logger_server is not None:
+                log_environment_metrics(self.env, environment_logger, episode)
+                if environment_logger.metrics:
+                    logger_server.log_worker(environment_logger.metrics, episode)
         finally:
             if stop.is_set():
                 print("worker stopped")


### PR DESCRIPTION
APE-X·IMPALA worker도 환경 어댑터에 logger를 전달하도록 변경합니다. worker가 원본 보상을 직접 해석하던 코드를 제거하고, 누적 지표를 보고 주기와 정상 종료 시점에 전달합니다.

검증: worker 주입·수명주기·실행 인자·epsilon 관련 테스트 23개 및 변경 파일 lint/type 검사 통과.

선행 PR: https://github.com/tinker495/jax-baseline/pull/43. 이 PR은 선행 브랜치를 base로 사용하므로 이번 단계의 변경만 표시됩니다.

