### PR TITLE
잔차 모델 블록을 너비 배열로 설정

### DIFF
--- a/experiments/configs/models/README.md
+++ b/experiments/configs/models/README.md
@@ -33,7 +33,8 @@ TD7의 MLP에는 은닉층이 하나 이상 필요합니다. 첫 층의 너비�
 SALE 인코더와 입력 투영 너비에도 적용됩니다. SIMBAv2 TD7의 `blocks`는
 인코더와 네트워크의 각 잔차 블록 구간에 동일하게 적용됩니다.
 
-SIMBA, SIMBAv2, FlashSAC의 잔차 네트워크는 블록 너비와 개수를 지정합니다.
+SIMBA, SIMBAv2, FlashSAC의 잔차 네트워크는 `blocks` 배열에 각 블록의
+출력 너비를 순서대로 지정합니다. `[512, 512]`는 출력 너비가 512인 블록 두 개입니다.
 Flax의 DDPG, TD3, SAC, TQC, CrossQ, TD7에서 MLP, SIMBA, SIMBAv2는
 JSON의 `type`으로 선택하며, actor와 critic에 서로 다른 구조를 사용할 수 있습니다.
 XQC와 Haiku 빌더는 MLP를 사용합니다.
@@ -41,8 +42,7 @@ XQC와 Haiku 빌더는 MLP를 사용합니다.
 ```json
 {
   "type": "simba",
-  "width": 512,
-  "blocks": 2,
+  "blocks": [512, 256],
   "activation": "relu",
   "embedding_mode": "normal"
 }
@@ -50,11 +50,14 @@ XQC와 Haiku 빌더는 MLP를 사용합니다.
 
 `type`에는 `simba`, `simbav2`, `flashsac`을 사용할 수 있습니다.
 `flashsac`은 FlashSAC 알고리즘의 블록입니다.
+`blocks`는 양의 정수로 이루어진 비어 있지 않은 배열이어야 합니다.
+첫 값은 입력 임베딩 너비도 결정하며, 마지막 값은 출력 헤드에 전달되는 너비입니다.
+예시의 `[512, 256]`처럼 너비가 달라지는 구간에는 투영을 적용합니다.
+별도의 `width` 필드와 정수 형태의 `blocks`, 빈 배열은 허용하지 않습니다.
 
 관측값의 평균과 표준편차를 누적해 정규화하는 기능은 네트워크 구조와 독립적입니다.
 `dpg`와 `pg`에서는 CLI의 `--obs_rms_norm` 또는 YAML의 `obs_rms_norm: true`로
 설정하며 기본값은 꺼짐입니다. FlashSAC은 외부 관측 RMS 정규화를 지원하지 않습니다.
-`blocks: 0`은 잔차 블록을 생략하며 입력 임베딩과 출력 헤드는 유지합니다.
 
 ## 이미지 임베딩
 

--- a/experiments/configs/models/flashsac_128x2_relu.json
+++ b/experiments/configs/models/flashsac_128x2_relu.json
@@ -1,7 +1,6 @@
 {
   "type": "flashsac",
-  "width": 128,
-  "blocks": 2,
+  "blocks": [128, 128],
   "activation": "relu",
   "embedding_mode": "normal"
 }

--- a/experiments/configs/models/flashsac_256x2_relu.json
+++ b/experiments/configs/models/flashsac_256x2_relu.json
@@ -1,7 +1,6 @@
 {
   "type": "flashsac",
-  "width": 256,
-  "blocks": 2,
+  "blocks": [256, 256],
   "activation": "relu",
   "embedding_mode": "normal"
 }

--- a/experiments/configs/models/simba_256x2_relu.json
+++ b/experiments/configs/models/simba_256x2_relu.json
@@ -1,7 +1,6 @@
 {
   "type": "simba",
-  "width": 256,
-  "blocks": 2,
+  "blocks": [256, 256],
   "activation": "relu",
   "embedding_mode": "normal"
 }

--- a/experiments/configs/models/simba_512x2_relu.json
+++ b/experiments/configs/models/simba_512x2_relu.json
@@ -1,7 +1,6 @@
 {
   "type": "simba",
-  "width": 512,
-  "blocks": 2,
+  "blocks": [512, 512],
   "activation": "relu",
   "embedding_mode": "normal"
 }

--- a/experiments/configs/models/simbav2_256x2_relu.json
+++ b/experiments/configs/models/simbav2_256x2_relu.json
@@ -1,7 +1,6 @@
 {
   "type": "simbav2",
-  "width": 256,
-  "blocks": 2,
+  "blocks": [256, 256],
   "activation": "relu",
   "embedding_mode": "normal"
 }

--- a/model_builder/flax/dpg/crossq_builder.py
+++ b/model_builder/flax/dpg/crossq_builder.py
@@ -38,10 +38,10 @@ class Actor(nn.Module):
         feature = network_body(features, self.network, self.layer)
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
             mu = SimbaV2Head(
-                self.network.width, self.action_size[0], kernel_init=clip_factorized_uniform(3)
+                self.network.blocks[-1], self.action_size[0], kernel_init=clip_factorized_uniform(3)
             )(feature)
             log_std = SimbaV2Head(
-                self.network.width,
+                self.network.blocks[-1],
                 self.action_size[0],
                 use_bias=True,
                 kernel_init=clip_factorized_uniform(3),
@@ -67,7 +67,7 @@ class Critic(nn.Module):
     ) -> jnp.ndarray:
         concat = jnp.concatenate([features, actions], axis=1)
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
-            return SimbaV2Head(self.network.width, 1)(network_body(concat, self.network))
+            return SimbaV2Head(self.network.blocks[-1], 1)(network_body(concat, self.network))
         feature = BatchReNorm(use_running_average=not training)(concat)
         if isinstance(self.network, MLPConfig):
             for layer in self.network.layers:

--- a/model_builder/flax/dpg/ddpg_td3_blocks.py
+++ b/model_builder/flax/dpg/ddpg_td3_blocks.py
@@ -18,7 +18,7 @@ class Actor(nn.Module):
     def __call__(self, features: jnp.ndarray) -> jnp.ndarray:
         features = network_body(features, self.network, self.layer)
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
-            action = SimbaV2Head(self.network.width, self.action_size[0])(features)
+            action = SimbaV2Head(self.network.blocks[-1], self.action_size[0])(features)
         else:
             action = self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))(
                 features
@@ -36,5 +36,5 @@ class Critic(nn.Module):
             jnp.concatenate([features, actions], axis=1), self.network, self.layer
         )
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
-            return SimbaV2Head(self.network.width, 1)(features)
+            return SimbaV2Head(self.network.blocks[-1], 1)(features)
         return self.layer(1, kernel_init=clip_factorized_uniform(3))(features)

--- a/model_builder/flax/dpg/flashsac_builder.py
+++ b/model_builder/flax/dpg/flashsac_builder.py
@@ -45,15 +45,22 @@ class Encoder(nn.Module):
     def __call__(self, feature: jax.Array, training: bool) -> jax.Array:
         feature = UnitBatchNorm(name="input_norm")(feature, training)
         feature = nn.Dense(
-            self.network.width,
+            self.network.blocks[0],
             use_bias=False,
             kernel_init=nn.initializers.orthogonal(),
             name="embed",
         )(feature)
-        for block in range(self.network.blocks):
+        for block, width in enumerate(self.network.blocks):
+            if feature.shape[-1] != width:
+                feature = nn.Dense(
+                    width,
+                    use_bias=False,
+                    kernel_init=nn.initializers.orthogonal(),
+                    name=f"block_{block}_project",
+                )(feature)
             residual = feature
             feature = nn.Dense(
-                self.network.width * 4,
+                width * 4,
                 use_bias=False,
                 kernel_init=nn.initializers.orthogonal(),
                 name=f"block_{block}_expand",
@@ -61,7 +68,7 @@ class Encoder(nn.Module):
             feature = UnitBatchNorm(name=f"block_{block}_norm1")(feature, training)
             feature = ACTIVATIONS[self.network.activation](feature)
             feature = nn.Dense(
-                self.network.width,
+                width,
                 use_bias=False,
                 kernel_init=nn.initializers.orthogonal(),
                 name=f"block_{block}_contract",
@@ -73,7 +80,7 @@ class Encoder(nn.Module):
 
 class Actor(nn.Module):
     action_dim: int
-    network: ResidualConfig = ResidualConfig("flashsac", width=128)
+    network: ResidualConfig = ResidualConfig("flashsac", (128, 128))
 
     @nn.compact
     def __call__(
@@ -113,7 +120,7 @@ def model_builder_maker(
     n_atoms = policy_kwargs.pop("n_atoms", 101)
     actor_kwargs, critic_kwargs = split_actor_critic_kwargs(
         policy_kwargs,
-        actor_default=ResidualConfig("flashsac", width=128),
+        actor_default=ResidualConfig("flashsac", (128, 128)),
         critic_default=ResidualConfig("flashsac"),
         allowed_embeddings=("normal",),
     )

--- a/model_builder/flax/dpg/gaussian_blocks.py
+++ b/model_builder/flax/dpg/gaussian_blocks.py
@@ -24,8 +24,8 @@ class Actor(nn.Module):
     def __call__(self, features: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
         features = network_body(features, self.network, self.layer)
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
-            mu = SimbaV2Head(self.network.width, self.action_size[0])(features)
-            log_std = SimbaV2Head(self.network.width, self.action_size[0])(features)
+            mu = SimbaV2Head(self.network.blocks[-1], self.action_size[0])(features)
+            log_std = SimbaV2Head(self.network.blocks[-1], self.action_size[0])(features)
         else:
             mu = self.layer(self.action_size[0], kernel_init=clip_factorized_uniform(3))(features)
             log_std = self.layer(

--- a/model_builder/flax/dpg/td7_builder.py
+++ b/model_builder/flax/dpg/td7_builder.py
@@ -34,7 +34,7 @@ class Encoder(nn.Module):
         width = (
             self.network.layers[0].units
             if isinstance(self.network, MLPConfig)
-            else self.network.width
+            else self.network.blocks[0]
         )
         encoded = nn.Sequential([Dense(width), jax.nn.elu, Dense(width), jax.nn.elu, Dense(width)])(
             features
@@ -52,11 +52,11 @@ class Actor(nn.Module):
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
             base = network_body(features, self.network)
             encoded = network_body(jnp.concatenate([base, zs], axis=1), self.network)
-            return jax.nn.tanh(SimbaV2Head(self.network.width, self.action_size[0])(encoded))
+            return jax.nn.tanh(SimbaV2Head(self.network.blocks[-1], self.action_size[0])(encoded))
         width = (
             self.network.layers[0].units
             if isinstance(self.network, MLPConfig)
-            else self.network.width
+            else self.network.blocks[0]
         )
         base = avgl1norm(self.layer(width)(features))
         encoded = network_body(jnp.concatenate([base, zs], axis=1), self.network, self.layer)
@@ -81,11 +81,11 @@ class Critic(nn.Module):
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
             base = network_body(concat, self.network)
             encoded = network_body(jnp.concatenate([base, zs, zsa], axis=1), self.network)
-            return SimbaV2Head(self.network.width, 1)(encoded)
+            return SimbaV2Head(self.network.blocks[-1], 1)(encoded)
         width = (
             self.network.layers[0].units
             if isinstance(self.network, MLPConfig)
-            else self.network.width
+            else self.network.blocks[0]
         )
         base = avgl1norm(self.layer(width)(concat))
         encoded = network_body(jnp.concatenate([base, zs, zsa], axis=1), self.network, self.layer)

--- a/model_builder/flax/dpg/tqc_builder.py
+++ b/model_builder/flax/dpg/tqc_builder.py
@@ -28,7 +28,7 @@ class Critic(nn.Module):
             jnp.concatenate([features, actions], axis=1), self.network, self.layer
         )
         if isinstance(self.network, ResidualConfig) and self.network.kind == "simbav2":
-            return SimbaV2Head(self.network.width, self.support_n)(features)
+            return SimbaV2Head(self.network.blocks[-1], self.support_n)(features)
         return self.layer(self.support_n, kernel_init=clip_factorized_uniform(3 / self.support_n))(
             features
         )

--- a/model_builder/flax/layers.py
+++ b/model_builder/flax/layers.py
@@ -332,17 +332,17 @@ def network_body(
             features = ACTIVATIONS[hidden.activation](layer(hidden.units)(features))
         return features
     if network.kind == "simba":
-        features = layer(network.width)(features)
-        for _ in range(network.blocks):
-            features = ResidualBlock(network.width, activation=ACTIVATIONS[network.activation])(
-                features
-            )
+        features = layer(network.blocks[0])(features)
+        for width in network.blocks:
+            if features.shape[-1] != width:
+                features = layer(width)(features)
+            features = ResidualBlock(width, activation=ACTIVATIONS[network.activation])(features)
         return nn.LayerNorm()(features)
     if network.kind == "simbav2":
-        features = SimbaV2Embedding(network.width)(features)
-        for _ in range(network.blocks):
-            features = SimbaV2Block(network.width, activation=ACTIVATIONS[network.activation])(
-                features
-            )
+        features = SimbaV2Embedding(network.blocks[0])(features)
+        for width in network.blocks:
+            if features.shape[-1] != width:
+                features = l2_normalize(HypersphericalDense(width, use_bias=False)(features))
+            features = SimbaV2Block(width, activation=ACTIVATIONS[network.activation])(features)
         return features
     raise ValueError(f"Unsupported network body: {network.kind!r}")

--- a/model_builder/model_config.py
+++ b/model_builder/model_config.py
@@ -49,18 +49,19 @@ class MLPConfig:
 @dataclass(frozen=True)
 class ResidualConfig:
     kind: Literal["simba", "simbav2", "flashsac"]
-    width: int = 256
-    blocks: int = 2
+    blocks: tuple[int, ...] = (256, 256)
     activation: str = "relu"
     embedding_mode: str = "normal"
 
     def __post_init__(self):
         if self.kind not in ("simba", "simbav2", "flashsac"):
             raise ValueError(f"Unknown residual network type: {self.kind!r}")
-        if type(self.width) is not int or self.width < 1:
-            raise ValueError("Residual width must be a positive integer")
-        if type(self.blocks) is not int or self.blocks < 0:
-            raise ValueError("Residual blocks must be a nonnegative integer")
+        if (
+            not isinstance(self.blocks, tuple)
+            or not self.blocks
+            or any(type(width) is not int or width < 1 for width in self.blocks)
+        ):
+            raise ValueError("Residual blocks must contain at least one positive integer width")
         if not isinstance(self.activation, str) or self.activation not in ACTIVATIONS:
             raise ValueError(f"Unknown activation: {self.activation!r}; use {sorted(ACTIVATIONS)}")
         if not isinstance(self.embedding_mode, str) or self.embedding_mode not in EMBEDDING_MODES:
@@ -114,18 +115,19 @@ def parse_model_config(value: object) -> ModelConfig:
     kind = options["type"]
     if not isinstance(kind, str) or kind not in kinds:
         raise ValueError(f"Unknown model type: {kind!r}")
-    if set(options) - {"type", "width", "blocks", "activation", "embedding_mode"} or not {
-        "width",
-        "blocks",
-    } <= set(options):
+    if set(options) - {"type", "blocks", "activation", "embedding_mode"} or "blocks" not in options:
         raise ValueError(
-            "Residual JSON requires width/blocks and accepts "
-            "type/width/blocks/activation/embedding_mode"
+            "Residual JSON requires 'blocks' and accepts type/blocks/activation/embedding_mode"
         )
-    width, blocks, activation = options["width"], options["blocks"], options["activation"]
-    if type(width) is not int or type(blocks) is not int or not isinstance(activation, str):
-        raise ValueError("Residual width/blocks must be integers and activation must be a name")
-    return ResidualConfig(kinds[kind], width, blocks, activation, embedding_mode=embedding_mode)
+    blocks, activation = options["blocks"], options["activation"]
+    if not isinstance(blocks, list) or not isinstance(activation, str):
+        raise TypeError("Residual blocks must be a JSON array and activation must be a name")
+    widths = []
+    for width in blocks:
+        if type(width) is not int:
+            raise TypeError("Residual block widths must be integers")
+        widths.append(width)
+    return ResidualConfig(kinds[kind], tuple(widths), activation, embedding_mode=embedding_mode)
 
 
 def load_model_config(path: str | Path) -> ModelConfig:
@@ -146,8 +148,7 @@ def model_config_dict(config: ModelConfig) -> dict:
         }
     return {
         "type": config.kind,
-        "width": config.width,
-        "blocks": config.blocks,
+        "blocks": list(config.blocks),
         "activation": config.activation,
         "embedding_mode": config.embedding_mode,
     }

--- a/tests/test_flax_dpg_builder_param_tree.py
+++ b/tests/test_flax_dpg_builder_param_tree.py
@@ -35,18 +35,18 @@ _NETWORK_CONFIGURATIONS = [
         {"Dense_0", "Dense_1", "Dense_2"},
     ),
     (
-        ResidualConfig("simba", 16),
-        ResidualConfig("simba", 32),
+        ResidualConfig("simba", (16, 16)),
+        ResidualConfig("simba", (32, 32)),
         {"Dense_0", "ResidualBlock_0", "ResidualBlock_1", "LayerNorm_0", "Dense_1"},
     ),
     (
-        ResidualConfig("simbav2", 16),
-        ResidualConfig("simbav2", 32),
+        ResidualConfig("simbav2", (16, 16)),
+        ResidualConfig("simbav2", (32, 32)),
         {"SimbaV2Embedding_0", "SimbaV2Block_0", "SimbaV2Block_1", "SimbaV2Head_0"},
     ),
     (
         _POLICY_KWARGS["actor_model"],
-        ResidualConfig("simbav2", 32),
+        ResidualConfig("simbav2", (32, 32)),
         {"SimbaV2Embedding_0", "SimbaV2Block_0", "SimbaV2Block_1", "SimbaV2Head_0"},
     ),
 ]

--- a/tests/test_observation_role_isolation.py
+++ b/tests/test_observation_role_isolation.py
@@ -58,8 +58,8 @@ def test_actor_critic_observation_roles_are_isolated(backend, family):
     "backend, actor_model, critic_model",
     [
         ("flax", MLPConfig((LayerConfig(16),)), MLPConfig((LayerConfig(32),))),
-        ("flax", ResidualConfig("simba", 16), ResidualConfig("simba", 32)),
-        ("flax", ResidualConfig("simbav2", 16), ResidualConfig("simbav2", 32)),
+        ("flax", ResidualConfig("simba", (16, 16)), ResidualConfig("simba", (32, 32))),
+        ("flax", ResidualConfig("simbav2", (16, 16)), ResidualConfig("simbav2", (32, 32))),
         ("haiku", MLPConfig((LayerConfig(16),)), MLPConfig((LayerConfig(32),))),
     ],
 )

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -83,8 +83,8 @@ def test_other_stochastic_dpg_algorithms_also_use_mode_for_evaluation(cls):
 def test_crossq_actors_have_no_batch_stats_but_critics_do():
     for actor_config, critic_config in (
         (MLPConfig((LayerConfig(16),)), MLPConfig((LayerConfig(128, "tanh"),))),
-        (ResidualConfig("simba", 16, 1), ResidualConfig("simba", 32, 1)),
-        (ResidualConfig("simbav2", 16, 1), MLPConfig((LayerConfig(32, "tanh"),))),
+        (ResidualConfig("simba", (16,)), ResidualConfig("simba", (32,))),
+        (ResidualConfig("simbav2", (16,)), MLPConfig((LayerConfig(32, "tanh"),))),
     ):
         builder = crossq_model_builder_maker(
             {"unified_obs": [4]},


### PR DESCRIPTION
SIMBA·SIMBAv2·FlashSAC의 `width: 512, blocks: 2` 설정을 `blocks: [512, 512]`로 바꿉니다. 각 값이 블록의 출력 너비이므로 서로 다른 너비도 지정할 수 있습니다.

```json
{
  "type": "simba",
  "blocks": [512, 256],
  "activation": "relu",
  "embedding_mode": "normal"
}
```

첫 블록 너비는 입력 임베딩에, 마지막 블록 너비는 출력 헤드에 반영됩니다. 너비가 바뀌는 구간에는 해당 모델의 투영층을 적용합니다. 이전 `width` 필드, 정수형 `blocks`, 빈 배열은 오류로 처리하며 프리셋 5개와 기존 테스트도 함께 전환합니다.

앞선 JSON 모델 설정 PR #49를 base로 하므로 변경 범위는 17개 파일입니다. 같은 너비를 반복한 설정은 기존 파라미터 구조와 초기화·출력을 유지합니다.

검증: 동일 너비 모델 13개의 파라미터·출력 일치, 서로 다른 너비 모델 13개의 순전파, 잔차 본체 12개의 유한한 출력·기울기를 확인했습니다. 실제 CLI에서 SIMBA/SIMBAv2 혼합 SAC와 FlashSAC을 각각 환경 8스텝·학습 갱신 7회 실행했고 저장한 파라미터가 유한했습니다. 관련 테스트 84개와 필수 커밋 훅도 통과했습니다.
