### PR TITLE
perf: AC GPU epoch 버퍼 조립을 학습 JIT에 통합

### DIFF
--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -25,10 +25,9 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         self.critic_opt_state = self.optimizer.init(self.critic_params)
         self._get_actions = jax.jit(self._get_actions)
         self._train_step = jax.jit(self._train_step)
+        self._train_rollout = jax.jit(self._train_rollout_step)
 
     def train_step(self, steps, logger_run=None):
-        data = self.buffer.get_buffer()
-
         (
             self.actor_params,
             self.critic_params,
@@ -38,14 +37,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             actor_loss,
             entropy_loss,
             targets,
-        ) = self._train_step(
-            self.actor_params,
-            self.critic_params,
-            self.actor_opt_state,
-            self.critic_opt_state,
-            None,
-            **data,
-        )
+        ) = self._train_epoch(None)
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)

--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -20,7 +20,7 @@ from jax_baselines.core.env_protocols import (
     log_environment_metrics,
     vector_autoreset_mask,
 )
-from jax_baselines.core.epoch_buffer import EpochBuffer
+from jax_baselines.core.epoch_buffer import EpochBatch, EpochBuffer, stack_transitions
 from jax_baselines.core.eval import (
     _normalize_action_for_step,
     evaluate_policy,
@@ -52,6 +52,8 @@ class Actor_Critic_Policy_Gradient_Family:
     _run_name = "A2C"
     actor: Callable
     _get_actions: Callable
+    _train_step: Callable
+    _train_rollout: Callable
     logger: AbstractContextManager
 
     def __init__(
@@ -225,8 +227,37 @@ class Actor_Critic_Policy_Gradient_Family:
     def setup_model(self):
         pass
 
-    def _train_step(self, steps):
-        pass
+    def _train_epoch(self, key):
+        args = (
+            self.actor_params,
+            self.critic_params,
+            self.actor_opt_state,
+            self.critic_opt_state,
+            key,
+        )
+        if self.memory_backend == "cpu":
+            return self._train_step(*args, **self.buffer.get_buffer())
+        result = self._train_rollout(*args, self.buffer.snapshot())
+        self.buffer.clear()
+        return result
+
+    def _train_rollout_step(
+        self,
+        actor_params,
+        critic_params,
+        actor_opt_state,
+        critic_opt_state,
+        key,
+        transitions: tuple[EpochBatch, ...],
+    ):
+        return self._train_step(
+            actor_params,
+            critic_params,
+            actor_opt_state,
+            critic_opt_state,
+            key,
+            **stack_transitions(transitions),
+        )
 
     def train_step(self, steps, logger_run=None):
         raise NotImplementedError

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -65,10 +65,9 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         self._get_actions = jax.jit(self._get_actions)
         self._preprocess = jax.jit(self._preprocess)
         self._train_step = jax.jit(self._train_step)
+        self._train_rollout = jax.jit(self._train_rollout_step)
 
     def train_step(self, steps, logger_run=None):
-        data = self.buffer.get_buffer()
-
         (
             self.actor_params,
             self.critic_params,
@@ -78,14 +77,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             actor_loss,
             entropy_loss,
             targets,
-        ) = self._train_step(
-            self.actor_params,
-            self.critic_params,
-            self.actor_opt_state,
-            self.critic_opt_state,
-            next(self.key_seq),
-            **data,
-        )
+        ) = self._train_epoch(next(self.key_seq))
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -65,10 +65,9 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         self._get_actions = jax.jit(self._get_actions)
         self._preprocess = jax.jit(self._preprocess)
         self._train_step = jax.jit(self._train_step)
+        self._train_rollout = jax.jit(self._train_rollout_step)
 
     def train_step(self, steps, logger_run=None):
-        data = self.buffer.get_buffer()
-
         (
             self.actor_params,
             self.critic_params,
@@ -79,14 +78,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             entropy_loss,
             kls,
             targets,
-        ) = self._train_step(
-            self.actor_params,
-            self.critic_params,
-            self.actor_opt_state,
-            self.critic_opt_state,
-            next(self.key_seq),
-            **data,
-        )
+        ) = self._train_epoch(next(self.key_seq))
 
         if logger_run:
             logger_run.log_metric("loss/critic_loss", critic_loss, steps)

--- a/jax_baselines/core/epoch_buffer.py
+++ b/jax_baselines/core/epoch_buffer.py
@@ -19,7 +19,7 @@ class EpochBatch(TypedDict):
 
 
 @jax.jit
