### PR TITLE
AC Actor·Critic 목적함수와 학습 업데이트 분리

### DIFF
--- a/experiments/cli/impala.py
+++ b/experiments/cli/impala.py
@@ -40,7 +40,6 @@ def add_args(parser):
     parser.add_argument("--hidden_n", type=int, default=2, help="hidden layer number")
     parser.add_argument("--optimizer", type=str, default="rmsprop", help="optimaizer")
     parser.add_argument("--ent_coef", type=float, default=0.1, help="entropy coefficient")
-    parser.add_argument("--val_coef", type=float, default=0.6, help="val coefficient")
 
 
 def make_workers(args, runtime):
@@ -61,7 +60,6 @@ def _common(a):
         "sample_size": a.sample_size,
         "buffer_size": int(a.buffer_size),
         "optimizer_factory": make_batch_scaled_optimizer_factory(a.optimizer, a.batch),
-        "val_coef": a.val_coef,
         "ent_coef": a.ent_coef,
         "rho_max": a.rho_max,
         "log_dir": a.logdir,

--- a/experiments/cli/pg.py
+++ b/experiments/cli/pg.py
@@ -66,7 +66,6 @@ def add_args(parser):
         help="linearly anneal learning rate from the configured value to 0",
     )
     parser.add_argument("--ent_coef", type=float, default=0.001, help="entropy coefficient")
-    parser.add_argument("--val_coef", type=float, default=0.6, help="val coefficient")
     parser.add_argument("--epoch_num", type=int, default=4, help="epoch number")
     parser.add_argument("--ppo_eps", type=float, default=0.2, help="PPO policy clip range")
     parser.add_argument(
@@ -107,7 +106,6 @@ def _common(a):
         "gamma": a.gamma,
         "learning_rate": a.learning_rate,
         "batch_size": a.batch,
-        "val_coef": a.val_coef,
         "ent_coef": a.ent_coef,
         "obs_normalization": a.obs_normalization,
         "memory_backend": a.memory_backend,

--- a/experiments/configs/impala_bipedal.yaml
+++ b/experiments/configs/impala_bipedal.yaml
@@ -14,7 +14,6 @@ base:
   hidden_n: 2
   sample_size: 8
   update_freq: 100
-  val_coef: 0.6
   buffer_size: 32
 variants:
   - {algo: PPO, optimizer: rmsprop}

--- a/experiments/configs/impala_breakout.yaml
+++ b/experiments/configs/impala_breakout.yaml
@@ -13,7 +13,6 @@ base:
   hidden_n: 1
   sample_size: 32
   update_freq: 100
-  val_coef: 0.6
   buffer_size: 256
   optimizer: rmsprop
 variants:

--- a/experiments/configs/impala_breakout_ppo.yaml
+++ b/experiments/configs/impala_breakout_ppo.yaml
@@ -15,7 +15,6 @@ base:
   hidden_n: 1
   sample_size: 32
   update_freq: 100
-  val_coef: 0.6
   buffer_size: 256
   optimizer: rmsprop
 variants:

--- a/experiments/configs/pg_breakout.yaml
+++ b/experiments/configs/pg_breakout.yaml
@@ -26,7 +26,6 @@ base:
   lr_annealing: true
   learning_rate: 0.00025
   ent_coef: 0.01
-  val_coef: 0.5
   epoch_num: 4
   value_clip: 0.1
   gae_normalize: true

--- a/experiments/configs/pg_mjlab_g1.yaml
+++ b/experiments/configs/pg_mjlab_g1.yaml
@@ -22,7 +22,6 @@ base:
   ppo_eps: 0.2
   value_clip: 0.2
   ent_coef: 0.01
-  val_coef: 0.01
   obs_normalization: true
   gae_normalize: true
   gae_normalize_scope: minibatch

--- a/experiments/configs/pg_mjlab_go1.yaml
+++ b/experiments/configs/pg_mjlab_go1.yaml
@@ -22,7 +22,6 @@ base:
   ppo_eps: 0.2
   value_clip: 0.2
   ent_coef: 0.01
-  val_coef: 0.01
   obs_normalization: true
   gae_normalize: true
   gae_normalize_scope: minibatch

--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -85,10 +85,11 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         value = jnp.vstack(value)
         targets = jnp.vstack(targets)
         adv = targets - value
-        (_total_loss, (critic_loss, actor_loss, entropy_loss)), (actor_grad, critic_grad) = (
-            jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
-                actor_params, critic_params, obses, actions, targets, adv, key
-            )
+        (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+            self._actor_loss, has_aux=True
+        )(actor_params, obses, actions, adv, key)
+        (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+            critic_params, actor_params, obses, targets, key
         )
         actor_updates, actor_opt_state = self.optimizer.update(
             actor_grad, actor_opt_state, params=actor_params
@@ -109,10 +110,12 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             jnp.mean(targets),
         )
 
-    def _loss_discrete(self, actor_params, critic_params, obses, actions, targets, adv, key):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
+    def _critic_loss(self, critic_params, actor_params, obses, targets, key):
+        values = self.critic(critic_params, actor_params, key, obses)
+        critic_loss = jnp.mean(jnp.square(targets - values))
+        return self.val_coef * critic_loss, critic_loss
 
+    def _actor_loss_discrete(self, actor_params, obses, actions, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -128,15 +131,12 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         actor_loss = -jnp.mean(log_prob * jax.lax.stop_gradient(adv))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(self, actor_params, critic_params, obses, actions, targets, adv, key):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(targets - vals)))
-
+    def _actor_loss_continuous(self, actor_params, obses, actions, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -157,7 +157,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         actor_loss = -jnp.mean(log_prob * jax.lax.stop_gradient(adv))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -88,7 +88,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
             self._actor_loss, has_aux=True
         )(actor_params, obses, actions, adv, key)
