### PR TITLE
[3/4] DPG 손실 분해와 실제 업데이트 기준 집계

### DIFF
--- a/jax_baselines/CrossQ/crossq.py
+++ b/jax_baselines/CrossQ/crossq.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 import jax
@@ -7,10 +8,16 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import (
+    critic_metrics,
+    reduce_metrics,
+    stochastic_actor_metrics,
+)
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset
 from jax_baselines.math.policy_math import entropy_target_from_sigma
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -26,7 +33,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         ent_coef="auto",
         sigma_target=0.15,
@@ -84,7 +91,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         self.critic_params = bundle.critic_params
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, obses, key=None) -> jnp.ndarray:
+    def _get_pi_log_prob(self, params, obses, key):
         mu, log_std = self.actor(params, None, obses)
         std = jnp.exp(log_std)
         x_t = mu + std * jax.random.normal(key, std.shape)
@@ -95,7 +102,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             axis=1,
             keepdims=True,
         )
-        return pi, log_prob
+        return pi, log_prob, log_std
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         mu, log_std = self.actor(params, None, convert_normalized_obs(obses))
@@ -118,6 +125,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._train_step(
             self.policy_params,
             self.critic_params,
@@ -133,7 +142,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metrics={**metrics, "loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metric_counts=metric_counts,
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -156,13 +166,15 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 self.opt_ent_coef_state,
                 self.log_ent_coef,
             ),
-            (losses, targets, ent_coefs, priorities),
+            (losses, targets, ent_coefs, priorities, metrics, metric_counts),
         ) = self._bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
-            metrics={"loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metrics={**metrics, "loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -187,6 +199,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 t_mean,
                 log_ent_coef,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 policy_params,
                 critic_params,
@@ -205,7 +219,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 opt_critic_state,
                 opt_ent_coef_state,
                 log_ent_coef,
-            ), (loss, t_mean, log_ent_coef, priorities)
+            ), (loss, t_mean, log_ent_coef, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
@@ -233,7 +247,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         ent_coef = jnp.exp(log_ent_coef)
         key1, key2 = jax.random.split(key, 2)
 
-        (critic_loss, (abs_error, targets, critic_params)), grad = jax.value_and_grad(
+        (critic_loss, (abs_error, targets, critic_params, metrics)), grad = jax.value_and_grad(
             self._critic_loss, has_aux=True
         )(
             critic_params,
@@ -250,7 +264,28 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
         critic_params = optax.apply_updates(critic_params, updates)
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                *stochastic_actor_metrics(
+                    jnp.zeros(1), jnp.zeros(1), 0.0, ent_coef, self.target_entropy
+                ),
+                *optimizer_metrics(opt_policy_state, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
+        if self.auto_entropy:
+            empty_actor_metrics.update(
+                dict.fromkeys(
+                    (
+                        "loss/ent_coef_loss",
+                        *optimizer_metrics(opt_ent_coef_state, "ent_coef"),
+                    ),
+                    jnp.asarray(0.0),
+                )
+            )
 
         def _opt_actor(
             policy_params,
@@ -260,18 +295,25 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             opt_ent_coef_state,
             key,
         ):
-            (_, log_prob), grad = jax.value_and_grad(self._actor_loss, has_aux=True)(
-                policy_params, critic_params, obses, key, ent_coef
-            )
+            (actor_loss, (log_prob, actor_metrics)), grad = jax.value_and_grad(
+                self._actor_loss, has_aux=True
+            )(policy_params, critic_params, obses, key, ent_coef)
             updates, opt_policy_state = self.optimizer.update(
                 grad, opt_policy_state, params=policy_params
             )
             policy_params = optax.apply_updates(policy_params, updates)
+            actor_metrics.update(
+                {
+                    "loss/actor_loss": actor_loss,
+                    **optimizer_metrics(opt_policy_state, "actor"),
+                }
+            )
 
             if self.auto_entropy:
-                log_ent_coef, opt_ent_coef_state = self._train_ent_coef(
+                log_ent_coef, opt_ent_coef_state, entropy_metrics = self._train_ent_coef(
                     log_ent_coef, opt_ent_coef_state, log_prob
                 )
+                actor_metrics.update(entropy_metrics)
             return (
                 policy_params,
                 critic_params,
@@ -279,6 +321,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 opt_policy_state,
                 opt_ent_coef_state,
                 key,
+                actor_metrics,
             )
 
         (
@@ -288,10 +331,11 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             opt_policy_state,
             opt_ent_coef_state,
             key,
+            actor_metrics,
         ) = jax.lax.cond(
             step % self.policy_delay == 0,
             lambda x: _opt_actor(*x),
-            lambda x: x,
+            lambda x: (*x, empty_actor_metrics),
             (
                 policy_params,
                 critic_params,
@@ -300,6 +344,14 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
                 opt_ent_coef_state,
                 key2,
             ),
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray(step % self.policy_delay == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
         )
 
         new_priorities = None
@@ -334,6 +386,8 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             jnp.mean(targets),
             log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         )
 
     def _critic_loss(
@@ -354,7 +408,7 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
             obses,
             nxtobses,
         )
-        next_policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
+        next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key)
         concated_actions = jnp.concatenate([actions, jax.lax.stop_gradient(next_policy)])
         (q1, q2), variable_updates = self.critic(
             critic_params, policy_params, key, concated_obses, concated_actions, True
@@ -369,10 +423,30 @@ class CrossQ(Deteministic_Policy_Gradient_Family):
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
             weights * jnp.square(error2)
         )
-        return critic_loss, (jnp.abs(error1), targets, critic_params)
+        return critic_loss, (
+            jnp.abs(error1),
+            targets,
+            critic_params,
+            critic_metrics(
+                (q1, q2),
+                targets,
+                (jnp.square(error1), jnp.square(error2)),
+                weights,
+                jnp.abs(error1) if self.prioritized_replay else None,
+            ),
+        )
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        policy, log_prob, log_std = self._get_pi_log_prob(policy_params, obses, key)
         (q1_pi, q2_pi), _ = self.critic(critic_params, policy_params, key, obses, policy, False)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
-        return actor_loss, log_prob
+        return actor_loss, (
+            log_prob,
+            stochastic_actor_metrics(
+                log_prob,
+                log_std,
+                jnp.minimum(q1_pi, q2_pi),
+                ent_coef,
+                self.target_entropy,
+            ),
+        )

--- a/jax_baselines/DDPG/base_class.py
+++ b/jax_baselines/DDPG/base_class.py
@@ -32,10 +32,18 @@ from jax_baselines.core.rollout_stats import EpisodeTracker
 from jax_baselines.core.seeding import key_gen, set_global_seeds
 from jax_baselines.core.training_session import TrainingSession, off_policy_loop
 from jax_baselines.DDPG.training import DPGTrainingLifecycle, DPGTrainReport
-from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
+from jax_baselines.optim import (
+    OptimizerFactory,
+    optimizer_metrics,
+    require_optimizer_factory,
+    track_optimizer,
+)
 
 
 class Deteministic_Policy_Gradient_Family:
+    _ent_coef: str | float
+    ent_coef_learning_rate: float | optax.Schedule
+    target_entropy: float
     _run_name = "DPG_network"
 
     supports_bulk_training = False
@@ -338,7 +346,9 @@ class Deteministic_Policy_Gradient_Family:
                 raise ValueError(f"Invalid value for ent_coef: {self._ent_coef}") from err
             self.auto_entropy = False
 
-        self.ent_coef_optimizer = optax.adam(self.ent_coef_learning_rate)
+        self.ent_coef_optimizer = track_optimizer(
+            optax.adam(self.ent_coef_learning_rate), self.ent_coef_learning_rate
+        )
         self.opt_ent_coef_state = self.ent_coef_optimizer.init(self.log_ent_coef)
 
     def _train_ent_coef(self, log_coef, opt_state, log_prob):
@@ -346,9 +356,16 @@ class Deteministic_Policy_Gradient_Family:
             entropy = -jax.lax.stop_gradient(log_prob)
             return jnp.mean(jnp.exp(log_ent_coef) * (entropy - self.target_entropy))
 
-        grad = jax.grad(loss)(log_coef)
+        ent_coef_loss, grad = jax.value_and_grad(loss)(log_coef)
         updates, opt_state = self.ent_coef_optimizer.update(grad, opt_state, log_coef)
-        return optax.apply_updates(log_coef, updates), opt_state
+        return (
+            optax.apply_updates(log_coef, updates),
+            opt_state,
+            {
+                "loss/ent_coef_loss": ent_coef_loss,
+                **optimizer_metrics(opt_state, "ent_coef"),
+            },
+        )
 
     def train_step(self, steps, gradient_steps, logger_run=None, log_interval=None):
         return self.training_lifecycle.train(steps, gradient_steps, logger_run, log_interval)
@@ -367,11 +384,19 @@ class Deteministic_Policy_Gradient_Family:
             return reports[-1]
         counts = jnp.array([report.update_count for report in reports])
         total = sum(report.update_count for report in reports)
-        metrics = {
-            name: jnp.sum(jnp.array([report.metrics[name] for report in reports]) * counts) / total
-            for name in reports[-1].metrics
-            if all(name in report.metrics for report in reports)
-        }
+        metrics = {}
+        metric_counts = {}
+        for name in dict.fromkeys(name for report in reports for name in report.metrics):
+            observations = [report for report in reports if name in report.metrics]
+            weights = jnp.asarray([report.metric_counts[name] for report in observations])
+            metric_counts[name] = jnp.sum(weights)
+            metrics[name] = jnp.sum(
+                jnp.where(
+                    weights > 0,
+                    jnp.asarray([report.metrics[name] for report in observations]) * weights,
+                    0,
+                )
+            ) / jnp.maximum(metric_counts[name], 1)
         target = None
         if all(report.target is not None for report in reports):
             target = jnp.sum(jnp.array([report.target for report in reports]) * counts) / total
@@ -379,6 +404,7 @@ class Deteministic_Policy_Gradient_Family:
             loss=jnp.sum(jnp.array([report.loss for report in reports]) * counts) / total,
             target=target,
             metrics=metrics,
+            metric_counts=metric_counts,
             update_count=total,
         )
 

--- a/jax_baselines/DDPG/ddpg.py
+++ b/jax_baselines/DDPG/ddpg.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
@@ -8,10 +9,12 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import critic_metrics, reduce_metrics
 from jax_baselines.DDPG.ou_noise import OUNoise
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -28,7 +31,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         exploration_fraction=0.3,
         exploration_final_eps=0.02,
@@ -131,6 +134,8 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._train_step(
             self.policy_params,
             self.critic_params,
@@ -142,7 +147,13 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             next(self.key_seq),
             **data,
         )
-        return DPGTrainReport(loss=loss, target=t_mean, new_priorities=new_priorities)
+        return DPGTrainReport(
+            loss=loss,
+            target=t_mean,
+            new_priorities=new_priorities,
+            metrics=metrics,
+            metric_counts=metric_counts,
+        )
 
     def _train_on_bulk(self, data, contexts):
         steps = jnp.asarray([context.train_steps_count for context in contexts])
@@ -164,12 +175,15 @@ class DDPG(Deteministic_Policy_Gradient_Family):
                 self.opt_policy_state,
                 self.opt_critic_state,
             ),
-            (losses, targets, priorities),
+            (losses, targets, priorities, metrics, metric_counts),
         ) = self._bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
+            metrics=metrics,
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -194,6 +208,8 @@ class DDPG(Deteministic_Policy_Gradient_Family):
                 loss,
                 t_mean,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 policy_params,
                 critic_params,
@@ -212,7 +228,7 @@ class DDPG(Deteministic_Policy_Gradient_Family):
                 target_critic_params,
                 opt_policy_state,
                 opt_critic_state,
-            ), (loss, t_mean, priorities)
+            ), (loss, t_mean, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
@@ -246,19 +262,25 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             not_terminateds,
             key,
         )
