### PR TITLE
feat: replay 샘플링·학습을 합치는 공통 JIT 실행 경로

### DIFF
--- a/jax_baselines/core/replay_training.py
+++ b/jax_baselines/core/replay_training.py
@@ -1,0 +1,125 @@
+"""GPU replay sampling and learner dispatch through a functional adapter seam."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import jax
+import jax.numpy as jnp
+
+from jax_baselines.core.bulk_training import (
+    flatten_bulk_batch,
+    normalize_bulk_weights,
+    reshape_bulk_batch,
+)
+from jax_baselines.core.normalization import (
+    FlashSACRewardNormalizer,
+    RewardNormalizer,
+    _normalize_device_observations,
+)
+
+
+class ReplayTrainingBuffer(Protocol):
+    def train(
+        self,
+        batch: ReplayTrainingBatch,
+        learner: Callable[..., Any],
+        args: tuple,
+        *,
+        bulk: bool,
+        priority_index: int | None,
+    ) -> Any:
+        ...
+
+
+@dataclass(frozen=True)
+class ReplayTrainingBatch:
+    """A pending sample; normalization statistics are snapshots for this pulse."""
+
+    replay: ReplayTrainingBuffer
+    sample_size: int
+    beta: float
+    chunk_size: int = 0
+    observation_statistics: tuple[dict[str, jax.Array], dict[str, jax.Array]] | None = None
+    reward_statistics: tuple[jax.Array, jax.Array | None] | None = None
+
+
+def reward_normalization_statistics(normalizer: RewardNormalizer | None):
+    if normalizer is None:
+        return None
+    minimum_scale = (
+        normalizer.max_abs_return / normalizer.normalized_G_max
+        if isinstance(normalizer, FlashSACRewardNormalizer)
+        else None
+    )
+    return normalizer.rms.vars["return"], minimum_scale
+
+
+def train_replay_batch(learner, data, *args, priority_index=-1):
+    if isinstance(data, ReplayTrainingBatch):
+        return data.replay.train(data, learner, args, bulk=False, priority_index=priority_index)
+    return learner(*args, **data)
+
+
+def train_replay_bulk(learner, data, carry, keys, steps, *, priority_index=-1):
+    if isinstance(data, ReplayTrainingBatch):
+        return data.replay.train(
+            data,
+            learner,
+            (carry, keys, steps),
+            bulk=True,
+            priority_index=priority_index,
+        )
+    return learner(carry, keys, steps, data)
+
+
+def train_replay(
+    state,
+    key,
+    args,
+    observation_statistics,
+    reward_statistics,
+    *,
+    sample,
+    update,
+    learner,
+    sample_size,
+    beta,
+    chunk_size,
+    bulk,
+    priority_index,
+):
+    key, data = sample(state, key, sample_size, beta)
+    chunk_size = chunk_size or (1 if bulk else 0)
+    if chunk_size:
+        data = normalize_bulk_weights(
+            reshape_bulk_batch(data, chunk_size, sample_size // chunk_size)
+        )
+    if observation_statistics is not None:
+        means, variances = observation_statistics
+        data["obses"] = _normalize_device_observations(data["obses"], means, variances)
+        data["nxtobses"] = _normalize_device_observations(data["nxtobses"], means, variances)
+    if reward_statistics is not None:
+        variance, minimum_scale = reward_statistics
+        scale = jnp.sqrt(variance + 1e-8)
+        if minimum_scale is not None:
+            scale = jnp.maximum(scale, minimum_scale)
+        data["rewards"] = data["rewards"] / scale
+    if bulk:
+        result = learner(*args, data)
+    else:
+        if chunk_size:
+            data = flatten_bulk_batch(data)
+        result = learner(*args, **data)
+    if update is not None:
+        if priority_index is None:
+            raise ValueError("Prioritized replay requires a learner priority output")
+        priorities = result[1][priority_index] if bulk else result[priority_index]
+        indexes = jnp.asarray(data["indexes"], dtype=jnp.int32).reshape(-1)
+        priorities = jnp.asarray(priorities, dtype=jnp.float32).reshape(-1)
+        if indexes.shape != priorities.shape or not indexes.size:
+            raise ValueError("Priority indexes and values must have matching non-empty shapes")
+        state = update(state, indexes, priorities)
+    return state, key, result

--- a/replay_memory/flashbax_buffer.py
+++ b/replay_memory/flashbax_buffer.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 from flashbax.buffers import prioritised_trajectory_buffer, sum_tree, trajectory_buffer
 
 from jax_baselines.core.replay_protocol import LocalReplayNeed, SelfPredictionReplayNeed
+from jax_baselines.core.replay_training import ReplayTrainingBatch, train_replay
 
 
 class FlashbaxReplayBuffer:
@@ -62,6 +63,7 @@ class FlashbaxReplayBuffer:
         self._add_compiled = jax.jit(self._add, donate_argnums=(0, 1))
         self._sample_compiled = jax.jit(self._sample, static_argnums=(2, 3))
         self._update_compiled = jax.jit(self._update_priorities, donate_argnums=(0,))
+        self._trainers = {}
         self.clear()
 
     def clear(self):
@@ -245,14 +247,69 @@ class FlashbaxReplayBuffer:
         )
 
     def sample(self, batch_size: int, beta=0.4):
+        self._validate_sample(batch_size, beta)
+        self._key, batch = self._sample_compiled(self.state, self._key, batch_size, beta)
+        return batch
+
+    def _validate_sample(self, batch_size, beta):
         if batch_size < 1 or not 0 <= beta <= 1:
             raise ValueError("batch_size must be positive and beta must be in [0, 1]")
         if not self._sample_ready:
             if len(self) == 0:
                 raise ValueError("Cannot sample from empty replay")
             self._sample_ready = True
-        self._key, batch = self._sample_compiled(self.state, self._key, batch_size, beta)
-        return batch
+
+    def train(self, batch: ReplayTrainingBatch, learner, args, *, bulk, priority_index):
+        self._validate_sample(batch.sample_size, batch.beta)
+        if batch.chunk_size < 0 or (batch.chunk_size and batch.sample_size % batch.chunk_size):
+            raise ValueError("Replay sample size must divide evenly into positive chunks")
+        runner_key = (learner, bulk, priority_index)
+        if runner_key not in self._trainers:
+            # Keep callables out of static keys and partial signature defaults:
+            # both can retain finished agents through JAX's global caches.
+            def train(
+                state,
+                key,
+                args,
+                observation_statistics,
+                reward_statistics,
+                *,
+                sample_size,
+                beta,
+                chunk_size,
+            ):
+                return train_replay(
+                    state,
+                    key,
+                    args,
+                    observation_statistics,
+                    reward_statistics,
+                    sample=self._sample,
+                    update=self._update_priorities if self.priority is not None else None,
+                    learner=learner,
+                    sample_size=sample_size,
+                    beta=beta,
+                    chunk_size=chunk_size,
+                    bulk=bulk,
+                    priority_index=priority_index,
+                )
+
+            self._trainers[runner_key] = jax.jit(
+                train,
+                static_argnames=("sample_size", "beta", "chunk_size"),
+                donate_argnums=(0,),
+            )
+        self.state, self._key, result = self._trainers[runner_key](
+            self.state,
+            self._key,
+            args,
+            batch.observation_statistics,
+            batch.reward_statistics,
+            sample_size=batch.sample_size,
+            beta=batch.beta,
+            chunk_size=batch.chunk_size,
+        )
+        return result
 
     def _sample(self, state, key, batch_size, beta):
         key, sample_key = jax.random.split(key)


### PR DESCRIPTION
GPU replay의 샘플링과 학습을 한 JIT 호출에서 실행할 공통 기반을 추가합니다. replay 상태·RNG·정규화 통계를 전달해 샘플링, learner 호출, PER 갱신을 묶으며 CPU의 기존 dict 배치도 같은 호출부에서 처리할 수 있습니다. 실제 알고리즘 연결은 다음 PR에 있습니다.

Flashbax 어댑터가 컴파일된 함수를 소유하고, learner를 전역 JIT 캐시의 static key나 callable 기본 인자에 넣지 않아 종료된 agent와 buffer의 수거를 막지 않도록 합니다. 코어는 replay 프로토콜에 의존하며 어댑터를 import하지 않습니다.