-        (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+        critic_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
             critic_params, actor_params, obses, targets, key
         )
         actor_updates, actor_opt_state = self.optimizer.update(
@@ -111,9 +111,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         )
 
     def _critic_loss(self, critic_params, actor_params, obses, targets, key):
-        values = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(targets - values))
-        return self.val_coef * critic_loss, critic_loss
+        return jnp.mean(jnp.square(targets - self.critic(critic_params, actor_params, key, obses)))
 
     def _actor_loss_discrete(self, actor_params, obses, actions, adv, key):
         prob, log_prob = self.get_logprob(

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -216,12 +216,12 @@ class Actor_Critic_Policy_Gradient_Family:
         if self.action_type == "discrete":
             self._get_actions = self._get_actions_discrete
             self.get_logprob = self.get_logprob_discrete
-            self._loss = self._loss_discrete
+            self._actor_loss = self._actor_loss_discrete
             self.actions = self.action_discrete
         elif self.action_type == "continuous":
             self._get_actions = self._get_actions_continuous
             self.get_logprob = self.get_logprob_continuous
-            self._loss = self._loss_continuous
+            self._actor_loss = self._actor_loss_continuous
             self.actions = self.action_continuous
 
     def setup_model(self):
@@ -290,11 +290,11 @@ class Actor_Critic_Policy_Gradient_Family:
         )
         return (prob, log_prob) if out_prob else log_prob
 
-    def _loss_continuous(self):
-        pass
+    def _actor_loss_continuous(self):
+        raise NotImplementedError
 
-    def _loss_discrete(self):
-        pass
+    def _actor_loss_discrete(self):
+        raise NotImplementedError
 
     def description(self, eval_result=None):
         description = ""

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -63,7 +63,6 @@ class Actor_Critic_Policy_Gradient_Family:
         gamma=0.995,
         learning_rate=3e-4,
         batch_size=32,
-        val_coef=0.2,
         ent_coef=0.01,
         use_entropy_adv_shaping=True,
         entropy_adv_shaping_kappa=2.0,
@@ -99,7 +98,6 @@ class Actor_Critic_Policy_Gradient_Family:
         self.batch_size = batch_size
         self.learning_rate = learning_rate
         self.gamma = gamma