-        (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key
-        )
+        (critic_loss, (abs_error, metrics)), grad = jax.value_and_grad(
+            self._critic_loss, has_aux=True
+        )(critic_params, policy_params, obses, actions, targets, weights, key)
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
         critic_params = optax.apply_updates(critic_params, updates)
 
-        grad = jax.grad(self._actor_loss)(policy_params, critic_params, obses, key)
+        actor_loss, grad = jax.value_and_grad(self._actor_loss)(
+            policy_params, critic_params, obses, key
+        )
         updates, opt_policy_state = self.optimizer.update(
             grad, opt_policy_state, params=policy_params
         )
         policy_params = optax.apply_updates(policy_params, updates)
+        metrics.update(optimizer_metrics(opt_policy_state, "actor"))
+        metrics.update({"loss/actor_loss": actor_loss, "loss/actor_q_mean": -actor_loss})
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
 
         target_critic_params = soft_update(
             critic_params, target_critic_params, self.target_network_update_tau
@@ -298,13 +320,24 @@ class DDPG(Deteministic_Policy_Gradient_Family):
             critic_loss,
             jnp.mean(targets),
             new_priorities,
+            metrics,
+            metric_counts,
         )
 
     def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
         vals = self.critic(critic_params, policy_params, key, obses, actions)
         error = jnp.squeeze(vals - targets)
         critic_loss = jnp.mean(weights * jnp.square(error))
-        return critic_loss, jnp.abs(error)
+        return critic_loss, (
+            jnp.abs(error),
+            critic_metrics(
+                (vals,),
+                targets,
+                (jnp.square(error),),
+                weights,
+                jnp.abs(error) if self.prioritized_replay else None,
+            ),
+        )
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
         actions = self.actor(policy_params, key, obses)

--- a/jax_baselines/DDPG/metrics.py
+++ b/jax_baselines/DDPG/metrics.py
@@ -1,0 +1,52 @@
+"""DPG diagnostics from the samples used by each optimizer update."""
+
+import jax.numpy as jnp
+
+from jax_baselines.math.metrics import (
+    array_metrics,
+    gaussian_metrics,
+    replay_metrics,
+    td_metrics,
+)
+
+
+def critic_metrics(q_values, targets, losses, weights, priorities=None, loss_scale=1.0):
+    targets = jnp.asarray(targets).reshape(-1)
+    values = [jnp.asarray(q).reshape(-1) for q in q_values]
+    metrics = {
+        "loss/target_std": jnp.std(targets),
+        "loss/target_min": jnp.min(targets),
+        "loss/target_max": jnp.max(targets),
+        "loss/unweighted_loss": loss_scale * sum(jnp.mean(loss) for loss in losses),
+        **td_metrics(jnp.stack(values), jnp.broadcast_to(targets, (len(values), targets.size))),
+    }
+    for index, (q, loss) in enumerate(zip(values, losses, strict=True), start=1):
+        metrics.update(array_metrics(q, f"loss/q{index}"))
+        metrics.update(td_metrics(q, targets, f"loss/td{index}"))
+        metrics[f"loss/critic{index}_loss"] = jnp.mean(jnp.asarray(weights).squeeze() * loss)
+    if len(values) == 2:
+        metrics["loss/q_disagreement"] = jnp.mean(jnp.abs(values[0] - values[1]))
+    if priorities is not None:
+        metrics.update(replay_metrics(weights, priorities))
+    return metrics
+
+
+def stochastic_actor_metrics(log_prob, log_std, q_value, ent_coef, target_entropy):
+    return {
+        "loss/entropy": -jnp.mean(log_prob),
+        "loss/entropy_gap": -jnp.mean(log_prob) - target_entropy,
+        "loss/policy_target_entropy": jnp.asarray(target_entropy),
+        "loss/actor_q_mean": jnp.mean(q_value),
+        "loss/actor_entropy_term": jnp.mean(ent_coef * log_prob),
+        **gaussian_metrics(log_std),
+    }
+
+
+def reduce_metrics(metrics, metric_counts):
+    """Average observations; a skipped optimizer update contributes no observation."""
+    counts = {name: jnp.sum(metric_counts[name]) for name in metrics}
+    return {
+        name: jnp.sum(jnp.where(metric_counts[name] > 0, value * metric_counts[name], 0))
+        / jnp.maximum(counts[name], 1)
+        for name, value in metrics.items()
+    }, counts

