### PR TITLE
perf: Q-Net·DPG GPU replay 샘플링을 학습 JIT에 통합

### DIFF
--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -6,6 +6,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -118,7 +119,9 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.policy_params,
             self.critic_params,
             self.opt_policy_state,
@@ -127,7 +130,6 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             next(self.key_seq),
             context.train_steps_count,
             self.log_ent_coef,
-            **data,
         )
         return DPGTrainReport(
             loss=loss,
@@ -157,7 +159,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 self.log_ent_coef,
             ),
             (losses, targets, ent_coefs, priorities),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -7,6 +7,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.ou_noise import OUNoise
 from jax_baselines.DDPG.training import DPGTrainReport
@@ -131,7 +132,9 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.policy_params,
             self.critic_params,
             self.target_policy_params,
@@ -140,7 +143,6 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             self.opt_critic_state,
             context.train_steps_count,
             next(self.key_seq),
-            **data,
         )
         return DPGTrainReport(loss=loss, target=t_mean, new_priorities=new_priorities)
 
@@ -165,7 +167,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
                 self.opt_critic_state,
             ),
             (losses, targets, priorities),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/DDPG/training.py
+++ b/jax_baselines/DDPG/training.py
@@ -20,6 +20,10 @@ from jax_baselines.core.bulk_training import (
     reshape_bulk_batch,
     uses_bulk_pulse,
 )
+from jax_baselines.core.replay_training import (
+    ReplayTrainingBatch,
+    reward_normalization_statistics,
+)
 
 
 @dataclass(frozen=True)
@@ -97,18 +101,14 @@ class DPGTrainingLifecycle:
     def _train_one_bulk_chunk(self, steps, chunk_size, train_on_bulk):
         contexts = make_train_contexts(self.agent, DPGTrainContext, steps, chunk_size)
 
-        data = self._sample_batch(chunk_size * self.agent.batch_size)
-        data = self._reshape_bulk_batch(data, chunk_size)
-        data = normalize_bulk_weights(data)
-        self._normalize_batch(data)
+        data = self._prepare_batch(chunk_size)
         report = train_on_bulk(data, contexts)
         self._update_priorities(data, report)
         return report
 
     def _train_one_batch(self, steps):
         self.agent.train_steps_count += 1