-        self.val_coef = val_coef
         self.ent_coef = ent_coef
         self.log_dir = log_dir
         self.use_entropy_adv_shaping = use_entropy_adv_shaping

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -24,10 +24,10 @@ class IMPALA(IMPALA_Family):
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
-        self._loss = (
-            jax.jit(self._loss_discrete)
+        self._actor_loss = (
+            jax.jit(self._actor_loss_discrete)
             if self.action_type == "discrete"
-            else jax.jit(self._loss_continuous)
+            else jax.jit(self._actor_loss_continuous)
         )
 
     def train_step(self, steps):
@@ -142,14 +142,11 @@ class IMPALA(IMPALA_Family):
             terminateds,
             truncateds,
         )
-        (
-            (
-                _total_loss,
-                (critic_loss, actor_loss, entropy_loss),
-            ),
-            (actor_grad, critic_grad),
-        ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
-            actor_params, critic_params, obses, actions, vs, adv, key
+        (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+            self._actor_loss, has_aux=True
+        )(actor_params, obses, actions, adv, key)
+        (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+            critic_params, actor_params, obses, vs, key
         )
         actor_updates, actor_opt_state = self.optimizer.update(
             actor_grad, actor_opt_state, params=actor_params
@@ -171,10 +168,7 @@ class IMPALA(IMPALA_Family):
             jnp.mean(vs),
         )
 
-    def _loss_discrete(self, actor_params, critic_params, obses, actions, vs, adv, key):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(vs - vals))
-
+    def _actor_loss_discrete(self, actor_params, obses, actions, adv, key):
         logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         entropy_h = -jnp.sum(prob * jnp.log(jnp.maximum(prob, 1e-8)), axis=-1, keepdims=True)
@@ -188,15 +182,12 @@ class IMPALA(IMPALA_Family):
 
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(self, actor_params, critic_params, obses, actions, vs, adv, key):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(vs - vals))
-
+    def _actor_loss_continuous(self, actor_params, obses, actions, adv, key):
         prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
@@ -215,7 +206,7 @@ class IMPALA(IMPALA_Family):
         actor_loss = -jnp.mean(log_prob * adv)
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/A2C/impala.py
+++ b/jax_baselines/A2C/impala.py
@@ -145,7 +145,7 @@ class IMPALA(IMPALA_Family):
         (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
             self._actor_loss, has_aux=True
         )(actor_params, obses, actions, adv, key)
-        (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+        critic_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
             critic_params, actor_params, obses, vs, key
         )
         actor_updates, actor_opt_state = self.optimizer.update(

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -190,7 +190,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                 (_, (a_loss, entropy_loss)), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
                 )(actor_params, obs, act, act_prob, adv, use_key)
-                (_, c_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                c_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
                     critic_params, actor_params, obs, oldv, target, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
@@ -265,7 +265,6 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
     def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):
         values = self.critic(critic_params, actor_params, key, obses)
         clipped_values = old_value + jnp.clip(values - old_value, -self.value_clip, self.value_clip)