--- a/jax_baselines/DDPG/training.py
+++ b/jax_baselines/DDPG/training.py
@@ -39,6 +39,7 @@ class DPGTrainReport:
     new_priorities: object = None
     metrics: dict = field(default_factory=dict)
     update_count: int = 1
+    metric_counts: dict[str, int | jax.Array] = field(default_factory=dict)
 
     def __post_init__(self):
         metrics = dict(self.metrics)
@@ -46,6 +47,9 @@ class DPGTrainReport:
         if self.target is not None:
             metrics.setdefault("loss/targets", self.target)
         self.metrics = metrics
+        if not self.metric_counts.keys() <= metrics.keys():
+            raise ValueError("Metric counts must refer to reported metrics")
+        self.metric_counts = {**dict.fromkeys(metrics, self.update_count), **self.metric_counts}
 
 
 class DPGTrainingLifecycle:
@@ -156,6 +160,12 @@ class DPGTrainingLifecycle:
         self.agent._last_log_step = steps
         metrics = report.metrics
         if self.agent.reward_normalizer is not None:
-            metrics = {**metrics, "rollout/reward_scale": self.agent.reward_normalizer.scale}
-        for metric_name, metric_value in jax.device_get(metrics).items():
+            metrics = {
+                **metrics,
+                "rollout/reward_scale": self.agent.reward_normalizer.scale,
+            }
+        metrics, counts = jax.device_get((metrics, report.metric_counts))
+        for metric_name, metric_value in metrics.items():
+            if metric_name in counts and counts[metric_name] == 0:
+                continue
             logger_run.log_metric(metric_name, metric_value, steps)

--- a/jax_baselines/FlashSAC/flashsac.py
+++ b/jax_baselines/FlashSAC/flashsac.py
@@ -15,11 +15,18 @@ from flax import struct
 
 from jax_baselines.core.normalization import FlashSACRewardNormalizer
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import (
+    critic_metrics,
+    reduce_metrics,
+    stochastic_actor_metrics,
+)
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.distributional import categorical_projection
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import categorical_metrics, support_metrics
 from jax_baselines.math.param_updates import project_unit_norm_params
 from jax_baselines.math.policy_math import entropy_target_from_sigma
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -125,7 +132,9 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
 
     def _make_optimizer(self, learning_rate):
         self.ent_coef_learning_rate = optax.cosine_decay_schedule(
-            learning_rate, self.lr_transition_steps, alpha=self.learning_rate_end / learning_rate
+            learning_rate,
+            self.lr_transition_steps,
+            alpha=self.learning_rate_end / learning_rate,
         )
         return self.optimizer_factory(self.ent_coef_learning_rate)
 
@@ -199,7 +208,7 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         return self._train_on_bulk(jax.tree.map(lambda x: jnp.expand_dims(x, 0), data), [context])
 
     def _train_on_bulk(self, data, contexts):
-        carry, metrics = self._compiled_updates(
+        carry, (metrics, metric_counts) = self._compiled_updates(
             (
                 self.policy_params,
                 self.critic_params,
@@ -222,21 +231,12 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             self.opt_ent_coef_state,
             self.log_ent_coef,
         ) = carry
-        actor_updates = max(
-            sum(
-                (context.train_steps_count - 1) % self.actor_update_period == 0
-                for context in contexts
-            ),
-            1,
-        )
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
-            loss=jnp.mean(metrics[0]),
-            target=jnp.mean(metrics[1]),
-            metrics={
-                "loss/ent_coef": jnp.mean(metrics[2]),
-                "loss/actor_loss": jnp.sum(metrics[3]) / actor_updates,
-                "loss/entropy": jnp.sum(metrics[4]) / actor_updates,
-            },
+            loss=metrics["loss/qloss"],
+            target=metrics["loss/targets"],
+            metrics=metrics,
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -251,10 +251,33 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         next_obs = convert_normalized_obs(data["nxtobses"])
         joint_obs = {name: jnp.concatenate((value, next_obs[name])) for name, value in obs.items()}
         batch_size = data["actions"].shape[0]
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                *stochastic_actor_metrics(
+                    jnp.zeros(1),
+                    jnp.zeros(1),
+                    0.0,
+                    jnp.exp(log_alpha),
+                    self.target_entropy,
+                ),
+                *optimizer_metrics(actor_opt, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
+        if self.auto_entropy:
+            empty_actor_metrics.update(
+                dict.fromkeys(
+                    ("loss/ent_coef_loss", *optimizer_metrics(alpha_opt, "ent_coef")),
+                    jnp.asarray(0.0),
+                )
+            )
 
         def update_actor(state):
             policy, actor_opt, log_alpha, alpha_opt = state
-            (loss, (log_prob, stats)), grad = jax.value_and_grad(self._actor_loss, has_aux=True)(
+            (loss, (log_prob, stats, actor_metrics)), grad = jax.value_and_grad(
+                self._actor_loss, has_aux=True
+            )(
                 policy["params"],
                 policy["batch_stats"],
                 critic,
@@ -267,14 +290,18 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
                 "params": project_unit_norm_params(optax.apply_updates(policy["params"], updates)),
                 "batch_stats": stats,
             }
+            actor_metrics.update({"loss/actor_loss": loss, **optimizer_metrics(actor_opt, "actor")})
             if self.auto_entropy:
-                log_alpha, alpha_opt = self._train_ent_coef(log_alpha, alpha_opt, log_prob)
-            return policy, actor_opt, log_alpha, alpha_opt, loss, -jnp.mean(log_prob)
+                log_alpha, alpha_opt, entropy_metrics = self._train_ent_coef(
+                    log_alpha, alpha_opt, log_prob
+                )
+                actor_metrics.update(entropy_metrics)
+            return policy, actor_opt, log_alpha, alpha_opt, actor_metrics
 
-        policy, actor_opt, log_alpha, alpha_opt, actor_loss, entropy = jax.lax.cond(
+        policy, actor_opt, log_alpha, alpha_opt, actor_metrics = jax.lax.cond(
             (step - 1) % self.actor_update_period == 0,
             update_actor,
-            lambda state: (*state, jnp.asarray(0.0), jnp.asarray(0.0)),
+            lambda state: (*state, empty_actor_metrics),
             (policy, actor_opt, log_alpha, alpha_opt),
         )
         (mean, log_std), _ = self.actor(policy, None, next_obs, False)
@@ -288,19 +315,20 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         select_first = jnp.sum(target_probs1 * self.value_support, axis=-1) <= jnp.sum(
             target_probs2 * self.value_support, axis=-1
         )
+        next_probs = jnp.where(select_first[:, None], target_probs1, target_probs2)
+        target_atoms = data["rewards"].reshape(-1, 1) + (
+            1 - data["terminateds"].reshape(-1, 1)
+        ) * self._gamma * (self.value_support - jnp.exp(log_alpha) * log_prob)
         target_probs = categorical_projection(
-            jnp.where(select_first[:, None], target_probs1, target_probs2),
-            data["rewards"].reshape(-1, 1)
-            + (1 - data["terminateds"].reshape(-1, 1))
-            * self._gamma
-            * (self.value_support - jnp.exp(log_alpha) * log_prob),
+            next_probs,
+            target_atoms,
             self.value_min,
             self.value_max,
             self.support_delta,
             self.n_atoms,
         )
         target_probs = jax.lax.stop_gradient(target_probs)
-        (critic_loss, stats), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+        (critic_loss, (stats, metrics)), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
             critic["params"],
             critic["batch_stats"],
             policy,
@@ -309,6 +337,8 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             target_probs,
         )
         updates, critic_opt = self.optimizer.update(grad, critic_opt, critic["params"])
+        metrics.update(optimizer_metrics(critic_opt, "critic"))
+        metrics.update(support_metrics(next_probs, target_atoms, self.value_min, self.value_max))
         critic = {
             "params": project_unit_norm_params(optax.apply_updates(critic["params"], updates)),
             "batch_stats": stats,
@@ -319,12 +349,24 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
             ),
             "batch_stats": target_updates["batch_stats"],
         }
+        metrics.update(
+            {
+                "loss/qloss": critic_loss,
+                "loss/targets": jnp.mean(jnp.sum(target_probs * self.value_support, axis=-1)),
+                "loss/ent_coef": jnp.exp(log_alpha),
+            }
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray((step - 1) % self.actor_update_period == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
+        )
         return (policy, critic, target, actor_opt, critic_opt, alpha_opt, log_alpha), (
-            critic_loss,
-            jnp.mean(jnp.sum(target_probs * self.value_support, axis=-1)),
-            jnp.exp(log_alpha),
-            actor_loss,
-            entropy,
+            metrics,
+            metric_counts,
         )
 
     def _actor_loss(self, params, stats, critic, joint_obs, key, alpha):
@@ -347,6 +389,9 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
         return jnp.mean(alpha * log_prob[:size, 0] - minimum), (
             log_prob[:size],
             updates["batch_stats"],
+            stochastic_actor_metrics(
+                log_prob[:size], log_std[:size], minimum, alpha, self.target_entropy
+            ),
         )
 
     def _critic_loss(self, params, stats, policy, obses, actions, target_probs):
@@ -362,4 +407,24 @@ class FlashSAC(Deteministic_Policy_Gradient_Family):
                 axis=-1,
             )
         )
-        return loss, updates["batch_stats"]
+        probabilities = (jax.nn.softmax(logits1[:size]), jax.nn.softmax(logits2[:size]))
+        metrics = critic_metrics(
+            [jnp.sum(probs * self.value_support, axis=-1) for probs in probabilities],
+            jnp.sum(target_probs * self.value_support, axis=-1),
+            [
+                -jnp.sum(target_probs * jax.nn.log_softmax(logits[:size]), axis=-1)
+                for logits in (logits1, logits2)
+            ],
+            1,
+            loss_scale=0.5,
+        )
+        for index, probs in enumerate(probabilities, start=1):
+            metrics.update(
+                categorical_metrics(
+                    probs,
+                    target_probs,
+                    self.value_support,
+                    prefix=f"loss/critic{index}",
+                )
+            )
+        return loss, (updates["batch_stats"], metrics)

--- a/jax_baselines/SAC/sac.py
+++ b/jax_baselines/SAC/sac.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
@@ -8,10 +9,16 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import (
+    critic_metrics,
+    reduce_metrics,
+    stochastic_actor_metrics,
+)
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
 from jax_baselines.math.policy_math import entropy_target_from_sigma
+from jax_baselines.optim import optimizer_metrics
 
 
 def sample_action(mu, log_std, key):
@@ -37,7 +44,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         ent_coef="auto_0.01",
         sigma_target=0.15,
@@ -95,7 +102,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = bundle.target_critic_params
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, obses, key=None) -> jnp.ndarray:
+    def _get_pi_log_prob(self, params, obses, key):
         mu, log_std = self.actor(params, None, obses)
         std = jnp.exp(log_std)
         x_t = mu + std * jax.random.normal(key, std.shape)
@@ -106,7 +113,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
             axis=1,
             keepdims=True,
         )
