### PR TITLE
[2/4] PG의 rollout 품질과 정책 변화 지표 기록

### DIFF
--- a/jax_baselines/A2C/a2c.py
+++ b/jax_baselines/A2C/a2c.py
@@ -4,7 +4,9 @@ import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import gaussian_metrics, rollout_metrics
 from jax_baselines.math.returns import discount_with_terminated
+from jax_baselines.optim import optimizer_metrics
 
 
 class A2C(Actor_Critic_Policy_Gradient_Family):
@@ -34,10 +36,7 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             self.critic_params,
             self.actor_opt_state,
             self.critic_opt_state,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-            targets,
+            metrics,
         ) = self._train_step(
             self.actor_params,
             self.critic_params,
@@ -48,12 +47,10 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         )
 
         if logger_run:
-            logger_run.log_metric("loss/critic_loss", critic_loss, steps)
-            logger_run.log_metric("loss/actor_loss", actor_loss, steps)
-            logger_run.log_metric("loss/entropy_loss", entropy_loss, steps)
-            logger_run.log_metric("loss/mean_target", targets, steps)
+            for name, value in metrics.items():
+                logger_run.log_metric(name, value, steps)
 
-        return critic_loss
+        return metrics["loss/critic_loss"]
 
     def _train_step(
         self,
@@ -85,9 +82,9 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         value = jnp.vstack(value)
         targets = jnp.vstack(targets)
         adv = targets - value
-        (_, (actor_loss, entropy_loss)), actor_grad = jax.value_and_grad(
-            self._actor_loss, has_aux=True
-        )(actor_params, obses, actions, adv, key)
+        (actor_objective, metrics), actor_grad = jax.value_and_grad(self._actor_loss, has_aux=True)(
+            actor_params, obses, actions, adv, key
+        )
         critic_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
             critic_params, actor_params, obses, targets, key
         )
@@ -99,15 +96,17 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
         )
         actor_params = optax.apply_updates(actor_params, actor_updates)
         critic_params = optax.apply_updates(critic_params, critic_updates)
+        metrics.update(rollout_metrics(value, targets, adv))
+        metrics.update(optimizer_metrics(actor_opt_state, "actor"))
+        metrics.update(optimizer_metrics(critic_opt_state, "critic"))
+        metrics["loss/actor_objective"] = actor_objective
+        metrics["loss/critic_loss"] = critic_loss
         return (
             actor_params,
             critic_params,
             actor_opt_state,
             critic_opt_state,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-            jnp.mean(targets),
+            metrics,
         )
 
     def _critic_loss(self, critic_params, actor_params, obses, targets, key):
@@ -132,7 +131,10 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+        }
 
     def _actor_loss_continuous(self, actor_params, obses, actions, adv, key):
         prob, log_prob = self.get_logprob(
@@ -158,4 +160,8 @@ class A2C(Actor_Critic_Policy_Gradient_Family):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            **gaussian_metrics(log_std),
+        }

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -5,11 +5,13 @@ import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import rollout_metrics
 from jax_baselines.math.returns import (
     get_gaes,
     normalize_advantage,
     validate_advantage_normalize_scope,
 )
+from jax_baselines.optim import optimizer_metrics
 
 
 class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
@@ -74,10 +76,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             self.critic_params,
             self.actor_opt_state,
             self.critic_opt_state,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-            targets,
+            metrics,
         ) = self._train_step(
             self.actor_params,
             self.critic_params,
@@ -88,12 +87,10 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         )
 
         if logger_run:
-            logger_run.log_metric("loss/critic_loss", critic_loss, steps)
-            logger_run.log_metric("loss/actor_loss", actor_loss, steps)
-            logger_run.log_metric("loss/entropy_loss", entropy_loss, steps)
-            logger_run.log_metric("loss/mean_target", targets, steps)
+            for name, value in metrics.items():
+                logger_run.log_metric(name, value, steps)
 
