### PR TITLE
mjlab G1 학습 설정 추가

### DIFF
--- a/experiments/configs/dpg_mjlab_g1.yaml
+++ b/experiments/configs/dpg_mjlab_g1.yaml
@@ -1,0 +1,36 @@
+family: dpg
+# Sampling schedule: FlashSAC's GPU-simulator recipe, adapted to local SAC.
+# https://github.com/Holiday-Robot/FlashSAC/blob/87edc9061150ae9e962dd84e6544e27a1554b3ab/scripts/run_isaaclab.sh
+runtime:
+  device: 0
+base:
+  env: Mjlab-Velocity-Flat-Unitree-G1
+  env_backend: mjlab
+  env_device: cuda:0
+  env_jax_arrays: true
+  env_reuse_for_eval: true
+  worker: 1024
+  # train_freq counts transitions across all workers: two updates per vector step.
+  train_freq: 1024
+  gradient_steps: 2
+  steps: 50000896
+  eval_num: 5
+  learning_rate: 0.0003
+  buffer_size: 5e6
+  batch: 2048
+  learning_starts: 100000
+  gamma: 0.99
+  n_step: 3
+  # Local observation normalization uses the SIMBA residual-network variant.
+  simba: true
+  actor_node: 512
+  critic_node: 512
+  hidden_n: 2
+  reward_normalization: true
+  target_update_tau: 0.01
+  ent_coef: auto_0.005
+  sigma_target: 0.15
+  actor_update_period: 2
+  optimizer: adam
+variants:
+  - {algo: TQC, enabled: true}

--- a/experiments/configs/flashsac_mjlab_g1.yaml
+++ b/experiments/configs/flashsac_mjlab_g1.yaml
@@ -1,0 +1,38 @@
+family: dpg
+# FlashSAC's IsaacLab recipe, applied to the MJLab Go1 task.
+# https://github.com/Holiday-Robot/FlashSAC/blob/87edc9061150ae9e962dd84e6544e27a1554b3ab/scripts/run_isaaclab.sh
+runtime:
+  device: 0
+base:
+  env: Mjlab-Velocity-Flat-Unitree-G1
+  env_backend: mjlab
+  env_device: cuda:0
+  env_jax_arrays: true
+  env_reuse_for_eval: true
+  model_lib: flax
+  worker: 1024
+  # train_freq counts transitions across all workers: two updates per vector step.
+  train_freq: 1024
+  gradient_steps: 2
+  steps: 50000896
+  eval_num: 10
+  learning_rate: 0.0003
+  learning_rate_end: 0.00015
+  optimizer: adam
+  memory_backend: gpu
+  buffer_size: 5e6
+  batch: 2048
+  learning_starts: 100000
+  gamma: 0.99
+  n_step: 3
+  actor_node: 128
+  critic_node: 256
+  hidden_n: 2
+  reward_normalization: true
+  target_update_tau: 0.01
+  ent_coef: auto_0.01
+  sigma_target: 0.15
+  actor_update_period: 2
+  seed: 0
+variants:
+  - {algo: FlashSAC, enabled: true}

--- a/experiments/configs/pg_mjlab_g1.yaml
+++ b/experiments/configs/pg_mjlab_g1.yaml
@@ -1,0 +1,34 @@
+family: pg
+runtime:
+  device: 0
+base:
+  env: Mjlab-Velocity-Flat-Unitree-G1
+  env_backend: mjlab
+  env_device: cuda:0
+  env_jax_arrays: true
+  env_reuse_for_eval: true
+  worker: 4096
+  steps: 491520000
+  eval_num: 5
+  batch: 24
+  actor_node: 512
+  critic_node: 512
+  hidden_n: 3
+  mini_batch: 24576
+  epoch_num: 5
+  learning_rate: 0.001
+  gamma: 0.99
+  lamda: 0.95
+  ppo_eps: 0.2
+  value_clip: 0.2
+  ent_coef: 0.01
+  val_coef: 0.01
+  obs_normalization: true
+  gae_normalize: true
+  gae_normalize_scope: minibatch
+  max_grad_norm: 1.0
+  optimizer: adam
+  optimizer_eps: 1.0e-8
+variants:
+  - {algo: PPO, enabled: true}
+  - {algo: SPO, enabled: true}


### PR DESCRIPTION
Unitree G1의 TQC·FlashSAC·PPO·SPO 학습을 실행하는 실험 설정 세 개를 추가합니다. 환경 로깅 코드와 분리해 학습 설정만 검토할 수 있습니다.

검증: 설정 테스트 3개 통과. 세 YAML의 `exp --dry-run`에서 의도한 네 알고리즘과 G1 환경 인자 생성을 확인했습니다. 설정에 지정된 CUDA 대규모 학습은 실행하지 않았습니다.

선행 PR: https://github.com/tinker495/jax-baseline/pull/44. 이 PR은 선행 브랜치를 base로 사용하므로 이번 단계의 변경만 표시됩니다.