-        return pi, log_prob
+        return pi, log_prob, log_std
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         mu, log_std = self.actor(params, None, convert_normalized_obs(obses))
@@ -128,6 +135,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._train_step(
             self.policy_params,
             self.critic_params,
@@ -144,7 +153,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metrics={**metrics, "loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metric_counts=metric_counts,
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -169,13 +179,15 @@ class SAC(Deteministic_Policy_Gradient_Family):
                 self.opt_ent_coef_state,
                 self.log_ent_coef,
             ),
-            (losses, targets, ent_coefs, priorities),
+            (losses, targets, ent_coefs, priorities, metrics, metric_counts),
         ) = self._bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
-            metrics={"loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metrics={**metrics, "loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -202,6 +214,8 @@ class SAC(Deteministic_Policy_Gradient_Family):
                 t_mean,
                 log_ent_coef,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 policy_params,
                 critic_params,
@@ -222,7 +236,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
                 opt_critic_state,
                 opt_ent_coef_state,
                 log_ent_coef,
-            ), (loss, t_mean, log_ent_coef, priorities)
+            ), (loss, t_mean, log_ent_coef, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
@@ -260,33 +274,61 @@ class SAC(Deteministic_Policy_Gradient_Family):
             ent_coef,
         )
 
-        (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key2
-        )
+        (critic_loss, (abs_error, metrics)), grad = jax.value_and_grad(
+            self._critic_loss, has_aux=True
+        )(critic_params, policy_params, obses, actions, targets, weights, key2)
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
         critic_params = optax.apply_updates(critic_params, updates)
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                *stochastic_actor_metrics(
+                    jnp.zeros(1), jnp.zeros(1), 0.0, ent_coef, self.target_entropy
+                ),
+                *optimizer_metrics(opt_policy_state, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
+        if self.auto_entropy:
+            empty_actor_metrics.update(
+                dict.fromkeys(
+                    (
+                        "loss/ent_coef_loss",
+                        *optimizer_metrics(opt_ent_coef_state, "ent_coef"),
+                    ),
+                    jnp.asarray(0.0),
+                )
+            )
 
         def update_actor(state):
             policy_params, opt_policy_state, log_ent_coef, opt_ent_coef_state = state
-            (actor_loss, log_prob), grad = jax.value_and_grad(self._actor_loss, has_aux=True)(
-                policy_params, critic_params, obses, key3, ent_coef
-            )
+            (actor_loss, (log_prob, actor_metrics)), grad = jax.value_and_grad(
+                self._actor_loss, has_aux=True
+            )(policy_params, critic_params, obses, key3, ent_coef)
             updates, opt_policy_state = self.optimizer.update(
                 grad, opt_policy_state, params=policy_params
             )
             policy_params = optax.apply_updates(policy_params, updates)
+            actor_metrics.update(
+                {
+                    "loss/actor_loss": actor_loss,
+                    **optimizer_metrics(opt_policy_state, "actor"),
+                }
+            )
             if self.auto_entropy:
-                log_ent_coef, opt_ent_coef_state = self._train_ent_coef(
+                log_ent_coef, opt_ent_coef_state, entropy_metrics = self._train_ent_coef(
                     log_ent_coef, opt_ent_coef_state, log_prob
                 )
+                actor_metrics.update(entropy_metrics)
             return (
                 policy_params,
                 opt_policy_state,
                 log_ent_coef,
                 opt_ent_coef_state,
-                actor_loss,
+                actor_metrics,
             )
 
         (
@@ -294,12 +336,20 @@ class SAC(Deteministic_Policy_Gradient_Family):
             opt_policy_state,
             log_ent_coef,
             opt_ent_coef_state,
-            actor_loss,
+            actor_metrics,
         ) = jax.lax.cond(
             (step - 1) % self.actor_update_period == 0,
             update_actor,
-            lambda state: (*state, jnp.asarray(0.0)),
+            lambda state: (*state, empty_actor_metrics),
             (policy_params, opt_policy_state, log_ent_coef, opt_ent_coef_state),
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray((step - 1) % self.actor_update_period == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
         )
 
         target_critic_params = soft_update(
@@ -336,9 +386,11 @@ class SAC(Deteministic_Policy_Gradient_Family):
             opt_critic_state,
             opt_ent_coef_state,
             critic_loss,
-            -actor_loss,
+            jnp.mean(targets),
             log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         )
 
     def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
@@ -348,13 +400,31 @@ class SAC(Deteministic_Policy_Gradient_Family):
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
             weights * jnp.square(error2)
         )
-        return critic_loss, jnp.abs(error1)
+        return critic_loss, (
+            jnp.abs(error1),
+            critic_metrics(
+                (q1, q2),
+                targets,
+                (jnp.square(error1), jnp.square(error2)),
+                weights,
+                jnp.abs(error1) if self.prioritized_replay else None,
+            ),
+        )
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        policy, log_prob, log_std = self._get_pi_log_prob(policy_params, obses, key)
         q1_pi, q2_pi = self.critic(critic_params, policy_params, key, obses, policy)
         actor_loss = jnp.mean(ent_coef * log_prob - jnp.minimum(q1_pi, q2_pi))
-        return actor_loss, log_prob
+        return actor_loss, (
+            log_prob,
+            stochastic_actor_metrics(
+                log_prob,
+                log_std,
+                jnp.minimum(q1_pi, q2_pi),
+                ent_coef,
+                self.target_entropy,
+            ),
+        )
 
     def _target(
         self,
@@ -366,7 +436,7 @@ class SAC(Deteministic_Policy_Gradient_Family):
         key,
         ent_coef,
     ):
-        policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
+        policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key)
         q1_pi, q2_pi = self.critic(target_critic_params, policy_params, key, nxtobses, policy)
         next_q = jnp.minimum(q1_pi, q2_pi) - ent_coef * log_prob
         return (not_terminateds * next_q * self._gamma) + rewards

--- a/jax_baselines/TD3/td3.py
+++ b/jax_baselines/TD3/td3.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
@@ -8,9 +9,11 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import critic_metrics, reduce_metrics
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.param_updates import scaled_by_reset, soft_update
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -27,7 +30,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         target_action_noise_mul=2.0,
         action_noise=0.1,
@@ -111,6 +114,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._train_step(
             self.policy_params,
             self.critic_params,
@@ -122,7 +127,13 @@ class TD3(Deteministic_Policy_Gradient_Family):
             context.train_steps_count,
             **data,
         )
-        return DPGTrainReport(loss=loss, target=t_mean, new_priorities=new_priorities)
+        return DPGTrainReport(
+            loss=loss,
+            target=t_mean,
+            new_priorities=new_priorities,
+            metrics=metrics,
+            metric_counts=metric_counts,
+        )
 
     def _train_on_bulk(self, data, contexts):
         steps = jnp.asarray([context.train_steps_count for context in contexts])
@@ -144,12 +155,15 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 self.opt_policy_state,
                 self.opt_critic_state,
             ),
