### PR TITLE
JAX 환경 지표 집계 연산을 묶어 호출 비용 절감

### DIFF
--- a/env_builder/metrics.py
+++ b/env_builder/metrics.py
@@ -35,6 +35,11 @@ def metric_leaves(values: Mapping[str, Any]) -> dict[str, Any]:
     return leaves
 
 
+@jax.jit
+def _pack_jax_metrics(values: tuple[jax.Array, ...]) -> jax.Array:
+    return jnp.stack([value.mean() for value in values])
+
+
 class EnvMetrics:
     """Keep bounded sums on the producing device; transfer only when logging."""
 
@@ -48,13 +53,21 @@ class EnvMetrics:
         if not leaves:
             return
         array_module = jnp if any(isinstance(v, jax.Array) for v in leaves.values()) else np
-        scalars = []
+        arrays = []
         for key, value in leaves.items():
             array = array_module.asarray(value)
             if array.dtype.kind not in "biuf" or not array.size:
                 raise ValueError(f"Environment metric {key!r} must contain real numeric values")
-            scalars.append(array.mean())
-        self.add_batch(tuple(leaves), array_module.stack(scalars), weight)
+            arrays.append(array)
+        self.add_batch(
+            tuple(leaves),
+            (
+                _pack_jax_metrics(tuple(arrays))
+                if array_module is jnp
+                else np.stack([array.mean() for array in arrays])
+            ),
+            weight,
+        )
 
     def add_batch(self, names: tuple[str, ...], values: Any, weight: int = 1) -> None:
         """Accept a packed native metric vector without per-term device operations."""


### PR DESCRIPTION
범용 JAX 환경 지표 입력에서 항목마다 평균 계산과 stack 연산을 제출하면서 집계 비용이 커졌습니다. 경계의 정규화·검증은 유지하고 JAX 배열 tuple의 평균과 묶기를 한 JIT 호출로 합칩니다. NumPy 처리와 기존 가중 누적 계약은 유지합니다.

RTX 4080 SUPER에서 예열 후 50개 JAX 항목 집계의 호스트 중앙값이 5.92ms에서 0.65ms로 감소했습니다. 측정 범위는 어댑터의 수집·집계입니다.

검증: 실제 코드의 자료형·배열 형태·가중치 조합 14개 통과. 1,000회 수집 중 호스트 변환 0회, flush에서 벡터 단위 변환 확인. 관련 기존 테스트 29개, Ruff·Ty 및 pre-commit 검사 통과.

선행 PR: https://github.com/tinker495/jax-baseline/pull/47. 이 PR은 선행 브랜치를 base로 사용해 JAX 집계 최적화 한 파일만 표시합니다.