-        critic_loss = jnp.mean(
+        return jnp.mean(
             jnp.maximum(jnp.square(values - targets), jnp.square(clipped_values - targets))
         )
-        return self.val_coef * critic_loss, critic_loss

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -17,8 +17,8 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
 
     PPO and SPO share identical rollout preprocessing (GAE) and the
     minibatch/epoch optimization loop; they differ only in the per-sample actor
-    loss supplied through ``_loss_discrete``/``_loss_continuous`` (wired to
-    ``self._loss`` by ``Actor_Critic_Policy_Gradient_Family``).
+    loss supplied through ``_actor_loss_discrete``/``_actor_loss_continuous``
+    (wired to ``self._actor_loss`` by ``Actor_Critic_Policy_Gradient_Family``).
     """
 
     def __init__(
@@ -187,10 +187,11 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (_total_loss, (c_loss, a_loss, entropy_loss)), (actor_grad, critic_grad) = (
-                    jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
-                        actor_params, critic_params, obs, act, oldv, target, act_prob, adv, use_key
-                    )
+                (_, (a_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+                    self._actor_loss, has_aux=True
+                )(actor_params, obs, act, act_prob, adv, use_key)
+                (_, c_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                    critic_params, actor_params, obs, oldv, target, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
                     actor_grad, actor_opt_state, params=actor_params
@@ -260,3 +261,11 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             entropy_loss / self.epoch_num,
             jnp.mean(targets),
         )
+
+    def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):
+        values = self.critic(critic_params, actor_params, key, obses)
+        clipped_values = old_value + jnp.clip(values - old_value, -self.value_clip, self.value_clip)
+        critic_loss = jnp.mean(
+            jnp.maximum(jnp.square(values - targets), jnp.square(clipped_values - targets))
+        )
+        return self.val_coef * critic_loss, critic_loss

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -42,7 +42,6 @@ class IMPALA_Family:
         update_freq=100,
         batch_size=1024,
         sample_size=1,
-        val_coef=0.2,
         ent_coef=0.01,
         use_entropy_adv_shaping=True,
         entropy_adv_shaping_kappa=2.0,
@@ -80,7 +79,6 @@ class IMPALA_Family:
         self.learning_rate = learning_rate
         self.gamma = gamma
         self.lamda = lamda
-        self.val_coef = val_coef
         self.ent_coef = ent_coef
         self.use_entropy_adv_shaping = use_entropy_adv_shaping
         self.entropy_adv_shaping_kappa = entropy_adv_shaping_kappa
@@ -120,9 +118,7 @@ class IMPALA_Family:
         return self.optimizer_factory(learning_rate)
 
     def _critic_loss(self, critic_params, actor_params, obses, targets, key):
-        values = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(targets - values))
-        return self.val_coef * critic_loss, critic_loss
+        return jnp.mean(jnp.square(targets - self.critic(critic_params, actor_params, key, obses)))
 
     def get_env_setup(self):
         (

--- a/jax_baselines/IMPALA/base_class.py
+++ b/jax_baselines/IMPALA/base_class.py
@@ -1,5 +1,7 @@
 import time
 from collections import deque
+from collections.abc import Callable
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -24,6 +26,7 @@ from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 
 
 class IMPALA_Family:
+    critic: Callable[..., Any]
     _run_name = "IMPALA"
     _learn_log_interval = 1000
 
@@ -115,6 +118,11 @@ class IMPALA_Family:
 
     def _make_optimizer(self, learning_rate):
         return self.optimizer_factory(learning_rate)
+
+    def _critic_loss(self, critic_params, actor_params, obses, targets, key):
+        values = self.critic(critic_params, actor_params, key, obses)
+        critic_loss = jnp.mean(jnp.square(targets - values))
+        return self.val_coef * critic_loss, critic_loss
 
     def get_env_setup(self):
         (

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -29,7 +29,6 @@ class SurrogateIMPALA(IMPALA_Family):
         update_freq=100,
         batch_size=1024,
         sample_size=1,
-        val_coef=0.2,
         ent_coef=0.01,
         use_entropy_adv_shaping=True,
         entropy_adv_shaping_kappa=2.0,
@@ -58,7 +57,6 @@ class SurrogateIMPALA(IMPALA_Family):
             update_freq=update_freq,
             batch_size=batch_size,
             sample_size=sample_size,
-            val_coef=val_coef,
             ent_coef=ent_coef,
             use_entropy_adv_shaping=use_entropy_adv_shaping,
             entropy_adv_shaping_kappa=entropy_adv_shaping_kappa,
@@ -237,7 +235,7 @@ class SurrogateIMPALA(IMPALA_Family):
                 (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
                 )(actor_params, obs, act, mu_prob, pi_prob, adv, use_key)
-                (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                critic_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
                     critic_params, actor_params, obs, vs, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(

--- a/jax_baselines/IMPALA/surrogate_base.py
+++ b/jax_baselines/IMPALA/surrogate_base.py
@@ -11,7 +11,7 @@ class SurrogateIMPALA(IMPALA_Family):
 
     Both share identical model setup, V-trace preprocessing, and the
     minibatch/epoch optimization loop; they differ only in the per-sample actor
-    loss supplied through ``_loss_discrete``/``_loss_continuous``. Subclasses
+    loss supplied through ``_actor_loss_discrete``/``_actor_loss_continuous``. Subclasses
     keep those plus their own ``learn``.
     """
 
@@ -87,10 +87,10 @@ class SurrogateIMPALA(IMPALA_Family):
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
-        self._loss = (
-            jax.jit(self._loss_discrete)
+        self._actor_loss = (
+            jax.jit(self._actor_loss_discrete)
             if self.action_type == "discrete"
-            else jax.jit(self._loss_continuous)
+            else jax.jit(self._actor_loss_continuous)
         )
 
     def train_step(self, steps):
@@ -234,14 +234,11 @@ class SurrogateIMPALA(IMPALA_Family):
                 actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, vs, mu_prob, pi_prob, adv = input
                 use_key, key = jax.random.split(key)
-                (
-                    (
-                        _total_loss,
-                        (critic_loss, actor_loss, entropy_loss),
-                    ),
-                    (actor_grad, critic_grad),
-                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
-                    actor_params, critic_params, obs, act, vs, mu_prob, pi_prob, adv, use_key
+                (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+                    self._actor_loss, has_aux=True
+                )(actor_params, obs, act, mu_prob, pi_prob, adv, use_key)
+                (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                    critic_params, actor_params, obs, vs, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
                     actor_grad, actor_opt_state, params=actor_params

--- a/jax_baselines/PPO/impala_ppo.py
+++ b/jax_baselines/PPO/impala_ppo.py
@@ -8,12 +8,7 @@ class IMPALA_PPO(SurrogateIMPALA):
     _run_name = "IMPALA_PPO"
     _learn_log_interval = 10
 
-    def _loss_discrete(
-        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
-
+    def _actor_loss_discrete(self, actor_params, obses, actions, mu_prob, pi_prob, adv, key):
         logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         # Paper's entropy: H = -sum(p * log(p)) >= 0
@@ -33,19 +28,14 @@ class IMPALA_PPO(SurrogateIMPALA):
         actor_loss = jnp.mean(jnp.maximum(cross_entropy1, cross_entropy2))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(
-        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
-    ):
-        # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
+    def _actor_loss_continuous(self, actor_params, obses, actions, mu_prob, pi_prob, adv, key):
+        # pi_prob is accepted for a uniform scan-call signature with _actor_loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
-
         prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
@@ -69,7 +59,7 @@ class IMPALA_PPO(SurrogateIMPALA):
         actor_loss = jnp.mean(jnp.maximum(cross_entropy1, cross_entropy2))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -7,15 +7,7 @@ from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
 class PPO(SurrogatePolicyGradient):
     _run_name = "PPO"
 
-    def _loss_discrete(
-        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(vals - targets)
-        vf2 = jnp.square(vals_clip - targets)
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
+    def _actor_loss_discrete(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -35,20 +27,12 @@ class PPO(SurrogatePolicyGradient):
         actor_loss = jnp.mean(jnp.maximum(cross_entropy1, cross_entropy2))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(
-        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(jnp.squeeze(vals - targets))
-        vf2 = jnp.square(jnp.squeeze(vals_clip - targets))
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
+    def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -73,7 +57,7 @@ class PPO(SurrogatePolicyGradient):
         actor_loss = jnp.mean(jnp.maximum(cross_entropy1, cross_entropy2))
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/SPO/impala_spo.py
+++ b/jax_baselines/SPO/impala_spo.py
@@ -8,12 +8,7 @@ class IMPALA_SPO(SurrogateIMPALA):
     _run_name = "IMPALA_SPO"
     _learn_log_interval = 10
 
-    def _loss_discrete(
-        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
-
+    def _actor_loss_discrete(self, actor_params, obses, actions, mu_prob, pi_prob, adv, key):
         logit = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(logit, actions, key, out_prob=True)
         # Paper's entropy: H = -sum(p * log(p)) >= 0
@@ -34,19 +29,14 @@ class IMPALA_SPO(SurrogateIMPALA):
         actor_loss = jnp.mean(-spo_term1 + spo_term2)
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(
-        self, actor_params, critic_params, obses, actions, vs, mu_prob, pi_prob, adv, key
-    ):
-        # pi_prob is accepted for a uniform scan-call signature with _loss_discrete;
+    def _actor_loss_continuous(self, actor_params, obses, actions, mu_prob, pi_prob, adv, key):
+        # pi_prob is accepted for a uniform scan-call signature with _actor_loss_discrete;
         # the continuous IS ratio uses mu_prob only.
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vals - vs)))
-
         prob = self.actor(actor_params, key, obses)
         prob, log_prob = self.get_logprob(prob, actions, key, out_prob=True)
         mu, log_std = prob
@@ -71,7 +61,7 @@ class IMPALA_SPO(SurrogateIMPALA):
         actor_loss = jnp.mean(-spo_term1 + spo_term2)
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -33,15 +33,7 @@ class SPO(SurrogatePolicyGradient):
             **kwargs,
         )
 
-    def _loss_discrete(
-        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(vals - targets)
-        vf2 = jnp.square(vals_clip - targets)
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
+    def _actor_loss_discrete(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -62,20 +54,12 @@ class SPO(SurrogatePolicyGradient):
         actor_loss = jnp.mean(-spo_term1 + spo_term2)
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(
-        self, actor_params, critic_params, obses, actions, old_value, targets, old_prob, adv, key
-    ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(vals - targets)
-        vf2 = jnp.square(vals_clip - targets)
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
+    def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -101,7 +85,7 @@ class SPO(SurrogatePolicyGradient):
         actor_loss = jnp.mean(-spo_term1 + spo_term2)
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -90,10 +90,10 @@ class IMPALA_TPPO(IMPALA_Family):
 
         self._train_step = jax.jit(self._train_step)
         self.preprocess = jax.jit(self.preprocess)
-        self._loss = (
-            jax.jit(self._loss_discrete)
+        self._actor_loss = (
+            jax.jit(self._actor_loss_discrete)
             if self.action_type == "discrete"
-            else jax.jit(self._loss_continuous)
+            else jax.jit(self._actor_loss_continuous)
         )
 
     def train_step(self, steps):
@@ -248,14 +248,11 @@ class IMPALA_TPPO(IMPALA_Family):
                 actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
                 obs, act, vs, old_prob, old_act_prob, adv = input
                 use_key, key = jax.random.split(key)
-                (
-                    (
-                        _total_loss,
-                        (critic_loss, actor_loss, entropy_loss),
-                    ),
-                    (actor_grad, critic_grad),
-                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
-                    actor_params, critic_params, obs, act, vs, old_prob, old_act_prob, adv, use_key
+                (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+                    self._actor_loss, has_aux=True
+                )(actor_params, obs, act, old_prob, old_act_prob, adv, use_key)
+                (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                    critic_params, actor_params, obs, vs, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
                     actor_grad, actor_opt_state, params=actor_params
@@ -327,21 +324,16 @@ class IMPALA_TPPO(IMPALA_Family):
             jnp.mean(vs),
         )
 
-    def _loss_discrete(
+    def _actor_loss_discrete(
         self,
         actor_params,
-        critic_params,
         obses,
         actions,
-        vs,
         old_prob,
         old_act_prob,
         adv,
         key,
     ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
-
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -366,26 +358,21 @@ class IMPALA_TPPO(IMPALA_Family):
         )
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
-    def _loss_continuous(
+    def _actor_loss_continuous(
         self,
         actor_params,
-        critic_params,
         obses,
         actions,
-        vs,
         old_prob,
         old_act_prob,
         adv,
         key,
     ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        critic_loss = jnp.mean(jnp.square(jnp.squeeze(vs - vals)))
-
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -417,10 +404,10 @@ class IMPALA_TPPO(IMPALA_Family):
         )
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss)
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss)
 
     def run_name_update(self, run_name):
         if self.mu_ratio != 0.0:

--- a/jax_baselines/TPPO/impala_tppo.py
+++ b/jax_baselines/TPPO/impala_tppo.py
@@ -30,7 +30,6 @@ class IMPALA_TPPO(IMPALA_Family):
         update_freq=100,
         batch_size=1024,
         sample_size=1,
-        val_coef=0.2,
         ent_coef=0.01,
         use_entropy_adv_shaping=True,
         entropy_adv_shaping_kappa=2.0,
@@ -61,7 +60,6 @@ class IMPALA_TPPO(IMPALA_Family):
             update_freq=update_freq,
             batch_size=batch_size,
             sample_size=sample_size,
-            val_coef=val_coef,
             ent_coef=ent_coef,
             use_entropy_adv_shaping=use_entropy_adv_shaping,
             entropy_adv_shaping_kappa=entropy_adv_shaping_kappa,
@@ -251,7 +249,7 @@ class IMPALA_TPPO(IMPALA_Family):
                 (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
                 )(actor_params, obs, act, old_prob, old_act_prob, adv, use_key)
-                (_, critic_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                critic_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
                     critic_params, actor_params, obs, vs, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -207,7 +207,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                     adv,
                     use_key,
                 )
-                (_, c_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                c_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
                     critic_params, actor_params, obs, old_value, target, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
@@ -298,10 +298,9 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
     def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):
         values = self.critic(critic_params, actor_params, key, obses)
         clipped_values = old_value + jnp.clip(values - old_value, -self.value_clip, self.value_clip)
-        critic_loss = jnp.mean(
+        return jnp.mean(
             jnp.maximum(jnp.square(values - targets), jnp.square(clipped_values - targets))
         )
-        return self.val_coef * critic_loss, critic_loss
 
     def _actor_loss_discrete(
         self,

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -196,23 +196,19 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (
-                    (
-                        _total_loss,
-                        (c_loss, a_loss, entropy_loss, kl),
-                    ),
-                    (actor_grad, critic_grad),
-                ) = jax.value_and_grad(self._loss, argnums=(0, 1), has_aux=True)(
+                (_, (a_loss, entropy_loss, kl)), actor_grad = jax.value_and_grad(
+                    self._actor_loss, has_aux=True
+                )(
                     actor_params,
-                    critic_params,
                     obs,
                     act,
-                    old_value,
-                    target,
                     old_prob,
                     old_act_prob,
                     adv,
                     use_key,
+                )
+                (_, c_loss), critic_grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+                    critic_params, actor_params, obs, old_value, target, use_key
                 )
                 actor_updates, actor_opt_state = self.optimizer.update(
                     actor_grad, actor_opt_state, params=actor_params
@@ -299,25 +295,24 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             jnp.mean(targets),
         )
 
-    def _loss_discrete(
+    def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):
+        values = self.critic(critic_params, actor_params, key, obses)
+        clipped_values = old_value + jnp.clip(values - old_value, -self.value_clip, self.value_clip)
+        critic_loss = jnp.mean(
+            jnp.maximum(jnp.square(values - targets), jnp.square(clipped_values - targets))
+        )
+        return self.val_coef * critic_loss, critic_loss
+
+    def _actor_loss_discrete(
         self,
         actor_params,
-        critic_params,
         obses,
         actions,
-        old_value,
-        targets,
         old_prob,
         old_act_prob,
         adv,
         key,
     ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(vals - targets)
-        vf2 = jnp.square(vals_clip - targets)
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -344,30 +339,21 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         )
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss, jnp.mean(kl))
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss, jnp.mean(kl))
 
-    def _loss_continuous(
+    def _actor_loss_continuous(
         self,
         actor_params,
-        critic_params,
         obses,
         actions,
-        old_value,
-        targets,
         old_prob,
         old_act_prob,
         adv,
         key,
     ):
-        vals = self.critic(critic_params, actor_params, key, obses)
-        vals_clip = old_value + jnp.clip(vals - old_value, -self.value_clip, self.value_clip)
-        vf1 = jnp.square(vals - targets)
-        vf2 = jnp.square(vals_clip - targets)
-        critic_loss = jnp.mean(jnp.maximum(vf1, vf2))
-
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -403,7 +389,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         )
         entropy_loss = -jnp.mean(entropy_h)
         if self.use_entropy_adv_shaping:
-            total_loss = self.val_coef * critic_loss + actor_loss
+            actor_objective = actor_loss
         else:
-            total_loss = self.val_coef * critic_loss + actor_loss + self.ent_coef * entropy_loss
-        return total_loss, (critic_loss, actor_loss, entropy_loss, jnp.mean(kl))
+            actor_objective = actor_loss + self.ent_coef * entropy_loss
+        return actor_objective, (actor_loss, entropy_loss, jnp.mean(kl))

--- a/tests/test_ppo_spo_shared.py
+++ b/tests/test_ppo_spo_shared.py
@@ -22,16 +22,16 @@ _PAIRS = [
         SurrogatePolicyGradient,
         PPO,
         SPO,
-        ("setup_model", "train_step", "_preprocess", "_train_step", "learn"),
+        ("setup_model", "train_step", "_preprocess", "_train_step", "_critic_loss", "learn"),
     ),
     (
         SurrogateIMPALA,
         IMPALA_PPO,
         IMPALA_SPO,
-        ("setup_model", "train_step", "preprocess", "_train_step", "learn"),
+        ("setup_model", "train_step", "preprocess", "_train_step", "_critic_loss", "learn"),
     ),
 ]
-_ALGO_SPECIFIC = ("_loss_discrete", "_loss_continuous")
+_ALGO_SPECIFIC = ("_actor_loss_discrete", "_actor_loss_continuous")
 
 
 @pytest.mark.parametrize("base, ppo_cls, spo_cls, shared", _PAIRS)

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -69,7 +69,7 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
     agent.kl_range = 0.05
     agent.minibatch_size = 2
     agent.epoch_num = 1
-    agent._loss = MethodType(cls._loss_continuous, agent)
+    agent._actor_loss = MethodType(cls._actor_loss_continuous, agent)
     obses, actions, scalars = _rollout(timesteps=2)
 
     if kind == "local":

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -62,7 +62,6 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
     agent.optimizer = optax.sgd(1e-3)
     agent.actor_opt_state = agent.optimizer.init(agent.actor_params)
     agent.critic_opt_state = agent.optimizer.init(agent.critic_params)
-    agent.val_coef = 0.2
     agent.ent_coef = 0.01
     agent.use_entropy_adv_shaping = False
     agent.kl_coef = 5.0


### PR DESCRIPTION
AC 계열은 Actor·Critic 파라미터와 optimizer 상태가 분리돼 있지만 결합 loss에서 두 gradient를 계산하고 있었습니다. A2C·PPO·SPO·TPPO 및 IMPALA 변형 모두 Actor와 Critic의 목적함수·미분을 분리하고, 각 역할의 optimizer 상태로 갱신하도록 변경합니다. 기존 결합 loss 계약과 이를 고정하던 테스트를 함께 제거합니다.

두 gradient는 갱신 전 파라미터에서 계산하며, 학습률·업데이트 주기·타깃·advantage·entropy/KL 수식·Critic의 val_coef는 유지합니다.

검증: 관련 테스트 76개 통과. 독립 SGD와 역할별 목적함수 검증 32개 조합 통과. 두 번의 clipped Adam 업데이트에서 파라미터·optimizer 상태·지표 1,384개 배열이 기준 커밋과 정확히 일치했습니다. 실제 CLI에서 네 알고리즘 × 두 행동 공간의 8개 실행을 비교했고, 184개 scalar 표본도 모두 동일했습니다. Ruff 통과, Ty는 기준 커밋의 42개 진단 그대로입니다.

선행 PR: https://github.com/tinker495/jax-baseline/pull/45. 이 PR은 선행 브랜치를 base로 사용해 AC 학습 분리만 표시합니다.
