### PR TITLE
fix: mjlab GPU 스냅샷의 메모리 소유권 보장

### DIFF
--- a/env_builder/mjlab_env.py
+++ b/env_builder/mjlab_env.py
@@ -81,10 +81,10 @@ class MjlabVectorizedEnv(VectorizedEnv):
         if not self.jax_arrays:
             return _to_numpy(value).copy()
         if isinstance(value, self._torch.Tensor):
-            # Clone on the producer stream before mjlab mutates/reset its buffers.
-            return jax.dlpack.from_dlpack(
-                value.detach().clone(memory_format=self._torch.contiguous_format)
-            )
+            # Finish the copy while the Torch storage is owned and before mjlab reuses it.
+            contiguous = value.detach().contiguous()
+            imported = jax.dlpack.from_dlpack(contiguous)
+            return jnp.array(imported, copy=True).block_until_ready()
         return jnp.array(value, copy=True)
 
     def _snapshot(self, value):


### PR DESCRIPTION
mjlab가 출력용 Torch 저장소를 재사용할 때, DLPack으로 전달한 과거 관측·보상·종료 플래그가 이후 스텝의 값으로 바뀔 수 있습니다. Torch 텐서와 imported 배열을 유지한 상태에서 JAX 소유 배열로 복사하고, 복사가 완료된 뒤 반환하도록 수정합니다. 비연속 텐서도 지원합니다.

Torch 배열마다 복사 완료를 기다리는 지점이 추가되므로 GPU 계산과 호스트 실행의 겹침이 줄어들 수 있습니다.