-        return critic_loss
+        return metrics["loss/critic_loss"]
 
     def _preprocess(
         self,
@@ -129,9 +126,10 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         pi_prob = jnp.vstack(pi_prob)
         adv = jnp.vstack(adv)
         targets = value + adv
+        metrics = rollout_metrics(value, targets, adv)
         if self.gae_normalize and self.gae_normalize_scope == "batch":
             adv = normalize_advantage(adv)
-        return obses, actions, value, targets, pi_prob, adv
+        return obses, actions, value, targets, pi_prob, adv, metrics
 
     def _train_step(
         self,
@@ -147,7 +145,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         terminateds,
         truncateds,
     ):
-        obses, actions, old_values, targets, act_prob, adv = self._preprocess(
+        obses, actions, old_values, targets, act_prob, adv, metrics = self._preprocess(
             actor_params,
             critic_params,
             key,
@@ -159,17 +157,8 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             truncateds,
         )
 
-        def i_f(idx, vals):
-            (
-                actor_params,
-                critic_params,
-                actor_opt_state,
-                critic_opt_state,
-                key,
-                critic_loss,
-                actor_loss,
-                entropy_loss,
-            ) = vals
+        def i_f(vals, _):
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(targets.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -187,7 +176,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (_, (a_loss, entropy_loss)), actor_grad = jax.value_and_grad(
+                (actor_objective, batch_metrics), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
                 )(actor_params, obs, act, act_prob, adv, use_key)
                 c_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
@@ -201,11 +190,17 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                 )
                 actor_params = optax.apply_updates(actor_params, actor_updates)
                 critic_params = optax.apply_updates(critic_params, critic_updates)
-                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
-                    c_loss,
-                    a_loss,
-                    entropy_loss,
-                )
+                batch_metrics["loss/critic_loss"] = c_loss
+                batch_metrics["loss/actor_objective"] = actor_objective
+                batch_metrics.update(optimizer_metrics(actor_opt_state, "actor"))
+                batch_metrics.update(optimizer_metrics(critic_opt_state, "critic"))
+                return (
+                    actor_params,
+                    critic_params,
+                    actor_opt_state,
+                    critic_opt_state,
+                    key,
+                ), batch_metrics
 
             updates, losses = jax.lax.scan(
                 f,
@@ -219,47 +214,22 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                     adv_batch,
                 ),
             )
-            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
-            cl, al, el = losses
-            critic_loss += jnp.mean(cl)
-            actor_loss += jnp.mean(al)
-            entropy_loss += jnp.mean(el)
-            return (
-                actor_params,
-                critic_params,
-                actor_opt_state,
-                critic_opt_state,
-                key,
-                critic_loss,
-                actor_loss,
-                entropy_loss,
-            )
+            return updates, jax.tree.map(jnp.mean, losses)
 
-        val = jax.lax.fori_loop(
-            0,
-            self.epoch_num,
+        updates, epoch_metrics = jax.lax.scan(
             i_f,
-            (actor_params, critic_params, actor_opt_state, critic_opt_state, key, 0.0, 0.0, 0.0),
+            (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
+            None,
+            length=self.epoch_num,
         )
-        (
-            actor_params,
-            critic_params,
-            actor_opt_state,
-            critic_opt_state,
-            key,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-        ) = val
+        actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
+        metrics.update(jax.tree.map(jnp.mean, epoch_metrics))
         return (
             actor_params,
             critic_params,
             actor_opt_state,
             critic_opt_state,
-            critic_loss / self.epoch_num,
-            actor_loss / self.epoch_num,
-            entropy_loss / self.epoch_num,
-            jnp.mean(targets),
+            metrics,
         )
 
     def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 
 from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
+from jax_baselines.math.metrics import gaussian_metrics, policy_ratio_metrics
 
 
 class PPO(SurrogatePolicyGradient):
@@ -30,7 +31,11 @@ class PPO(SurrogatePolicyGradient):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
+        }
 
     def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
@@ -60,4 +65,9 @@ class PPO(SurrogatePolicyGradient):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
+            **gaussian_metrics(log_std),
+        }

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 
 from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
+from jax_baselines.math.metrics import gaussian_metrics, policy_ratio_metrics
 
 
 class SPO(SurrogatePolicyGradient):
@@ -57,7 +58,11 @@ class SPO(SurrogatePolicyGradient):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
+        }
 
     def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
         prob, log_prob = self.get_logprob(
@@ -88,4 +93,9 @@ class SPO(SurrogatePolicyGradient):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss)
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
+            **gaussian_metrics(log_std),
+        }

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -5,6 +5,7 @@ import optax
 
 from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import gaussian_metrics, rollout_metrics
 from jax_baselines.math.policy_math import (
     kl_divergence_continuous,
     kl_divergence_discrete,
@@ -14,6 +15,7 @@ from jax_baselines.math.returns import (
     normalize_advantage,
     validate_advantage_normalize_scope,
 )
+from jax_baselines.optim import optimizer_metrics
 
 
 class TPPO(Actor_Critic_Policy_Gradient_Family):
@@ -74,11 +76,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             self.critic_params,
             self.actor_opt_state,
             self.critic_opt_state,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-            kls,
-            targets,
+            metrics,
         ) = self._train_step(
             self.actor_params,
             self.critic_params,
@@ -89,13 +87,10 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         )
 
         if logger_run:
-            logger_run.log_metric("loss/critic_loss", critic_loss, steps)
-            logger_run.log_metric("loss/actor_loss", actor_loss, steps)
-            logger_run.log_metric("loss/entropy_loss", entropy_loss, steps)
-            logger_run.log_metric("loss/mean_target", targets, steps)
-            logger_run.log_metric("loss/kl_divergence", kls, steps)
+            for name, value in metrics.items():
+                logger_run.log_metric(name, value, steps)
 
