### PR TITLE
[1/4] 학습 지표 계산과 optimizer 계측 기반 추가

### DIFF
--- a/experiments/optimizers.py
+++ b/experiments/optimizers.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import optax
 
-from jax_baselines.optim import OptimizerFactory, adopt, optimizer_reset_by_period
+from jax_baselines.optim import (
+    OptimizerFactory,
+    adopt,
+    optimizer_reset_by_period,
+    track_optimizer,
+)
 
 
 def _require_contrib_transform(name: str):
@@ -68,7 +73,7 @@ def select_optimizer(optim_str, lr, eps=1e-2 / 256.0, weight_decay=1e-4, grad_ma
     if reset_steps is not None:
         optim = optimizer_reset_by_period(optim, reset_steps)
 
-    return optim
+    return track_optimizer(optim, lr, grad_max=grad_max, reset_steps=reset_steps)
 
 
 def make_optimizer_factory(
@@ -78,10 +83,10 @@ def make_optimizer_factory(
     weight_decay: float = 1e-4,
     grad_max: float | None = None,
 ) -> OptimizerFactory:
-    def factory(lr):
+    def factory(learning_rate: optax.ScalarOrSchedule) -> optax.GradientTransformation:
         return select_optimizer(
             optim_str,
-            lr,
+            learning_rate,
             eps=eps,
             weight_decay=weight_decay,
             grad_max=grad_max,

--- a/jax_baselines/math/distributional.py
+++ b/jax_baselines/math/distributional.py
@@ -17,11 +17,12 @@ decisions (the canonical Munchausen form is ``c51.py`` / ``hl_gauss_c51.py``).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Literal, Protocol, overload
 
 import jax
 import jax.numpy as jnp
 
+from jax_baselines.math.metrics import support_metrics
 from jax_baselines.math.policy_math import q_log_pi
 
 
@@ -138,11 +139,11 @@ class DistributionalBackend(Protocol):
         self,
         next_dists: jax.Array,
         weights: jax.Array,
-        entropy_shift: Optional[jax.Array],
+        entropy_shift: jax.Array | None,
         reward: jax.Array,
         not_terminated: jax.Array,
         gamma: jax.Array,
-    ) -> jax.Array:
+    ) -> tuple[jax.Array, dict[str, jax.Array]]:
         """Build the ``[B, bins]`` target distribution from per-action next dists.
 
         Args:
@@ -156,7 +157,7 @@ class DistributionalBackend(Protocol):
             gamma: scalar or ``[B, 1]`` discount.
 
         Returns:
-            ``[B, bins]`` target distribution.
+            ``[B, bins]`` target distribution and pre-projection support diagnostics.
         """
         ...
 
@@ -179,11 +180,11 @@ class CategoricalBackend:
         self,
         next_dists: jax.Array,
         weights: jax.Array,
-        entropy_shift: Optional[jax.Array],
+        entropy_shift: jax.Array | None,
         reward: jax.Array,
         not_terminated: jax.Array,
         gamma: jax.Array,
-    ) -> jax.Array:
+    ) -> tuple[jax.Array, dict[str, jax.Array]]:
         if entropy_shift is None:
             entropy_shift = jnp.zeros(weights.shape, dtype=self.support.dtype)
         # per-action shifted support: [B, A, bins]
@@ -206,7 +207,9 @@ class CategoricalBackend:
         dist_per_action = jax.vmap(project_action, in_axes=(1, 1), out_axes=1)(
             next_dists, target_atoms
         )
-        return jnp.sum(jnp.expand_dims(weights, axis=2) * dist_per_action, axis=1)
+        return jnp.sum(jnp.expand_dims(weights, axis=2) * dist_per_action, axis=1), support_metrics(
+            next_dists * weights[:, :, None], target_atoms, self.support_min, self.support_max
+        )
 
 
 @dataclass(frozen=True, eq=False)
@@ -223,11 +226,11 @@ class HLGaussBackend:
         self,
         next_dists: jax.Array,
         weights: jax.Array,
-        entropy_shift: Optional[jax.Array],
+        entropy_shift: jax.Array | None,
         reward: jax.Array,
         not_terminated: jax.Array,
         gamma: jax.Array,
-    ) -> jax.Array:
+    ) -> tuple[jax.Array, dict[str, jax.Array]]:
         next_q = self.hl_gauss.to_scalar(next_dists)  # [B, A]
         if entropy_shift is None:
             entropy_shift = jnp.zeros(next_q.shape, dtype=next_q.dtype)