-            (losses, targets, priorities),
+            (losses, targets, priorities, metrics, metric_counts),
         ) = self._bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
+            metrics=metrics,
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -174,6 +188,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 loss,
                 t_mean,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 policy_params,
                 critic_params,
@@ -192,7 +208,7 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 target_critic_params,
                 opt_policy_state,
                 opt_critic_state,
-            ), (loss, t_mean, priorities)
+            ), (loss, t_mean, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
@@ -225,13 +241,22 @@ class TD3(Deteministic_Policy_Gradient_Family):
             not_terminateds,
             key,
         )
-        (critic_loss, abs_error), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
-            critic_params, policy_params, obses, actions, targets, weights, key
-        )
+        (critic_loss, (abs_error, metrics)), grad = jax.value_and_grad(
+            self._critic_loss, has_aux=True
+        )(critic_params, policy_params, obses, actions, targets, weights, key)
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
         critic_params = optax.apply_updates(critic_params, updates)
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                "loss/actor_q_mean",
+                *optimizer_metrics(opt_policy_state, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
 
         def _opt_actor(
             policy_params,
@@ -241,7 +266,9 @@ class TD3(Deteministic_Policy_Gradient_Family):
             opt_policy_state,
             key,
         ):
-            grad = jax.grad(self._actor_loss)(policy_params, critic_params, obses, key)
+            actor_loss, grad = jax.value_and_grad(self._actor_loss)(
+                policy_params, critic_params, obses, key
+            )
             updates, opt_policy_state = self.optimizer.update(
                 grad, opt_policy_state, params=policy_params
             )
@@ -259,6 +286,11 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 target_critic_params,
                 opt_policy_state,
                 key,
+                {
+                    "loss/actor_loss": actor_loss,
+                    "loss/actor_q_mean": -actor_loss,
+                    **optimizer_metrics(opt_policy_state, "actor"),
+                },
             )
 
         (
@@ -268,10 +300,11 @@ class TD3(Deteministic_Policy_Gradient_Family):
             target_critic_params,
             opt_policy_state,
             key,
+            actor_metrics,
         ) = jax.lax.cond(
             step % self.policy_delay == 0,
             lambda x: _opt_actor(*x),
-            lambda x: x,
+            lambda x: (*x, empty_actor_metrics),
             (
                 policy_params,
                 critic_params,
@@ -280,6 +313,14 @@ class TD3(Deteministic_Policy_Gradient_Family):
                 opt_policy_state,
                 key,
             ),
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray(step % self.policy_delay == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
         )
 
         new_priorities = None
@@ -314,6 +355,8 @@ class TD3(Deteministic_Policy_Gradient_Family):
             critic_loss,
             jnp.mean(targets),
             new_priorities,
+            metrics,
+            metric_counts,
         )
 
     def _critic_loss(self, critic_params, policy_params, obses, actions, targets, weights, key):
@@ -323,7 +366,16 @@ class TD3(Deteministic_Policy_Gradient_Family):
         critic_loss = jnp.mean(weights * jnp.square(error1)) + jnp.mean(
             weights * jnp.square(error2)
         )
-        return critic_loss, jnp.abs(error1)
+        return critic_loss, (
+            jnp.abs(error1),
+            critic_metrics(
+                (q1, q2),
+                targets,
+                (jnp.square(error1), jnp.square(error2)),
+                weights,
+                jnp.abs(error1) if self.prioritized_replay else None,
+            ),
+        )
 
     def _actor_loss(self, policy_params, critic_params, obses, key):
         actions = self.actor(policy_params, key, obses)

--- a/jax_baselines/TD7/td7.py
+++ b/jax_baselines/TD7/td7.py
@@ -9,10 +9,12 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import critic_metrics, reduce_metrics
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import hubberloss
 from jax_baselines.math.param_updates import hard_update, scaled_by_reset
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -185,6 +187,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
             loss,
             t_mean,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._compiled_train_step(
             self.actor_encoder_params,
             self.critic_encoder_params,
@@ -208,7 +212,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/encoder_loss": repr_loss},
+            metrics={**metrics, "loss/encoder_loss": repr_loss},
+            metric_counts=metric_counts,
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -247,13 +252,15 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 self.opt_policy_state,
                 self.opt_critic_state,
             ),
-            (repr_losses, losses, targets, priorities),
+            (repr_losses, losses, targets, priorities, metrics, metric_counts),
         ) = self._compiled_bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
-            metrics={"loss/encoder_loss": jnp.mean(repr_losses)},
+            metrics={**metrics, "loss/encoder_loss": jnp.mean(repr_losses)},
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -295,6 +302,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 loss,
                 t_mean,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 actor_encoder_params,
                 critic_encoder_params,
@@ -329,29 +338,20 @@ class TD7(Deteministic_Policy_Gradient_Family):
                 critic_encoder_opt_state,
                 opt_policy_state,
                 opt_critic_state,