-        return critic_loss
+        return metrics["loss/critic_loss"]
 
     def _preprocess(
         self,
@@ -136,9 +131,10 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         pi_prob = jnp.vstack(pi_prob)
         adv = jnp.vstack(adv)
         targets = value + adv
+        metrics = rollout_metrics(value, targets, adv)
         if self.gae_normalize and self.gae_normalize_scope == "batch":
             adv = normalize_advantage(adv)
-        return obses, actions, value, targets, prob, pi_prob, adv
+        return obses, actions, value, targets, prob, pi_prob, adv, metrics
 
     def _train_step(
         self,
@@ -154,7 +150,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         terminateds,
         truncateds,
     ):
-        obses, actions, old_value, targets, old_prob, old_act_prob, adv = self._preprocess(
+        obses, actions, old_value, targets, old_prob, old_act_prob, adv, metrics = self._preprocess(
             actor_params,
             critic_params,
             key,
@@ -166,18 +162,8 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             truncateds,
         )
 
-        def i_f(idx, vals):
-            (
-                actor_params,
-                critic_params,
-                actor_opt_state,
-                critic_opt_state,
-                key,
-                critic_loss,
-                actor_loss,
-                entropy_loss,
-                kls,
-            ) = vals
+        def i_f(vals, _):
+            actor_params, critic_params, actor_opt_state, critic_opt_state, key = vals
             use_key, key = jax.random.split(key)
             batch_idxes = jax.random.permutation(use_key, jnp.arange(targets.shape[0])).reshape(
                 -1, self.minibatch_size
@@ -196,7 +182,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
-                (_, (a_loss, entropy_loss, kl)), actor_grad = jax.value_and_grad(
+                (actor_objective, batch_metrics), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
                 )(
                     actor_params,
@@ -218,12 +204,17 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                 )
                 actor_params = optax.apply_updates(actor_params, actor_updates)
                 critic_params = optax.apply_updates(critic_params, critic_updates)
-                return (actor_params, critic_params, actor_opt_state, critic_opt_state, key), (
-                    c_loss,
-                    a_loss,
-                    entropy_loss,
-                    kl,
-                )
+                batch_metrics["loss/critic_loss"] = c_loss
+                batch_metrics["loss/actor_objective"] = actor_objective
+                batch_metrics.update(optimizer_metrics(actor_opt_state, "actor"))
+                batch_metrics.update(optimizer_metrics(critic_opt_state, "critic"))
+                return (
+                    actor_params,
+                    critic_params,
+                    actor_opt_state,
+                    critic_opt_state,
+                    key,
+                ), batch_metrics
 
             updates, losses = jax.lax.scan(
                 f,
@@ -238,61 +229,22 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
                     adv_batch,
                 ),
             )
-            actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
-            cl, al, el, kl = losses
-            critic_loss += jnp.mean(cl)
-            actor_loss += jnp.mean(al)
-            entropy_loss += jnp.mean(el)
-            kls += jnp.mean(kl)
-            return (
-                actor_params,
-                critic_params,
-                actor_opt_state,
-                critic_opt_state,
-                key,
-                critic_loss,
-                actor_loss,
-                entropy_loss,
-                kls,
-            )
+            return updates, jax.tree.map(jnp.mean, losses)
 
-        val = jax.lax.fori_loop(
-            0,
-            self.epoch_num,
+        updates, epoch_metrics = jax.lax.scan(
             i_f,
-            (
-                actor_params,
-                critic_params,
-                actor_opt_state,
-                critic_opt_state,
-                key,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ),
+            (actor_params, critic_params, actor_opt_state, critic_opt_state, key),
+            None,
+            length=self.epoch_num,
         )
-        (
-            actor_params,
-            critic_params,
-            actor_opt_state,
-            critic_opt_state,
-            key,
-            critic_loss,
-            actor_loss,
-            entropy_loss,
-            kls,
-        ) = val
+        actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
+        metrics.update(jax.tree.map(jnp.mean, epoch_metrics))
         return (
             actor_params,
             critic_params,
             actor_opt_state,
             critic_opt_state,
-            critic_loss / self.epoch_num,
-            actor_loss / self.epoch_num,
-            entropy_loss / self.epoch_num,
-            kls / self.epoch_num,
-            jnp.mean(targets),
+            metrics,
         )
 
     def _critic_loss(self, critic_params, actor_params, obses, old_value, targets, key):
@@ -341,7 +293,11 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss, jnp.mean(kl))
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(kl),
+        }
 
     def _actor_loss_continuous(
         self,
@@ -391,4 +347,9 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             actor_objective = actor_loss
         else:
             actor_objective = actor_loss + self.ent_coef * entropy_loss
-        return actor_objective, (actor_loss, entropy_loss, jnp.mean(kl))
+        return actor_objective, {
+            "loss/actor_loss": actor_loss,
+            "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(kl),
+            **gaussian_metrics(log_std),
+        }

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -114,4 +114,13 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
 
     assert jnp.isfinite(result[0]["bias"])
     assert jnp.isfinite(result[1]["bias"])
-    assert all(bool(jnp.all(jnp.isfinite(value))) for value in result[4:])
+    if kind == "local":
+        metrics = result[4]
+        assert jnp.isnan(metrics["loss/explained_variance"])
+        assert all(
+            bool(jnp.all(jnp.isfinite(value)))
+            for name, value in metrics.items()
+            if name != "loss/explained_variance"
+        )
+    else:
+        assert all(bool(jnp.all(jnp.isfinite(value))) for value in result[4:])

--- a/tests/test_training_session.py
+++ b/tests/test_training_session.py
@@ -441,21 +441,18 @@ class _EmptyBuffer:
 
 
 @pytest.mark.parametrize(
-    ("algorithm", "train_result", "metric_names"),
+    ("algorithm", "metric_names"),
     [
         (
             A2C,
-            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4),
             ["critic_loss", "actor_loss", "entropy_loss", "mean_target"],
         ),
         (
             SurrogatePolicyGradient,
-            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4),
             ["critic_loss", "actor_loss", "entropy_loss", "mean_target"],
         ),
         (
             TPPO,
-            ("actor-params", "critic-params", "actor-opt-state", "critic-opt-state", 1, 2, 3, 4, 5),
             [
                 "critic_loss",
                 "actor_loss",
@@ -466,7 +463,7 @@ class _EmptyBuffer:
         ),
     ],
 )
-def test_on_policy_train_logger_is_explicit_and_not_retained(algorithm, train_result, metric_names):
+def test_on_policy_train_logger_is_explicit_and_not_retained(algorithm, metric_names):
     agent = algorithm.__new__(algorithm)
     agent.buffer = _EmptyBuffer()
     agent.actor_params = "old-actor-params"
@@ -474,15 +471,23 @@ def test_on_policy_train_logger_is_explicit_and_not_retained(algorithm, train_re
     agent.actor_opt_state = "old-actor-opt-state"
     agent.critic_opt_state = "old-critic-opt-state"
     agent.key_seq = iter(["key-1", "key-2"])
-    agent._train_step = lambda *args, **kwargs: train_result
+    metrics = {f"loss/{name}": index for index, name in enumerate(metric_names, start=1)}
+    metrics["optim/actor_learning_rate"] = 0.001
+    agent._train_step = lambda *args, **kwargs: (
+        "actor-params",
+        "critic-params",
+        "actor-opt-state",
+        "critic-opt-state",
+        metrics,
+    )
     logger_run = _MetricLoggerRun()
 
     assert algorithm.train_step(agent, 7, logger_run=logger_run) == 1
-    assert [name for name, _, _ in logger_run.metrics] == [f"loss/{name}" for name in metric_names]
+    assert logger_run.metrics == [(name, value, 7) for name, value in metrics.items()]
     assert not hasattr(agent, "logger_run")
 
     algorithm.train_step(agent, 8)
-    assert len(logger_run.metrics) == len(metric_names)
+    assert len(logger_run.metrics) == len(metrics)
 
 
 def test_on_policy_test_logger_is_local_to_context_manager():


### PR DESCRIPTION
PG의 기존 actor/critic/entropy loss에 rollout 품질과 정책 변화 지표를 추가합니다. A2C·PPO·SPO·TPPO가 같은 metrics dict를 logger까지 전달하므로 새 지표가 학습 반환 경로에서 유실되지 않습니다.

- 업데이트 전 value/return 통계, 정규화·entropy shaping 전 advantage 통계와 explained variance를 기록합니다.
- PPO·SPO의 k3 KL/ratio clip fraction, 연속 정책의 Gaussian std/log_std 범위, 실제 actor objective와 optimizer별 진단을 기록합니다. TPPO의 exact KL과 기존 loss 키는 유지합니다.
- Minibatch·epoch 전체를 평균하며, return 분산 0의 EV는 `NaN`으로 남깁니다.

영향받는 테스트 26개와 4개 알고리즘 × discrete/continuous × entropy shaping 유무의 16개 수치 비교를 통과했습니다. 기존 parameter/optimizer update와 loss가 FP 허용오차 내 일치합니다. 정상 PPO/Pendulum CLI에서 29개 loss/optimizer scalar, LR annealing과 clipping 비율을 확인했습니다. Ruff와 저장소 커밋 검사를 통과했으며 신규 ty 진단은 없습니다. 기존 소스 타입 진단 21개는 남아 있습니다.