@@ -235,7 +238,9 @@ class HLGaussBackend:
             jnp.sum(weights * (next_q - entropy_shift), axis=1, keepdims=True) * not_terminated
         )
         target_q = next_vals * gamma + reward
-        return self.hl_gauss.to_probs(target_q)
+        return self.hl_gauss.to_probs(target_q), support_metrics(
+            jnp.ones_like(target_q), target_q, self.hl_gauss.support[0], self.hl_gauss.support[-1]
+        )
 
 
 @dataclass(frozen=True)
@@ -246,6 +251,7 @@ class MunchausenSpec:
     tau: float
 
 
+@overload
 def distributional_td_target(
     *,
     next_dists: jax.Array,
@@ -254,10 +260,44 @@ def distributional_td_target(
     not_terminated: jax.Array,
     gamma: jax.Array,
     backend: DistributionalBackend,
-    online_next_dists: Optional[jax.Array] = None,
-    behavior_dists: Optional[jax.Array] = None,
-    munchausen: Optional[MunchausenSpec] = None,
+    online_next_dists: jax.Array | None = None,
+    behavior_dists: jax.Array | None = None,
+    munchausen: MunchausenSpec | None = None,
+    return_diagnostics: Literal[False] = False,
 ) -> jax.Array:
+    ...
+
+
+@overload
+def distributional_td_target(
+    *,
+    next_dists: jax.Array,
+    actions: jax.Array,
+    reward: jax.Array,
+    not_terminated: jax.Array,
+    gamma: jax.Array,
+    backend: DistributionalBackend,
+    online_next_dists: jax.Array | None = None,
+    behavior_dists: jax.Array | None = None,
+    munchausen: MunchausenSpec | None = None,
+    return_diagnostics: Literal[True],
+) -> tuple[jax.Array, dict[str, jax.Array]]:
+    ...
+
+
+def distributional_td_target(
+    *,
+    next_dists: jax.Array,
+    actions: jax.Array,
+    reward: jax.Array,
+    not_terminated: jax.Array,
+    gamma: jax.Array,
+    backend: DistributionalBackend,
+    online_next_dists: jax.Array | None = None,
+    behavior_dists: jax.Array | None = None,
+    munchausen: MunchausenSpec | None = None,
+    return_diagnostics: bool = False,
+) -> jax.Array | tuple[jax.Array, dict[str, jax.Array]]:
     """Compute the distributional TD target distribution ``[B, bins]``.
 
     Owns the scalar scaffolding shared by every distributional ``_target``;
@@ -281,6 +321,7 @@ def distributional_td_target(
         behavior_dists: ``[B, A, bins]`` current-state dists for the Munchausen
             addon; required when ``munchausen`` is set.
         munchausen: Munchausen spec, or ``None`` for the greedy target.
+        return_diagnostics: include probability mass clipped before projection.
 
     Returns:
         ``[B, bins]`` target distribution.
@@ -291,7 +332,7 @@ def distributional_td_target(
         q_next = backend.action_values(selection_dists)
         greedy = jnp.argmax(q_next, axis=1)
         weights = jax.nn.one_hot(greedy, q_next.shape[1], dtype=next_dists.dtype)
-        return backend.project(
+        target, metrics = backend.project(
             next_dists,
             weights,
             None,
@@ -299,6 +340,7 @@ def distributional_td_target(
             not_terminated,
             gamma,
         )
+        return (target, metrics) if return_diagnostics else target
 
     tau = munchausen.tau
     q_next = backend.action_values(selection_dists)
@@ -312,7 +354,7 @@ def distributional_td_target(
     addon = jnp.take_along_axis(clipped_tau_log_pi, actions, axis=1)
     shaped_reward = reward + munchausen.alpha * addon
 
-    return backend.project(
+    target, metrics = backend.project(
         next_dists,
         pi_next,
         tau_log_pi_next,
@@ -320,3 +362,4 @@ def distributional_td_target(
         not_terminated,
         gamma,
     )
+    return (target, metrics) if return_diagnostics else target

--- a/jax_baselines/math/metrics.py
+++ b/jax_baselines/math/metrics.py
@@ -1,0 +1,138 @@
+"""Scalar learner diagnostics computed from the tensors used by an update."""
+
+import jax
+import jax.numpy as jnp
+
+
+def array_metrics(values: jax.Array, prefix: str) -> dict[str, jax.Array]:
+    return {
+        f"{prefix}_mean": jnp.mean(values),
+        f"{prefix}_std": jnp.std(values),
+        f"{prefix}_min": jnp.min(values),
+        f"{prefix}_max": jnp.max(values),
+    }
+
+
+def td_metrics(
+    predictions: jax.Array, targets: jax.Array, prefix: str = "loss/td"
+) -> dict[str, jax.Array]:
+    """Summarize target minus prediction, independently of the optimized loss."""
+    residual = jnp.ravel(targets) - jnp.ravel(predictions)
+    return {
+        f"{prefix}_signed_mean": jnp.mean(residual),
+        f"{prefix}_abs_mean": jnp.mean(jnp.abs(residual)),
+        f"{prefix}_abs_p95": jnp.percentile(jnp.abs(residual), 95),
+    }
+
+
+def rollout_metrics(values, targets, raw_advantages) -> dict[str, jax.Array]:
+    target_variance = jnp.var(targets)
+    return {
+        "loss/explained_variance": jnp.where(
+            target_variance > 0,
+            1 - jnp.var(jnp.ravel(targets) - jnp.ravel(values)) / target_variance,
+            jnp.nan,
+        ),
+        "loss/value_mean": jnp.mean(values),
+        "loss/value_std": jnp.std(values),
+        "loss/mean_target": jnp.mean(targets),
+        "loss/target_std": jnp.std(targets),
+        "loss/advantage_mean": jnp.mean(raw_advantages),
+        "loss/advantage_std": jnp.std(raw_advantages),
+    }
+
+
+def gaussian_metrics(log_std: jax.Array) -> dict[str, jax.Array]:
+    std = jnp.exp(log_std)
+    return {
+        "loss/policy_std_mean": jnp.mean(std),
+        "loss/policy_std_min": jnp.min(std),
+        "loss/policy_std_max": jnp.max(std),
+        "loss/log_std_mean": jnp.mean(log_std),
+        "loss/log_std_min": jnp.min(log_std),
+        "loss/log_std_max": jnp.max(log_std),
+    }
+
+
+def policy_ratio_metrics(new_log_prob, old_log_prob, clip_eps) -> dict[str, jax.Array]:
+    log_ratio = new_log_prob - old_log_prob
+    ratio = jnp.exp(log_ratio)
+    return {
+        "loss/approx_kl": jnp.mean(jnp.expm1(log_ratio) - log_ratio),
+        "loss/clip_fraction": jnp.mean(jnp.abs(ratio - 1) > clip_eps),
+    }
+
+
+def replay_metrics(weights, priorities) -> dict[str, jax.Array]:
+    """Priorities submitted by the learner; ESS concerns sampled IS weights only."""
+    priorities = jnp.ravel(priorities)
+    weights = jnp.broadcast_to(jnp.ravel(weights), priorities.shape)
+    return {
+        "loss/priority_mean": jnp.mean(priorities),
+        "loss/priority_max": jnp.max(priorities),
+        "loss/priority_p95": jnp.percentile(priorities, 95),
+        "loss/is_weight_mean": jnp.mean(weights),
+        "loss/is_weight_min": jnp.min(weights),
+        "loss/is_weight_max": jnp.max(weights),
+        "loss/is_weight_ess": jnp.square(jnp.sum(weights)) / jnp.sum(jnp.square(weights)),
+    }
+
+
+def categorical_metrics(
+    probabilities, target_probs, support, prefix: str = "loss"
+) -> dict[str, jax.Array]:
+    if probabilities.shape[-1] != support.size:
+        raise ValueError("categorical support must have one value per probability bin")
+    target_log = jnp.log(jnp.maximum(target_probs, jnp.finfo(target_probs.dtype).tiny))
+    online_log = jnp.log(jnp.maximum(probabilities, jnp.finfo(probabilities.dtype).tiny))
+    return {
+        f"{prefix}/categorical_cross_entropy": -jnp.mean(
+            jnp.sum(target_probs * online_log, axis=-1)
+        ),
+        f"{prefix}/categorical_kl": jnp.mean(
+            jnp.sum(target_probs * (target_log - online_log), axis=-1)
+        ),
+        f"{prefix}/target_entropy": -jnp.mean(jnp.sum(target_probs * target_log, axis=-1)),
+        f"{prefix}/online_edge_mass_low": jnp.mean(probabilities[..., 0]),
+        f"{prefix}/online_edge_mass_high": jnp.mean(probabilities[..., -1]),
+        f"{prefix}/target_edge_mass_low": jnp.mean(target_probs[..., 0]),
+        f"{prefix}/target_edge_mass_high": jnp.mean(target_probs[..., -1]),
+    }
+
+
+def support_metrics(
+    probabilities, target_atoms, support_min, support_max, prefix: str = "loss"
+) -> dict[str, jax.Array]:
+    """Probability mass outside the support before projection, summed per sample."""
+    return {
+        f"{prefix}/support_clipped_mass_low": jnp.mean(
+            jnp.sum(
+                (probabilities * (target_atoms < support_min)).reshape(probabilities.shape[0], -1),
+                axis=1,
+            )
+        ),
+        f"{prefix}/support_clipped_mass_high": jnp.mean(
+            jnp.sum(
+                (probabilities * (target_atoms > support_max)).reshape(probabilities.shape[0], -1),
+                axis=1,
+            )
+        ),
+    }
+
+
+def quantile_metrics(quantiles, taus=None, prefix: str = "loss") -> dict[str, jax.Array]:
+    """Distribution width and adjacent crossings, with outputs ordered by tau."""
+    if taus is not None:
+        quantiles = jnp.take_along_axis(
+            quantiles, jnp.argsort(jnp.broadcast_to(taus, quantiles.shape), axis=-1), axis=-1
+        )
+    return {
+        f"{prefix}/quantile_spread": jnp.mean(
+            jnp.max(quantiles, axis=-1) - jnp.min(quantiles, axis=-1)
+        ),
+        f"{prefix}/quantile_crossing_rate": (
+            jnp.mean(quantiles[..., :-1] > quantiles[..., 1:])
+            if quantiles.shape[-1] > 1
+            else jnp.asarray(0.0)
+        ),
+    }

--- a/jax_baselines/optim/__init__.py
+++ b/jax_baselines/optim/__init__.py
@@ -5,7 +5,8 @@ adapters. String names, defaults, clipping policy, and reset-suffix parsing are
 experiment policy and must not be resolved in core constructors.
 """
 
-from typing import Any, Callable, Optional, Protocol
+from collections.abc import Callable
+from typing import Any, NamedTuple, Protocol
 
 import jax
 import jax.numpy as jnp
@@ -31,12 +32,85 @@ def require_optimizer_factory(
     return optimizer_factory
 
 
+class OptimizerMetricsState(NamedTuple):
+    inner_state: optax.OptState
+    count: jax.Array
+    grad_norm_pre_clip: jax.Array
+    update_norm: jax.Array
+    parameter_norm: jax.Array
+    learning_rate: jax.Array
+    grad_clip_fraction: jax.Array
+
+
+def track_optimizer(
+    optimizer: optax.GradientTransformation,
+    learning_rate: optax.ScalarOrSchedule,
+    grad_max: float | None = None,
+    reset_steps: int | None = None,
+) -> optax.GradientTransformation:
+    """Observe optimizer inputs and updates without changing their values.
+
+    Learning rate is the supplied scalar schedule, before any adaptive
+    preconditioning. Parameter norm is measured before the update. A periodic
+    inner-state reset also restarts the schedule's diagnostic counter.
+    """
+    if reset_steps is not None and reset_steps <= 0:
+        raise ValueError("optimizer reset_steps must be positive")
+
+    def rate(count):
+        if reset_steps is not None:
+            count = count % reset_steps
+        return jnp.asarray(learning_rate(count) if callable(learning_rate) else learning_rate)
+
+    def init_fn(params):
+        zero = jnp.asarray(0.0)
+        return OptimizerMetricsState(
+            optimizer.init(params),
+            jnp.zeros((), dtype=jnp.int32),
+            zero,
+            zero,
+            optax.tree.norm(params),
+            rate(jnp.zeros((), dtype=jnp.int32)),
+            zero,
+        )
+
+    def update_fn(updates, state, params=None):
+        grad_norm = optax.tree.norm(updates)
+        updates, inner_state = optimizer.update(updates, state.inner_state, params)
+        return updates, OptimizerMetricsState(
+            inner_state,
+            jnp.asarray(optax.safe_increment(state.count)),
+            grad_norm,
+            optax.tree.norm(updates),
+            optax.tree.norm(params) if params is not None else jnp.asarray(jnp.nan),
+            rate(state.count),
+            (grad_norm > grad_max).astype(jnp.float32)
+            if grad_max is not None
+            else jnp.asarray(0.0),
+        )
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def optimizer_metrics(opt_state: optax.OptState, prefix: str) -> dict[str, jax.Array]:
+    """Read the last update; arbitrary injected Optax optimizers may opt out."""
+    if not isinstance(opt_state, OptimizerMetricsState):
+        return {}
+    return {
+        f"optim/{prefix}_grad_norm_pre_clip": opt_state.grad_norm_pre_clip,
+        f"optim/{prefix}_update_norm": opt_state.update_norm,
+        f"optim/{prefix}_parameter_norm": opt_state.parameter_norm,
+        f"optim/{prefix}_learning_rate": opt_state.learning_rate,
+        f"optim/{prefix}_grad_clip_fraction": opt_state.grad_clip_fraction,
+    }
+
+
 def adopt(
     learning_rate: optax.ScalarOrSchedule,
     b1: float = 0.9,
     b2: float = 0.9999,
     eps: float = 1e-6,
-    mu_dtype: Optional[Any] = None,
+    mu_dtype: Any | None = None,
     *,
     nesterov: bool = False,
     use_clipping: bool = True,
@@ -58,7 +132,7 @@ def scale_by_adopt(
     b1: float = 0.9,
     b2: float = 0.9999,
     eps: float = 1e-6,
-    mu_dtype: Optional[jnp.dtype] = None,
+    mu_dtype: jnp.dtype | None = None,
     *,
     nesterov: bool = False,
     use_clipping: bool = True,
@@ -119,6 +193,8 @@ def optimizer_reset_by_period(
         return (opt_state, jnp.zeros((), dtype=jnp.int32))
 
     def update_fn(updates, state, params=None):
+        if params is None:
+            raise ValueError("periodic optimizer reset requires parameters")
         opt_state, step_count = state
         updates, opt_state = optimizer.update(updates, opt_state, params)
 
@@ -137,8 +213,11 @@ def optimizer_reset_by_period(
 
 __all__ = [
     "OptimizerFactory",
+    "OptimizerMetricsState",
     "adopt",
+    "optimizer_metrics",
     "optimizer_reset_by_period",
     "require_optimizer_factory",
     "scale_by_adopt",
+    "track_optimizer",
 ]

--- a/tests/test_experiment_optimizers.py
+++ b/tests/test_experiment_optimizers.py
@@ -92,12 +92,14 @@ def test_select_optimizer_reset_suffix_resets_inner_state_on_period_boundary():
     state = optimizer.init(params)
 
     _, state = optimizer.update(_grads(), state, params)
-    assert int(state[1]) == 1
+    assert int(state.inner_state[1]) == 1
 
     _, state = optimizer.update(_grads(), state, params)
-    fresh_inner_state = select_optimizer("adam", 0.1).init(params)
-    assert int(state[1]) == 2
-    for observed, expected in zip(jax.tree.leaves(state[0]), jax.tree.leaves(fresh_inner_state)):
+    fresh_inner_state = select_optimizer("adam", 0.1).init(params).inner_state
+    assert int(state.inner_state[1]) == 2
+    for observed, expected in zip(
+        jax.tree.leaves(state.inner_state[0]), jax.tree.leaves(fresh_inner_state)
+    ):
         np.testing.assert_allclose(observed, expected, rtol=1e-6)
 
 


### PR DESCRIPTION
기존 손실 값만으로 구분하기 어려운 정책 변화, TD 잔차, 분포형 오차와 optimizer 동작을 기록하기 위한 공통 계산을 추가합니다. 다음 세 PR이 이 계산을 각 계열의 기존 logger 경로에 연결합니다.

- Rollout EV, raw advantage, Gaussian scale, PPO k3 KL/clip fraction, TD/PER, categorical CE/KL/entropy/support, quantile 진단을 순수 함수로 계산합니다.
- Experiment optimizer를 계측해 clip 전 gradient norm, update/parameter norm, 실제 scalar schedule 값과 clipping 비율을 보관합니다. 내부 update는 그대로 반환하며, 직접 주입한 Optax factory도 사용할 수 있습니다.
- Categorical/HL-Gauss projection은 투영 전 범위 이탈 통계를 함께 반환합니다. 공통 TD target 함수의 기본 array 반환은 유지합니다.

공통 수치·optimizer·adapter 경계의 기존 테스트 53개를 검증했습니다. 같은 JIT 조건에서 clipping, LR schedule, periodic reset을 포함한 7회 optimizer update가 기존 Optax와 bitwise 일치했습니다. Ruff와 저장소 커밋 검사를 통과했습니다. 이 범위의 ty 오류는 해소됐으며 기존 Optax 내부 import 경고 2개는 남아 있습니다.

`update_norm`은 optimizer가 반환한 update의 norm이며, 이후 parameter projection/reset은 포함하지 않습니다. Percentile과 전체 parameter reduction에는 계산 비용이 있습니다.