-            ), (repr_loss, loss, t_mean, priorities)
+            ), (repr_loss, loss, t_mean, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
     def _aggregate_train_reports(self, reports):
-        counts = jnp.array([report.update_count for report in reports])
-        total = sum(report.update_count for report in reports)
-        mean_repr_loss = (
-            jnp.sum(jnp.array([report.metrics["loss/encoder_loss"] for report in reports]) * counts)
-            / total
-        )
-        mean_loss = jnp.sum(jnp.array([report.loss for report in reports]) * counts) / total
-        mean_target = jnp.sum(jnp.array([report.target for report in reports]) * counts) / total
-        return DPGTrainReport(
-            loss=mean_loss,
-            target=mean_target,
-            update_count=total,
-            metrics={
-                "loss/encoder_loss": mean_repr_loss,
+        report = super()._aggregate_train_reports(reports)
+        report.metrics.update(
+            {
                 "loss/min_value": self.critic_params["values"]["min_value"],
                 "loss/max_value": self.critic_params["values"]["max_value"],
-            },
+            }
         )
+        report.metric_counts.update({"loss/min_value": 1, "loss/max_value": 1})
+        return report
 
     def _train_step(
         self,
@@ -387,10 +387,12 @@ class TD7(Deteministic_Policy_Gradient_Family):
         updates, actor_encoder_opt_state = self.optimizer.update(
             actor_encoder_grad, actor_encoder_opt_state, params=actor_encoder_params
         )
+        encoder_metrics = optimizer_metrics(actor_encoder_opt_state, "actor_encoder")
         actor_encoder_params = optax.apply_updates(actor_encoder_params, updates)
         updates, critic_encoder_opt_state = self.optimizer.update(
             critic_encoder_grad, critic_encoder_opt_state, params=critic_encoder_params
         )
+        encoder_metrics.update(optimizer_metrics(critic_encoder_opt_state, "critic_encoder"))
         critic_encoder_params = optax.apply_updates(critic_encoder_params, updates)
 
         targets = self._target(
@@ -413,7 +415,9 @@ class TD7(Deteministic_Policy_Gradient_Family):
         critic_feature, critic_zs = self.critic_encoder(
             fixed_critic_encoder_params, fixed_actor_encoder_params, key, obses
         )
-        (critic_loss, priority), grad = jax.value_and_grad(self._critic_loss, has_aux=True)(
+        (critic_loss, (priority, metrics)), grad = jax.value_and_grad(
+            self._critic_loss, has_aux=True
+        )(
             critic_params,
             fixed_critic_encoder_params,
             critic_feature,
@@ -425,11 +429,21 @@ class TD7(Deteministic_Policy_Gradient_Family):
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(encoder_metrics)
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
         critic_params = optax.apply_updates(critic_params, updates)
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                "loss/actor_q_mean",
+                *optimizer_metrics(opt_policy_state, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
 
         def update_actor(state):
             policy_params, opt_policy_state = state
-            grad = jax.grad(self._actor_loss)(
+            actor_loss, grad = jax.value_and_grad(self._actor_loss)(
                 policy_params,
                 critic_params,
                 fixed_critic_encoder_params,
@@ -442,13 +456,29 @@ class TD7(Deteministic_Policy_Gradient_Family):
             updates, opt_policy_state = self.optimizer.update(
                 grad, opt_policy_state, params=policy_params
             )
-            return optax.apply_updates(policy_params, updates), opt_policy_state
+            return (
+                optax.apply_updates(policy_params, updates),
+                opt_policy_state,
+                {
+                    "loss/actor_loss": actor_loss,
+                    "loss/actor_q_mean": -actor_loss,
+                    **optimizer_metrics(opt_policy_state, "actor"),
+                },
+            )
 
-        policy_params, opt_policy_state = jax.lax.cond(
+        policy_params, opt_policy_state, actor_metrics = jax.lax.cond(
             step % self.policy_delay == 0,
             update_actor,
-            lambda state: state,
+            lambda state: (*state, empty_actor_metrics),
             (policy_params, opt_policy_state),
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray(step % self.policy_delay == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
         )
         target_policy_params = hard_update(
             policy_params, target_policy_params, step, self.target_network_update_freq
@@ -518,6 +548,8 @@ class TD7(Deteministic_Policy_Gradient_Family):
             critic_loss,
             jnp.mean(targets),
             priority,
+            metrics,
+            metric_counts,
         )
 
     def _encoder_loss(
@@ -573,7 +605,16 @@ class TD7(Deteministic_Policy_Gradient_Family):
         error2 = jnp.squeeze(q2 - targets)
         critic_loss = jnp.mean(hubberloss(error1, 1.0)) + jnp.mean(hubberloss(error2, 1.0))
         priority = jnp.maximum(jnp.maximum(jnp.abs(error1), jnp.abs(error2)), 1.0)
-        return critic_loss, priority
+        return critic_loss, (
+            priority,
+            critic_metrics(
+                (q1, q2),
+                targets,
+                (hubberloss(error1, 1.0), hubberloss(error2, 1.0)),
+                1,
+                priority,
+            ),
+        )
 
     def _target(
         self,
@@ -590,7 +631,10 @@ class TD7(Deteministic_Policy_Gradient_Family):
             fixed_actor_encoder_target_params, key, nxtobses
         )
         critic_feature, critic_zs = self.critic_encoder(
-            fixed_critic_encoder_target_params, fixed_actor_encoder_target_params, key, nxtobses
+            fixed_critic_encoder_target_params,
+            fixed_actor_encoder_target_params,
+            key,
+            nxtobses,
         )
         next_action = jnp.clip(
             self.actor(target_policy_params, key, actor_feature, actor_zs)

--- a/jax_baselines/TQC/tqc.py
+++ b/jax_baselines/TQC/tqc.py
@@ -1,10 +1,13 @@
+from collections.abc import Callable
 from copy import deepcopy
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
+from jax_baselines.DDPG.metrics import critic_metrics, stochastic_actor_metrics
 from jax_baselines.math.losses import QuantileHuberLosses
+from jax_baselines.math.metrics import quantile_metrics
 from jax_baselines.math.policy_math import truncated_mixture
 from jax_baselines.SAC.sac import SAC, SACCheckpointParams
 
@@ -17,7 +20,7 @@ class TQC(SAC):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         ent_coef="auto",
         n_support=25,
@@ -82,26 +85,45 @@ class TQC(SAC):
             self.quantile,
             self.delta,
         )
+        losses = [huber0]
         critic_loss = jnp.mean(weights * huber0)
         for q in qnets[1:]:
-            critic_loss += jnp.mean(
-                weights
-                * QuantileHuberLosses(
+            losses.append(
+                QuantileHuberLosses(
                     logit_valid_tile,
                     jnp.expand_dims(q, axis=1),
                     self.quantile,
                     self.delta,
                 )
             )
-        return critic_loss, huber0
+            critic_loss += jnp.mean(weights * losses[-1])
+        metrics = critic_metrics(
+            [jnp.mean(q, axis=-1) for q in qnets],
+            jnp.mean(targets, axis=-1),
+            losses,
+            weights,
+            huber0 if self.prioritized_replay else None,
+        )
+        for index, q in enumerate(qnets, start=1):
+            metrics.update(quantile_metrics(q, prefix=f"loss/critic{index}"))
+        return critic_loss, (huber0, metrics)
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        policy, log_prob = self._get_pi_log_prob(policy_params, obses, key)
+        policy, log_prob, log_std = self._get_pi_log_prob(policy_params, obses, key)
         qnets_pi = self.critic(critic_params, policy_params, key, obses, policy)
         actor_loss = jnp.mean(
             ent_coef * log_prob - jnp.mean(jnp.concatenate(qnets_pi, axis=1), axis=1)
         )
-        return actor_loss, log_prob
+        return actor_loss, (
+            log_prob,
+            stochastic_actor_metrics(
+                log_prob,
+                log_std,
+                jnp.mean(jnp.concatenate(qnets_pi, axis=1), axis=1),
+                ent_coef,
+                self.target_entropy,
+            ),
+        )
 
     def _target(
         self,
@@ -113,7 +135,7 @@ class TQC(SAC):
         key,
         ent_coef,
     ):
-        policy, log_prob = self._get_pi_log_prob(policy_params, nxtobses, key)
+        policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key)
         qnets_pi = self.critic(target_critic_params, policy_params, key, nxtobses, policy)
         if self.mixture_type == "min":
             next_q = jnp.min(jnp.stack(qnets_pi, axis=-1), axis=-1) - ent_coef * log_prob

--- a/jax_baselines/XQC/xqc.py
+++ b/jax_baselines/XQC/xqc.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
@@ -8,15 +9,22 @@ import optax
 from flax import struct
 
 from jax_baselines.DDPG.base_class import Deteministic_Policy_Gradient_Family
+from jax_baselines.DDPG.metrics import (
+    critic_metrics,
+    reduce_metrics,
+    stochastic_actor_metrics,
+)
 from jax_baselines.DDPG.training import DPGTrainReport
 from jax_baselines.math.distributional import categorical_projection
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import categorical_metrics, support_metrics
 from jax_baselines.math.param_updates import (
     project_dense_kernels,
     scaled_by_reset,
     soft_update,
 )
 from jax_baselines.math.policy_math import entropy_target_from_sigma
+from jax_baselines.optim import optimizer_metrics
 
 
 @struct.dataclass
@@ -33,7 +41,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
 
     def __init__(
         self,
-        env_builder: callable,
+        env_builder: Callable,
         model_builder_maker,
         ent_coef="auto_0.01",
         sigma_target=0.15,
@@ -116,7 +124,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
         self.target_critic_params = getattr(bundle, "target_critic_params", bundle.critic_params)
         self.log_ent_coef = bundle.log_ent_coef
 
-    def _get_pi_log_prob(self, params, obses, key=None, training: bool = True) -> jnp.ndarray:
+    def _get_pi_log_prob(self, params, obses, key, training: bool = True):
         (mu, log_std), updates = self.actor(params, None, obses, training)
         params["batch_stats"] = updates["batch_stats"]
         std = jnp.exp(log_std)
@@ -128,7 +136,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
             axis=1,
             keepdims=True,
         )
-        return pi, log_prob, params
+        return pi, log_prob, params, log_std
 
     def _get_actions(self, params, obses, key=None) -> jnp.ndarray:
         (mu, log_std), _ = self.actor(params, None, convert_normalized_obs(obses), False)
@@ -152,6 +160,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
             t_mean,
             self.log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         ) = self._train_step(
             self.policy_params,
             self.critic_params,
@@ -168,7 +178,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
             loss=loss,
             target=t_mean,
             new_priorities=new_priorities,
-            metrics={"loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metrics={**metrics, "loss/ent_coef": jnp.exp(self.log_ent_coef)},
+            metric_counts=metric_counts,
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -193,13 +204,15 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 self.opt_ent_coef_state,
                 self.log_ent_coef,
             ),
-            (losses, targets, ent_coefs, priorities),
+            (losses, targets, ent_coefs, priorities, metrics, metric_counts),
         ) = self._bulk_scan(carry, keys, steps, data)
+        metrics, metric_counts = reduce_metrics(metrics, metric_counts)
         return DPGTrainReport(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             new_priorities=priorities,
-            metrics={"loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metrics={**metrics, "loss/ent_coef": jnp.mean(jnp.exp(ent_coefs))},
+            metric_counts=metric_counts,
             update_count=len(contexts),
         )
 
@@ -226,6 +239,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 t_mean,
                 log_ent_coef,
                 priorities,
+                metrics,
+                metric_counts,
             ) = self._train_step(
                 policy_params,
                 critic_params,
@@ -246,7 +261,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 opt_critic_state,
                 opt_ent_coef_state,
                 log_ent_coef,
-            ), (loss, t_mean, log_ent_coef, priorities)
+            ), (loss, t_mean, log_ent_coef, priorities, metrics, metric_counts)
 
         return jax.lax.scan(train_one, carry, (keys, steps, data))
 
@@ -274,7 +289,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
         not_terminateds = 1.0 - terminateds
         ent_coef = jnp.exp(log_ent_coef)
         key1, key2 = jax.random.split(key, 2)
-        target_distribution, target_q, next_policy = self._target(
+        target_distribution, target_q, next_policy, target_metrics = self._target(
             policy_params,
             target_critic_params,
             obses,
@@ -286,7 +301,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
             key1,
         )
 
-        (critic_loss, (cross_entropy, critic_params)), grad = jax.value_and_grad(
+        (critic_loss, (cross_entropy, critic_params, metrics)), grad = jax.value_and_grad(
             self._critic_loss, has_aux=True
         )(
             critic_params,
@@ -302,11 +317,33 @@ class XQC(Deteministic_Policy_Gradient_Family):
         updates, opt_critic_state = self.optimizer.update(
             grad, opt_critic_state, params=critic_params
         )
+        metrics.update(optimizer_metrics(opt_critic_state, "critic"))
+        metrics.update(target_metrics)
         critic_params = optax.apply_updates(critic_params, updates)
         critic_params = project_dense_kernels(critic_params)
         target_critic_params = soft_update(
             critic_params, target_critic_params, self.target_network_update_tau
         )
+        empty_actor_metrics = dict.fromkeys(
+            (
+                "loss/actor_loss",
+                *stochastic_actor_metrics(
+                    jnp.zeros(1), jnp.zeros(1), 0.0, ent_coef, self.target_entropy
+                ),
+                *optimizer_metrics(opt_policy_state, "actor"),
+            ),
+            jnp.asarray(0.0),
+        )
+        if self.auto_entropy:
+            empty_actor_metrics.update(
+                dict.fromkeys(
+                    (
+                        "loss/ent_coef_loss",
+                        *optimizer_metrics(opt_ent_coef_state, "ent_coef"),
+                    ),
+                    jnp.asarray(0.0),
+                )
+            )
 
         def _opt_actor(
             policy_params,
@@ -316,7 +353,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
             opt_ent_coef_state,
             key,
         ):
-            (_, (log_prob, policy_params)), grad = jax.value_and_grad(
+            (actor_loss, (log_prob, policy_params, actor_metrics)), grad = jax.value_and_grad(
                 self._actor_loss, has_aux=True
             )(policy_params, critic_params, obses, key2, ent_coef)
             updates, opt_policy_state = self.optimizer.update(
@@ -324,11 +361,18 @@ class XQC(Deteministic_Policy_Gradient_Family):
             )
             policy_params = optax.apply_updates(policy_params, updates)
             policy_params = project_dense_kernels(policy_params)
+            actor_metrics.update(
+                {
+                    "loss/actor_loss": actor_loss,
+                    **optimizer_metrics(opt_policy_state, "actor"),
+                }
+            )
 
             if self.auto_entropy:
-                log_ent_coef, opt_ent_coef_state = self._train_ent_coef(
+                log_ent_coef, opt_ent_coef_state, entropy_metrics = self._train_ent_coef(
                     log_ent_coef, opt_ent_coef_state, log_prob
                 )
+                actor_metrics.update(entropy_metrics)
             return (
                 policy_params,
                 critic_params,
@@ -336,6 +380,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 opt_policy_state,
                 opt_ent_coef_state,
                 key,
+                actor_metrics,
             )
 
         (
@@ -345,10 +390,11 @@ class XQC(Deteministic_Policy_Gradient_Family):
             opt_policy_state,
             opt_ent_coef_state,
             key,
+            actor_metrics,
         ) = jax.lax.cond(
             (step - 1) % self.policy_delay == 0,
             lambda x: _opt_actor(*x),
-            lambda x: x,
+            lambda x: (*x, empty_actor_metrics),
             (
                 policy_params,
                 critic_params,
@@ -357,6 +403,14 @@ class XQC(Deteministic_Policy_Gradient_Family):
                 opt_ent_coef_state,
                 key,
             ),
+        )
+        metric_counts = {name: jnp.asarray(1) for name in metrics}
+        metrics.update(actor_metrics)
+        metric_counts.update(
+            {
+                name: jnp.asarray((step - 1) % self.policy_delay == 0, dtype=jnp.int32)
+                for name in actor_metrics
+            }
         )
 
         new_priorities = None
@@ -392,6 +446,8 @@ class XQC(Deteministic_Policy_Gradient_Family):
             jnp.mean(target_q),
             log_ent_coef,
             new_priorities,
+            metrics,
+            metric_counts,
         )
 
     def _critic_loss(
@@ -425,18 +481,44 @@ class XQC(Deteministic_Policy_Gradient_Family):
         weights = jnp.asarray(weights).squeeze()
         critic_loss = jnp.mean(weights * cross_entropy1) + jnp.mean(weights * cross_entropy2)
         cross_entropy = 0.5 * (cross_entropy1 + cross_entropy2)
-        return critic_loss, (cross_entropy, critic_params)
+        metrics = critic_metrics(
+            (self._categorical_q(logits1), self._categorical_q(logits2)),
+            jnp.sum(target_distribution * self.value_support, axis=-1),
+            (cross_entropy1, cross_entropy2),
+            weights,
+            cross_entropy if self.prioritized_replay else None,
+        )
+        for index, logits in enumerate((logits1, logits2), start=1):
+            metrics.update(
+                categorical_metrics(
+                    jax.nn.softmax(logits, axis=-1),
+                    target_distribution,
+                    self.value_support,
+                    prefix=f"loss/critic{index}",
+                )
+            )
+        return critic_loss, (cross_entropy, critic_params, metrics)
 
     def _categorical_q(self, logits):
         return jnp.sum(jax.nn.softmax(logits, axis=-1) * self.value_support, axis=-1)
 
     def _actor_loss(self, policy_params, critic_params, obses, key, ent_coef):
-        policy, log_prob, policy_params = self._get_pi_log_prob(policy_params, obses, key)
+        policy, log_prob, policy_params, log_std = self._get_pi_log_prob(policy_params, obses, key)
         (logits1, logits2), _ = self.critic(critic_params, policy_params, key, obses, policy, False)
         q1_pi = self._categorical_q(logits1)
         q2_pi = self._categorical_q(logits2)
         actor_loss = jnp.mean(ent_coef * jnp.squeeze(log_prob, axis=-1) - jnp.minimum(q1_pi, q2_pi))
-        return actor_loss, (log_prob, policy_params)
+        return actor_loss, (
+            log_prob,
+            policy_params,
+            stochastic_actor_metrics(
+                log_prob,
+                log_std,
+                jnp.minimum(q1_pi, q2_pi),
+                ent_coef,
+                self.target_entropy,
+            ),
+        )
 
     def _target(
         self,
@@ -453,7 +535,7 @@ class XQC(Deteministic_Policy_Gradient_Family):
         concated_obses = {
             name: jnp.concatenate([obs, nxtobses[name]]) for name, obs in obses.items()
         }
-        next_policy, log_prob, _ = self._get_pi_log_prob(policy_params, nxtobses, key, False)
+        next_policy, log_prob, _, _ = self._get_pi_log_prob(policy_params, nxtobses, key, False)
         concated_actions = jnp.concatenate([actions, next_policy])
         (logits1, logits2), _ = self.critic(
             target_critic_params,
@@ -484,4 +566,9 @@ class XQC(Deteministic_Policy_Gradient_Family):
         )
         target_distribution = jax.lax.stop_gradient(target_distribution)
         target_q = jnp.sum(target_distribution * self.value_support, axis=-1)
-        return target_distribution, target_q, next_policy
+        return (
+            target_distribution,
+            target_q,
+            next_policy,
+            support_metrics(next_probs, shifted_atoms, self.value_min, self.value_max),
+        )

--- a/tests/test_dpg_entropy_coef.py
+++ b/tests/test_dpg_entropy_coef.py
@@ -65,12 +65,13 @@ def test_train_ent_coef_uses_adam_state_and_entropy_error():
     log_coef = jnp.asarray(np.log(0.1))
     log_prob = jnp.asarray([[-2.0]])
 
-    updated, opt_state = Deteministic_Policy_Gradient_Family._train_ent_coef(
+    updated, opt_state, metrics = Deteministic_Policy_Gradient_Family._train_ent_coef(
         carrier, log_coef, carrier.opt_ent_coef_state, log_prob
     )
 
     assert float(updated) < float(log_coef)
-    assert int(opt_state[0].count) == 1
+    assert int(opt_state.inner_state[0].count) == 1
+    assert float(metrics["loss/ent_coef_loss"]) == pytest.approx(0.1)
 
 
 def test_train_ent_coef_is_jittable():
@@ -81,5 +82,5 @@ def test_train_ent_coef_is_jittable():
             carrier, lc, state, lp
         )
     )
-    out, _ = fn(jnp.asarray(0.0), carrier.opt_ent_coef_state, jnp.asarray([[-1.0]]))
+    out, _, _ = fn(jnp.asarray(0.0), carrier.opt_ent_coef_state, jnp.asarray([[-1.0]]))
     assert np.isfinite(float(out))

--- a/tests/test_dpg_training.py
+++ b/tests/test_dpg_training.py
@@ -391,6 +391,8 @@ def test_ddpg_train_on_bulk_scans_updates_and_stacks_priorities():
             step.astype(float),
             step.astype(float) + 10.0,
             priorities,
+            {},
+            {},
         )
 
     agent._train_step = train_step

--- a/tests/test_sac_flashsac.py
+++ b/tests/test_sac_flashsac.py
@@ -8,6 +8,7 @@ import pytest
 
 from experiments.cli.dpg import DPG_RUNNER
 from jax_baselines.CrossQ.crossq import CrossQ
+from jax_baselines.DDPG.metrics import stochastic_actor_metrics
 from jax_baselines.math.policy_math import entropy_target_from_sigma
 from jax_baselines.SAC.sac import SAC, mode_action, sample_action
 from jax_baselines.TQC.tqc import TQC
@@ -46,7 +47,9 @@ def test_dpg_eval_path_uses_sac_mode_without_sampling():
 
 def test_sac_actor_loss_uses_minimum_expected_q():
     agent = object.__new__(SAC)
+    agent.target_entropy = 0.0
     agent._get_pi_log_prob = lambda params, feature, key: (
+        jnp.zeros((feature["unified_obs"].shape[0], 1)),
         jnp.zeros((feature["unified_obs"].shape[0], 1)),
         jnp.zeros((feature["unified_obs"].shape[0], 1)),
     )
@@ -186,10 +189,13 @@ def test_sac_actor_and_temperature_update_on_configured_period():
     assert int(second[5][0].count) == 1
     np.testing.assert_allclose(second[0], first[0])
     assert int(first[5][0].count) == 1
+    assert first[11]["loss/actor_loss"] == 1
+    assert second[11]["loss/actor_loss"] == 0
 
 
 def test_sac_actor_and_target_use_distinct_fresh_keys():
     agent = object.__new__(SAC)
+    agent.target_entropy = 0.0
     agent.optimizer = optax.sgd(0.0)
     agent.actor_update_period = 1
     agent.target_network_update_tau = 0.01
@@ -201,11 +207,14 @@ def test_sac_actor_and_target_use_distinct_fresh_keys():
     )
     agent._critic_loss = lambda critic, policy, obses, actions, targets, weights, key: (
         targets + 0.0 * critic,
-        jnp.zeros((1,)),
+        (jnp.zeros((1,)), {}),
     )
     agent._actor_loss = lambda policy, critic, obses, key, alpha: (
         jax.random.uniform(key) + 0.0 * policy,
-        jnp.zeros((1, 1)),
+        (
+            jnp.zeros((1, 1)),
+            stochastic_actor_metrics(jnp.zeros((1, 1)), jnp.zeros((1, 1)), 0.0, 0.01, 0.0),
+        ),
     )
 
     policy_params = jnp.asarray(0.0)
@@ -232,8 +241,9 @@ def test_sac_actor_and_target_use_distinct_fresh_keys():
     target_key, _, actor_key = jax.random.split(key, 3)
 
     np.testing.assert_allclose(output[6], jax.random.uniform(target_key))
-    np.testing.assert_allclose(-output[7], jax.random.uniform(actor_key))
-    assert not np.allclose(output[6], -output[7])
+    np.testing.assert_allclose(output[7], jax.random.uniform(target_key))
+    np.testing.assert_allclose(output[10]["loss/actor_loss"], jax.random.uniform(actor_key))
+    assert not np.allclose(output[7], output[10]["loss/actor_loss"])
 
 
 def test_sac_cli_uses_flashsac_defaults_without_changing_sibling_algorithms():


### PR DESCRIPTION
SAC·TQC의 `loss/targets`가 실제로는 `-actor_loss`였던 문제를 수정하고, DPG의 actor/critic/temperature 진단을 분리합니다. Actor 갱신을 건너뛴 0이 평균에 섞이거나 bulk chunk에서 지표가 사라지던 보고 경로도 실제 관측 수로 집계합니다.

- DDPG·TD3·SAC·TQC·CrossQ·XQC·FlashSAC·TD7에 critic별 loss/Q/TD, target 통계, PER 및 optimizer 진단을 연결합니다.
- SAC 계열에 entropy, sigma에서 계산한 목표 entropy, entropy gap, actor Q/entropy 항과 자동 temperature loss를 추가합니다. TQC의 quantile 진단, XQC·FlashSAC의 categorical/support 진단, TD7 encoder optimizer도 포함합니다.
- 지표별 관측 수를 bulk와 fallback 전체에서 합산합니다. 실제 갱신이 없는 actor/alpha 지표는 생략하고, 실제 갱신의 `NaN`은 유지합니다.

기존 집중 테스트 47개와 8개 알고리즘의 정상 CLI/실제 TensorBoard scalar 검증을 통과했습니다. 고정 배치에서 8개 알고리즘의 변경 전후 parameter pytree가 모두 bitwise 일치합니다. Uniform replay SAC의 전체 CLI checkpoint도 동일합니다. PER 샘플러는 동일 seed 재실행 간 차이가 있어 수치 보존 비교는 고정 배치로 수행했습니다. Ruff와 저장소 커밋 검사를 통과했고, 소스 ty 진단은 기존 72개에서 52개로 줄었으며 신규 진단은 없습니다.