-        data = self._sample_batch()
-        self._normalize_batch(data)
+        data = self._prepare_batch()
         context = DPGTrainContext(
             steps=steps,
             train_steps_count=self.agent.train_steps_count,
@@ -116,6 +116,24 @@ class DPGTrainingLifecycle:
         report = self.agent._train_on_batch(data, context)
         self._update_priorities(data, report)
         return report
+
+    def _prepare_batch(self, chunk_size=0):
+        sample_size = (chunk_size or 1) * self.agent.batch_size
+        if self.agent.memory_backend == "gpu":
+            obs_rms = self.agent._policy_update_obs_rms() if self.agent.obs_rms_norm else None
+            return ReplayTrainingBatch(
+                replay=self.agent.replay_buffer,
+                sample_size=sample_size,
+                beta=self.agent.prioritized_replay_beta0,
+                chunk_size=chunk_size,
+                observation_statistics=None if obs_rms is None else (obs_rms.means, obs_rms.vars),
+                reward_statistics=reward_normalization_statistics(self.agent.reward_normalizer),
+            )
+        data = self._sample_batch(sample_size)
+        if chunk_size:
+            data = normalize_bulk_weights(self._reshape_bulk_batch(data, chunk_size))
+        self._normalize_batch(data)
+        return data
 
     def _sample_batch(self, batch_size=None):
         batch_size = self.agent.batch_size if batch_size is None else batch_size
@@ -138,7 +156,7 @@ class DPGTrainingLifecycle:
             data["rewards"] = self.agent.reward_normalizer.normalize(data["rewards"])
 
     def _update_priorities(self, data, report):
-        if not self.agent.prioritized_replay:
+        if not self.agent.prioritized_replay or isinstance(data, ReplayTrainingBatch):
             return
         convert = (
             flatten_priority_values

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -21,6 +21,7 @@ from jax_baselines.core.replay_protocol import (
     require_replay_factory,
     select_replay_device,
 )
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.core.rollout import (
     ActionSelection,
     CheckpointTrainPulse,
@@ -280,13 +281,14 @@ class Q_Network_Family:
             loss,
             target,
             priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.params,
             self.target_params,
             self.opt_state,
             context.train_steps_count,
             next(self.key_seq) if self.param_noise else None,
-            **data,
         )
         return QNetTrainResult.from_values(loss=loss, target=target, replay_priorities=priorities)
 
@@ -301,7 +303,7 @@ class Q_Network_Family:
                 targets,
                 priorities,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/DQN/training.py
+++ b/jax_baselines/DQN/training.py
@@ -21,6 +21,10 @@ from jax_baselines.core.bulk_training import (
     reshape_bulk_batch,
     uses_bulk_pulse,
 )
+from jax_baselines.core.replay_training import (
+    ReplayTrainingBatch,
+    reward_normalization_statistics,
+)
 
 
 @dataclass(frozen=True)
@@ -112,8 +116,7 @@ class QNetTrainingLifecycle:
 
     def _train_one_batch(self, steps, gradient_steps):
         self.agent.train_steps_count += 1
-        data = self.agent._sample_batch()
-        self._normalize_batch(data)
+        data = self._prepare_batch()
         context = QNetTrainContext(
             steps=steps,
             train_steps_count=self.agent.train_steps_count,
@@ -141,10 +144,7 @@ class QNetTrainingLifecycle:
                 chunk_size,
                 gradient_steps=chunk_size,
             )
-            data = self.agent._sample_batch(chunk_size * self.agent.batch_size)
-            data = self._reshape_bulk_batch(data, chunk_size)
-            data = normalize_bulk_weights(data)
-            self._normalize_batch(data)
+            data = self._prepare_batch(chunk_size)
             result = self._normalise_train_result(train_on_bulk(data, contexts))
             self._update_priorities(data, result)
             reports.append(result.report)
@@ -155,6 +155,22 @@ class QNetTrainingLifecycle:
             remaining -= 1
 
         return self.agent._aggregate_train_reports(reports)
+
+    def _prepare_batch(self, chunk_size=0):
+        sample_size = (chunk_size or 1) * self.agent.batch_size
+        if self.agent.memory_backend == "gpu":
+            return ReplayTrainingBatch(
+                replay=self.agent.replay_buffer,
+                sample_size=sample_size,
+                beta=self.agent.prioritized_replay_beta0,
+                chunk_size=chunk_size,
+                reward_statistics=reward_normalization_statistics(self.agent.reward_normalizer),
+            )
+        data = self.agent._sample_batch(sample_size)
+        if chunk_size:
+            data = normalize_bulk_weights(self._reshape_bulk_batch(data, chunk_size))
+        self._normalize_batch(data)
+        return data
 
     def _reshape_bulk_batch(self, data, chunk_size):
         return reshape_bulk_batch(data, chunk_size, self.agent.batch_size)
@@ -174,7 +190,7 @@ class QNetTrainingLifecycle:
         )
 
     def _update_priorities(self, data, result):
-        if not self.agent.prioritized_replay:
+        if not self.agent.prioritized_replay or isinstance(data, ReplayTrainingBatch):
             return
 
         if data is None:

--- a/jax_baselines/FQF/fqf.py
+++ b/jax_baselines/FQF/fqf.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 import optax
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -104,7 +105,9 @@ class FQF(Q_Network_Family):
             t_std,
             tau,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.params,
             self.fqf_params,
             self.target_params,
@@ -112,7 +115,6 @@ class FQF(Q_Network_Family):
             self.fqf_opt_state,
             context.train_steps_count,
             next(self.key_seq),
-            **data,
         )
 
         return QNetTrainResult.from_values(
@@ -149,7 +151,7 @@ class FQF(Q_Network_Family):
                 taus,
                 priorities,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/FlashSAC/flashsac.py
+++ b/jax_baselines/FlashSAC/flashsac.py
@@ -14,6 +14,7 @@ import optax
 from flax import struct
 
 from jax_baselines.core.normalization import FlashSACRewardNormalizer
+from jax_baselines.core.replay_training import ReplayTrainingBatch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.distributional import categorical_projection
@@ -196,10 +197,17 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         return jnp.tanh(mean)
 
     def _train_on_batch(self, data, context):
-        return self._train_on_bulk(jax.tree.map(lambda x: jnp.expand_dims(x, 0), data), [context])
+        return self._train_on_bulk(
+            data
+            if isinstance(data, ReplayTrainingBatch)
+            else jax.tree.map(lambda x: jnp.expand_dims(x, 0), data),
+            [context],
+        )
 
     def _train_on_bulk(self, data, contexts):
-        carry, metrics = self._compiled_updates(
+        carry, metrics = train_replay_bulk(
+            self._compiled_updates,
+            data,
             (
                 self.policy_params,
                 self.critic_params,
@@ -211,7 +219,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             ),
             jax.random.split(next(self.key_seq), len(contexts)),
             jnp.asarray([context.train_steps_count for context in contexts]),
-            data,
+            priority_index=None,
         )
         (
             self.policy_params,

--- a/jax_baselines/IQN/iqn.py
+++ b/jax_baselines/IQN/iqn.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 import optax
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -82,13 +83,14 @@ class IQN(Q_Network_Family):
             t_mean,
             t_std,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.params,
             self.target_params,
             self.opt_state,
             context.train_steps_count,
             next(self.key_seq),
-            **data,
         )
         return QNetTrainResult.from_values(
             loss=loss,
@@ -109,7 +111,7 @@ class IQN(Q_Network_Family):
                 target_stds,
                 priorities,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/QRDQN/qrdqn.py
+++ b/jax_baselines/QRDQN/qrdqn.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 import optax
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -77,13 +78,14 @@ class QRDQN(Q_Network_Family):
             t_mean,
             t_std,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.params,
             self.target_params,
             self.opt_state,
             context.train_steps_count,
             next(self.key_seq) if self.param_noise else None,
-            **data,
         )
         return QNetTrainResult.from_values(
             loss=loss,
@@ -104,7 +106,7 @@ class QRDQN(Q_Network_Family):
                 target_stds,
                 priorities,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -7,6 +7,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -128,7 +129,9 @@ class SAC(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.policy_params,
             self.critic_params,
             self.target_critic_params,
@@ -138,7 +141,6 @@ class SAC(Deteministic_Policy_Gradient_Family):
             next(self.key_seq),
             context.train_steps_count,
             self.log_ent_coef,
-            **data,
         )
         return DPGTrainReport(
             loss=loss,
@@ -170,7 +172,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
                 self.log_ent_coef,
             ),
             (losses, targets, ent_coefs, priorities),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/SPR/spr.py
+++ b/jax_baselines/SPR/spr.py
@@ -12,6 +12,7 @@ from jax_baselines.core.replay_protocol import (
     SelfPredictionReplayNeed,
     require_replay_factory,
 )
+from jax_baselines.core.replay_training import ReplayTrainingBatch, train_replay_batch
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import (
     QNetTrainContext,
@@ -169,13 +170,15 @@ class SPR(Q_Network_Family):
             t_mean,
             new_priorities,
             rprloss,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.params,
             self.target_params,
             self.opt_state,
             context.train_steps_count,
             next(self.key_seq),
-            **data,
+            priority_index=-2,
         )
 
         return QNetTrainResult.from_values(
@@ -187,7 +190,7 @@ class SPR(Q_Network_Family):
 
     def _train_on_bulk(self, data, contexts):
         result = self._train_on_batch(
-            flatten_bulk_batch(data),
+            data if isinstance(data, ReplayTrainingBatch) else flatten_bulk_batch(data),
             QNetTrainContext(
                 steps=contexts[0].steps,
                 train_steps_count=contexts[0].train_steps_count,

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -7,6 +7,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -111,7 +112,9 @@ class TD3(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.policy_params,
             self.critic_params,
             self.target_policy_params,
@@ -120,7 +123,6 @@ class TD3(Deteministic_Policy_Gradient_Family):
             self.opt_critic_state,
             next(self.key_seq),
             context.train_steps_count,
-            **data,
         )
         return DPGTrainReport(loss=loss, target=t_mean, new_priorities=new_priorities)
 
@@ -145,7 +147,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 self.opt_critic_state,
             ),
             (losses, targets, priorities),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -8,6 +8,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
@@ -185,7 +186,9 @@ class TD7(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
-        ) = self._compiled_train_step(
+        ) = train_replay_batch(
+            self._compiled_train_step,
+            data,
             self.actor_encoder_params,
             self.critic_encoder_params,
             self.policy_params,
@@ -202,7 +205,6 @@ class TD7(Deteministic_Policy_Gradient_Family):
             self.opt_critic_state,
             next(self.key_seq),
             context.train_steps_count,
-            **data,
         )
         return DPGTrainReport(
             loss=loss,
@@ -248,7 +250,7 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 self.opt_critic_state,
             ),
             (repr_losses, losses, targets, priorities),
-        ) = self._compiled_bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._compiled_bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -7,6 +7,7 @@ import numpy as np
 import optax
 from flax import struct
 
+from jax_baselines.core.replay_training import train_replay_batch, train_replay_bulk
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.distributional import categorical_projection
@@ -152,7 +153,9 @@ class XQC(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
-        ) = self._train_step(
+        ) = train_replay_batch(
+            self._train_step,
+            data,
             self.policy_params,
             self.critic_params,
             self.target_critic_params,
@@ -162,7 +165,6 @@ class XQC(Deteministic_Policy_Gradient_Family):
             next(self.key_seq),
             context.train_steps_count,
             self.log_ent_coef,
-            **data,
         )
         return DPGTrainReport(
             loss=loss,
@@ -194,7 +196,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 self.log_ent_coef,
             ),
             (losses, targets, ent_coefs, priorities),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = train_replay_bulk(self._bulk_scan, data, carry, keys, steps)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),

--- a/jax_baselines/core/replay_training.py
+++ b/jax_baselines/core/replay_training.py
@@ -1,0 +1,125 @@
+"""GPU replay sampling and learner dispatch through a functional adapter seam."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import jax
+import jax.numpy as jnp
+
+from jax_baselines.core.bulk_training import (
+    flatten_bulk_batch,
+    normalize_bulk_weights,
+    reshape_bulk_batch,
+)
+from jax_baselines.core.normalization import (
+    FlashSACRewardNormalizer,
+    RewardNormalizer,
+    _normalize_device_observations,
+)
+
+
+class ReplayTrainingBuffer(Protocol):
+    def train(
+        self,
+        batch: ReplayTrainingBatch,
+        learner: Callable[..., Any],
+        args: tuple,
+        *,
+        bulk: bool,
+        priority_index: int | None,
+    ) -> Any:
+        ...
+
+
+@dataclass(frozen=True)
+class ReplayTrainingBatch:
+    """A pending sample; normalization statistics are snapshots for this pulse."""
+
+    replay: ReplayTrainingBuffer
+    sample_size: int
+    beta: float
+    chunk_size: int = 0
+    observation_statistics: tuple[dict[str, jax.Array], dict[str, jax.Array]] | None = None
+    reward_statistics: tuple[jax.Array, jax.Array | None] | None = None
+
+
+def reward_normalization_statistics(normalizer: RewardNormalizer | None):
+    if normalizer is None:
+        return None
+    minimum_scale = (
+        normalizer.max_abs_return / normalizer.normalized_G_max
+        if isinstance(normalizer, FlashSACRewardNormalizer)
+        else None
+    )
+    return normalizer.rms.vars["return"], minimum_scale
+
+
+def train_replay_batch(learner, data, *args, priority_index=-1):
+    if isinstance(data, ReplayTrainingBatch):
+        return data.replay.train(data, learner, args, bulk=False, priority_index=priority_index)
+    return learner(*args, **data)
+
+
+def train_replay_bulk(learner, data, carry, keys, steps, *, priority_index=-1):
+    if isinstance(data, ReplayTrainingBatch):
+        return data.replay.train(
+            data,
+            learner,
+            (carry, keys, steps),
+            bulk=True,
+            priority_index=priority_index,
+        )
+    return learner(carry, keys, steps, data)
+
+
+def train_replay(
+    state,
+    key,
+    args,
+    observation_statistics,
+    reward_statistics,
+    *,
+    sample,
+    update,
+    learner,
+    sample_size,
+    beta,
+    chunk_size,
+    bulk,
+    priority_index,
+):
+    key, data = sample(state, key, sample_size, beta)
+    chunk_size = chunk_size or (1 if bulk else 0)
+    if chunk_size:
+        data = normalize_bulk_weights(
+            reshape_bulk_batch(data, chunk_size, sample_size // chunk_size)
+        )
+    if observation_statistics is not None:
+        means, variances = observation_statistics
+        data["obses"] = _normalize_device_observations(data["obses"], means, variances)
+        data["nxtobses"] = _normalize_device_observations(data["nxtobses"], means, variances)
+    if reward_statistics is not None:
+        variance, minimum_scale = reward_statistics
+        scale = jnp.sqrt(variance + 1e-8)
+        if minimum_scale is not None:
+            scale = jnp.maximum(scale, minimum_scale)
+        data["rewards"] = data["rewards"] / scale
+    if bulk:
+        result = learner(*args, data)
+    else:
+        if chunk_size:
+            data = flatten_bulk_batch(data)
+        result = learner(*args, **data)
+    if update is not None:
+        if priority_index is None:
+            raise ValueError("Prioritized replay requires a learner priority output")
+        priorities = result[1][priority_index] if bulk else result[priority_index]
+        indexes = jnp.asarray(data["indexes"], dtype=jnp.int32).reshape(-1)
+        priorities = jnp.asarray(priorities, dtype=jnp.float32).reshape(-1)
+        if indexes.shape != priorities.shape or not indexes.size:
+            raise ValueError("Priority indexes and values must have matching non-empty shapes")
+        state = update(state, indexes, priorities)
+    return state, key, result

--- a/replay_memory/flashbax_buffer.py
+++ b/replay_memory/flashbax_buffer.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 from flashbax.buffers import prioritised_trajectory_buffer, sum_tree, trajectory_buffer
 
 from jax_baselines.core.replay_protocol import LocalReplayNeed, SelfPredictionReplayNeed
+from jax_baselines.core.replay_training import ReplayTrainingBatch, train_replay
 
 
 class FlashbaxReplayBuffer:
@@ -62,6 +63,7 @@ class FlashbaxReplayBuffer:
         self._add_compiled = jax.jit(self._add, donate_argnums=(0, 1))
         self._sample_compiled = jax.jit(self._sample, static_argnums=(2, 3))
         self._update_compiled = jax.jit(self._update_priorities, donate_argnums=(0,))
+        self._trainers = {}
         self.clear()
 
     def clear(self):
@@ -245,14 +247,69 @@ class FlashbaxReplayBuffer:
         )
 
     def sample(self, batch_size: int, beta=0.4):
+        self._validate_sample(batch_size, beta)
+        self._key, batch = self._sample_compiled(self.state, self._key, batch_size, beta)
+        return batch
+
+    def _validate_sample(self, batch_size, beta):
         if batch_size < 1 or not 0 <= beta <= 1:
             raise ValueError("batch_size must be positive and beta must be in [0, 1]")
         if not self._sample_ready:
             if len(self) == 0:
                 raise ValueError("Cannot sample from empty replay")
             self._sample_ready = True
-        self._key, batch = self._sample_compiled(self.state, self._key, batch_size, beta)
-        return batch
+
+    def train(self, batch: ReplayTrainingBatch, learner, args, *, bulk, priority_index):
+        self._validate_sample(batch.sample_size, batch.beta)
+        if batch.chunk_size < 0 or (batch.chunk_size and batch.sample_size % batch.chunk_size):
+            raise ValueError("Replay sample size must divide evenly into positive chunks")
+        runner_key = (learner, bulk, priority_index)
+        if runner_key not in self._trainers:
+            # Keep callables out of static keys and partial signature defaults:
+            # both can retain finished agents through JAX's global caches.
+            def train(
+                state,
+                key,
+                args,
+                observation_statistics,
+                reward_statistics,
+                *,
+                sample_size,
+                beta,
+                chunk_size,
+            ):
+                return train_replay(
+                    state,
+                    key,
+                    args,
+                    observation_statistics,
+                    reward_statistics,
+                    sample=self._sample,
+                    update=self._update_priorities if self.priority is not None else None,
+                    learner=learner,
+                    sample_size=sample_size,
+                    beta=beta,
+                    chunk_size=chunk_size,
+                    bulk=bulk,
+                    priority_index=priority_index,
+                )
+
+            self._trainers[runner_key] = jax.jit(
+                train,
+                static_argnames=("sample_size", "beta", "chunk_size"),
+                donate_argnums=(0,),
+            )
+        self.state, self._key, result = self._trainers[runner_key](
+            self.state,
+            self._key,
+            args,
+            batch.observation_statistics,
+            batch.reward_statistics,
+            sample_size=batch.sample_size,
+            beta=batch.beta,
+            chunk_size=batch.chunk_size,
+        )
+        return result
 
     def _sample(self, state, key, batch_size, beta):
         key, sample_key = jax.random.split(key)

--- a/tests/test_dpg_training.py
+++ b/tests/test_dpg_training.py
@@ -90,6 +90,7 @@ class FakeLoggerRun:
 
 class FakeAgent:
     def __init__(self):
+        self.memory_backend = "cpu"
         self.replay_buffer = FakeReplayBuffer()
         self.batch_size = 4
         self.prioritized_replay = True

--- a/tests/test_frame_buffer.py
+++ b/tests/test_frame_buffer.py
@@ -140,6 +140,7 @@ def test_prioritized_sample_consistent_with_ground_truth():
 
 class _FrameBufferBulkAgent:
     def __init__(self, replay_buffer):
+        self.memory_backend = "cpu"
         self.replay_buffer = replay_buffer
         self.batch_size = 4
         self.max_bulk_updates_per_pulse = 2

--- a/tests/test_qnet_training.py
+++ b/tests/test_qnet_training.py
@@ -85,6 +85,7 @@ class FakeRewardNormalizer:
 
 class FakeAgent:
     def __init__(self):
+        self.memory_backend = "cpu"
         self.replay_buffer = FakeReplayBuffer()
         self.batch_size = 4
         self.prioritized_replay = True
@@ -454,6 +455,7 @@ def test_qnet_training_lifecycle_keeps_non_positive_bulk_cap_invalid():
 
 def test_spr_lineage_single_update_uses_scalar_path_without_bulk_hook():
     agent = SPR.__new__(SPR)
+    agent.memory_backend = "cpu"
     agent.max_bulk_updates_per_pulse = 8
     agent.replay_buffer = FakeReplayBuffer()
     agent.batch_size = 4


### PR DESCRIPTION
GPU memory backend의 Q-Net·DPG 학습이 샘플링 설명과 정규화 통계를 공통 replay JIT 경로에 전달하도록 연결합니다. 샘플링·정규화·학습·PER 갱신 사이의 개별 호출을 줄이고, 기존 CPU 배치 처리와 업데이트 횟수·RNG·chunk별 priority 갱신 순서를 유지합니다.

분포형 Q-Net과 SPR의 priority 반환 위치, FlashSAC의 bulk 경로, TD7 등 각 learner의 상태 구성을 함께 연결합니다. 기존 테스트의 fake agent에도 현재 계약인 memory_backend를 명시합니다.