-def _stack_transitions(transitions: list[EpochBatch]) -> EpochBatch:
+def stack_transitions(transitions: tuple[EpochBatch, ...]) -> EpochBatch:
     return jax.tree.map(lambda *values: jnp.stack(values, axis=1), *transitions)
 
 
@@ -116,9 +116,16 @@ class EpochBuffer:
             )
         self._transitions.append(transition)
 
-    def get_buffer(self) -> EpochBatch:
+    def snapshot(self) -> tuple[EpochBatch, ...]:
         if not self._transitions:
             raise ValueError("Cannot consume an empty EpochBuffer")
+        return tuple(self._transitions)
+
+    def clear(self) -> None:
+        self._transitions.clear()
+
+    def get_buffer(self) -> EpochBatch:
+        rollout = self.snapshot()
         if self.memory_backend == "cpu":
             transitions: EpochBatch = {
                 "obses": {
@@ -135,6 +142,6 @@ class EpochBuffer:
                 "truncateds": np.stack([row["truncateds"] for row in self._transitions], axis=1),
             }
         else:
-            transitions = _stack_transitions(self._transitions)
-        self._transitions.clear()
+            transitions = stack_transitions(rollout)
+        self.clear()
         return transitions

--- a/tests/test_returns_episode_boundary.py
+++ b/tests/test_returns_episode_boundary.py
@@ -27,6 +27,7 @@ from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.APE_X.dpg_worker import Ape_X_Worker as ApeXDPGWorker
 from jax_baselines.APE_X.worker import Ape_X_Worker as ApeXQWorker
 from jax_baselines.core.env_info import infer_action_meta
+from jax_baselines.core.rollout_stats import TrainingProgress
 from jax_baselines.IMPALA.base_class import IMPALA_Family
 from jax_baselines.IMPALA.worker import Impala_Worker
 from jax_baselines.math.returns import discount_with_terminated, get_gaes, get_vtrace
@@ -165,7 +166,7 @@ def _vtrace(rewards, rhos, c_ts, terminateds, truncateds, values, next_values):
 def test_vtrace_terminal_stops_bootstrap():
     # On-policy ratios (rho=1, c=0.95). Terminal at idx2 must zero the bootstrap
     # so vs[2] is just its own reward, not r + gamma*next_value.
-    on_policy = dict(rhos=[1, 1, 1, 1], c_ts=[0.95, 0.95, 0.95, 0.95])
+    on_policy = {"rhos": [1, 1, 1, 1], "c_ts": [0.95, 0.95, 0.95, 0.95]}
     vs = _vtrace(
         [1, 1, 1, 1],
         terminateds=[0, 0, 1, 0],
@@ -180,7 +181,7 @@ def test_vtrace_terminal_stops_bootstrap():
 def test_vtrace_truncation_keeps_bootstrap():
     # Truncation (term=0) still bootstraps from next_value at idx2, unlike a
     # terminal -- pins the term/trunc asymmetry the V-trace correction relies on.
-    on_policy = dict(rhos=[1, 1, 1, 1], c_ts=[0.95, 0.95, 0.95, 0.95])
+    on_policy = {"rhos": [1, 1, 1, 1], "c_ts": [0.95, 0.95, 0.95, 0.95]}
     vs = _vtrace(
         [1, 1, 1, 1],
         terminateds=[0, 0, 0, 0],
@@ -342,6 +343,7 @@ class _Ctx:
         self.eval_freq = 10_000
         self.log_interval = 10_000
         self.logger_run = _NullLogger()
+        self.progress = TrainingProgress()
 
 
 def test_a2c_vectorized_flags_autoreset_dummy_step_as_terminal():

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -469,6 +469,7 @@ class _EmptyBuffer:
 def test_on_policy_train_logger_is_explicit_and_not_retained(algorithm, train_result, metric_names):
     agent = algorithm.__new__(algorithm)
     agent.buffer = _EmptyBuffer()
+    agent.memory_backend = "cpu"
     agent.actor_params = "old-actor-params"
     agent.critic_params = "old-critic-params"
     agent.actor_opt_state = "old-actor-opt-state"


### PR DESCRIPTION
GPU epoch 버퍼가 전이 tuple을 학습 함수에 전달하여 stack 연산을 기존 learner JIT 내부에서 수행하도록 합니다. A2C·PPO·TPPO·SPO가 이 경로를 공유하며, GAE·순열·epoch 업데이트의 계산 순서와 CPU 배치 처리를 유지합니다.

GPU 버퍼는 학습 dispatch가 성공한 뒤 비웁니다. 컴파일·dispatch 실패 시 수집한 rollout을 보존하며, 기존 테스트 문맥에는 TrainingProgress와 memory_backend를 명시합니다.
