### PR TITLE
[4/4] QNET 분포형·PER·representation 진단 기록

### DIFF
--- a/docs/loss_metrics.md
+++ b/docs/loss_metrics.md
@@ -1,0 +1,102 @@
+# Loss 지표 정의
+
+로컬 `pg`, `dpg`, `qnet`의 학습 지표다. 기존 logger와 기록 주기를 사용하며,
+`loss/`에는 목적함수와 진단 통계가 함께 들어간다. Optimizer 지표는 `optim/`에 기록한다.
+지표가 작아지거나 Q값이 커졌다는 사실만으로 정책 성능 개선을 판단하지 않는다.
+
+## PG
+
+A2C·PPO·SPO·TPPO에 적용한다. 표의 키는 `loss/` 접두사를 생략했다.
+
+| 키                                                     | 정의와 측정 시점                                                                                                          |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `critic_loss`, `actor_loss`, `entropy_loss`            | 기존 손실 정의를 유지한다. `entropy_loss`는 음의 entropy다.                                                               |
+| `actor_objective`                                      | 실제 미분한 actor 목적함수. Entropy advantage shaping을 켜면 additive entropy 항을 다시 더하지 않는다.                    |
+| `explained_variance`                                   | 업데이트 전 rollout의 `1 - Var(target - value) / Var(target)`. Target 분산이 0이면 `NaN`이다.                             |
+| `value_mean`, `value_std`, `mean_target`, `target_std` | 업데이트 전 rollout의 value와 return 통계.                                                                                |
+| `advantage_mean`, `advantage_std`                      | 정규화와 entropy advantage shaping 전 advantage 통계.                                                                     |
+| `approx_kl`                                            | PPO·SPO에서 `l = log_pi_new - log_pi_old`일 때 `mean(exp(l) - 1 - l)`. Old policy 표본으로 `KL(old \|\| new)`를 추정한다. |
+| `clip_fraction`                                        | PPO·SPO의 `mean(abs(exp(l) - 1) > ppo_eps)`. 실제 objective가 clipped branch를 선택한 비율과는 다르다.                    |
+| `kl_divergence`                                        | TPPO의 기존 exact KL. PPO의 ratio clipping 통계로 대체하지 않는다.                                                        |
+| `policy_std_mean/min/max`, `log_std_mean/min/max`      | 연속 정책 Gaussian 파라미터의 표준편차와 log 표준편차. Bounded action 표본의 표준편차는 아니다.                           |
+
+Rollout 통계는 rollout마다 한 번 측정한다. Surrogate 목적함수, KL, clip fraction,
+정책 scale, optimizer 지표는 각 minibatch의 업데이트 시점에서 계산한 뒤 epoch 전체를 평균한다.
+
+## DPG
+
+DDPG·TD3·SAC·TQC·CrossQ·XQC·FlashSAC·TD7에 적용한다.
+
+| `loss/` 키                                                  | 정의와 적용 조건                                                                                                                                    |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `qloss`, `critic1_loss`, `critic2_loss`                     | 실제 critic 목적함수와 critic별 항. 일반 twin critic은 합, FlashSAC는 두 CE의 평균이다. TQC는 각 critic의 quantile Huber를 기록한다.                |
+| `targets`                                                   | 실제 critic target 평균. SAC·TQC에서 이전에 잘못 기록하던 `-actor_loss`를 교정했다.                                                                 |
+| `q1_mean/std/min/max`, `q2_mean/std/min/max`                | 업데이트에 사용한 replay action의 critic 예측. TQC는 각 critic 분포의 평균, XQC·FlashSAC는 support 기댓값이다.                                      |
+| `target_std/min/max`                                        | Replay 표본별 target 기댓값의 통계.                                                                                                                 |
+| `actor_loss`, `actor_q_mean`                                | 실제 actor 목적함수와 그 목적함수에 사용한 Q값의 평균. Replay action Q와 별도다.                                                                    |
+| `td_signed_mean`, `td_abs_mean`, `td_abs_p95`               | `target - prediction`을 모든 critic과 표본에 걸쳐 요약. `td1_*`, `td2_*`는 critic별 값이다.                                                         |
+| `q_disagreement`                                            | Twin critic의 `mean(abs(q1 - q2))`. 실제 return 대비 과대평가량은 아니다.                                                                           |
+| `entropy`, `policy_target_entropy`, `entropy_gap`           | SAC 계열의 `-mean(log_pi)`, sigma에서 계산한 목표 entropy, 두 값의 차이. 실제 actor 표본과 tanh 보정을 재사용한다.                                  |
+| `actor_entropy_term`                                        | SAC 계열 actor 목적함수의 `mean(alpha * log_pi)` 항.                                                                                                |
+| `ent_coef`, `ent_coef_loss`                                 | Alpha와 자동 temperature 목적함수 `mean(alpha * (entropy - target_entropy))`. 고정 alpha에서는 temperature loss와 optimizer 지표를 기록하지 않는다. |
+| `policy_std_*`, `log_std_*`                                 | SAC 계열 Gaussian 파라미터의 mean/min/max.                                                                                                          |
+| `criticN/quantile_spread`, `criticN/quantile_crossing_rate` | TQC 각 critic의 분위수 폭과 인접 분위수 역전율.                                                                                                     |
+
+Actor와 temperature 지표는 실제 해당 optimizer가 갱신된 횟수로 평균한다.
+갱신을 건너뛴 스텝은 관측값 0으로 섞지 않으며, 갱신이 전혀 없는 로그 구간에서는 키를 생략한다.
+실제 갱신에서 나온 `NaN`은 유지한다. Chunk와 단일 update가 섞여도 지표별 관측 수를 합산한다.
+TD7의 기존 encoder loss와 value bounds도 유지한다.
+
+## QNET와 분포형 진단
+
+DQN·C51·QRDQN·IQN·FQF·SPR·BBF 및 HL-Gauss 변형에 적용한다.
+
+| `loss/` 키                                                                     | 정의와 적용 조건                                                                                                                                  |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `q_mean/std/min/max`, `target_mean/std/min/max`                                | Replay의 선택 행동 Q와 target 기댓값. FQF는 학습된 fraction 구간 폭으로 가중한다.                                                                 |
+| `td_signed_mean`, `td_abs_mean`, `td_abs_p95`                                  | Scalar 기댓값의 `target - prediction`. 기존 MSE, CE, quantile Huber와 별개다.                                                                     |
+| `categorical_cross_entropy`, `categorical_kl`, `target_entropy`                | 같은 안정화된 log로 계산한 `CE`, `KL(target \|\| online)`, `H(target)`. `CE = KL + H` 관계를 만족한다. 기존 최적화 CE의 epsilon과는 다를 수 있다. |
+| `online_edge_mass_low/high`, `target_edge_mass_low/high`                       | 현재 분포와 투영된 target의 첫/마지막 bin 확률.                                                                                                   |
+| `support_clipped_mass_low/high`                                                | 투영하기 전 support 범위 밖의 target 확률 질량. C51은 action mixture와 atom 확률로 가중한다. HL-Gauss는 변환 전 scalar target의 범위 이탈률이다.  |
+| `quantile_spread`                                                              | 선택 행동의 online 분위수 최대값과 최소값 차이. Epistemic uncertainty로 해석하지 않는다.                                                          |
+| `quantile_crossing_rate`                                                       | Tau 순서로 정렬한 뒤 인접 Q 분위수가 역전된 비율. IQN의 무작위 tau 순서를 그대로 비교하지 않는다.                                                 |
+| `fraction_entropy`, `fraction_width_min/max`                                   | FQF fraction 분포의 entropy와 구간 폭 범위. 기존 `fqf_loss`, `tau` histogram도 유지한다.                                                          |
+| `total_loss`, `weighted_rprloss`                                               | SPR·BBF의 실제 `qloss + spr_weight * rprloss`와 가중 representation 항. Raw `rprloss`도 유지한다.                                                 |
+| `online_action_churn`, `target_action_churn`, `online_target_action_agreement` | SPR·BBF의 학습 전후 greedy action 변화율과 학습 후 online/target 일치율.                                                                          |
+| `action_churn_updates_spanned`                                                 | Churn 측정 전후 사이의 실제 optimizer update 수. Bulk chunk 크기에 따른 측정 구간 차이를 표시한다.                                                |
+
+XQC·FlashSAC의 categorical CE/KL/entropy/edge 통계는 `loss/criticN/`에 기록하고,
+support clipping은 `loss/`에 기록한다. 기존 `target_stds`는 target 분위수 내부 표준편차의
+평균이며 새 `target_std`와 다르다. 기존 FQF `targets`의 평균 방식도 유지한다.
+
+SPR·BBF의 action 지표는 로그가 필요한 마지막 update 또는 bulk chunk에서만 측정한다.
+동일한 replay 관측 최대 32개와 고정 진단 키를 사용하고 학습용 RNG는 소비하지 않는다.
+Logger가 없거나 로그 주기가 아니면 추가 forward를 실행하지 않는다. Churn은 해당 update 또는
+chunk 전후의 변화이며 서로 다른 로그 시점의 action 변화율은 아니다.
+
+## PER와 optimizer
+
+PER 활성화 시 learner가 replay에 전달하는 priority의 `loss/priority_mean/max/p95`와
+실제 loss에 적용한 weight의 `loss/is_weight_mean/min/max/ess`를 기록한다.
+`ESS = sum(w)^2 / sum(w^2)`는 현재 배치의 weight 통계다. 버퍼 전체의 다양성을 뜻하지 않는다.
+`loss/unweighted_loss`는 importance weight를 적용하기 전의 동일한 critic loss다.
+TD7의 priority 경로는 importance weight를 사용하지 않으므로 weight 1을 기준으로 기록한다.
+FlashSAC는 PER를 지원하지 않는다.
+
+| `optim/{optimizer}_` 접미사 | 정의                                                                                                              |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `grad_norm_pre_clip`        | Optimizer에 전달된 gradient pytree의 전체 L2 norm.                                                                |
+| `grad_clip_fraction`        | 설정된 global norm clipping 임계값을 초과한 update의 비율. Optimizer 내부의 개별 변환 clipping은 포함하지 않는다. |
+| `update_norm`               | Optimizer가 반환한 update의 L2 norm. 이후 parameter projection/reset은 포함하지 않는다.                           |
+| `parameter_norm`            | 해당 optimizer update 직전 parameter pytree의 L2 norm.                                                            |
+| `learning_rate`             | 해당 update에 공급한 scalar/schedule 값. Adaptive preconditioning까지 포함한 파라미터별 유효 step size는 아니다.  |
+
+Optimizer 이름은 `actor`, `critic`, `ent_coef`, `q`, `fraction`, `actor_encoder`,
+`critic_encoder` 중 해당하는 값이다. Schedule의 실제 update counter와 periodic optimizer
+reset을 따른다. Experiment factory는 자동으로 계측한다. 직접 주입한 Optax factory도 기존처럼
+사용할 수 있으며, 계측이 필요하면 `track_optimizer`로 감싼다. 내부 optimizer state는
+`OptimizerMetricsState.inner_state`에 보관한다.
+
+DPG·QNET bulk 로그의 std, min/max, p95는 **update별 통계를 평균한 값**이다.
+여러 배치의 원소를 합쳐 다시 구한 std나 p95가 아니다. Parameter reduction과 percentile에는
+계산 비용이 있으며 지표 추가가 학습 처리량을 유지한다고 보장하지 않는다.

--- a/jax_baselines/BBF/bbf.py
+++ b/jax_baselines/BBF/bbf.py
@@ -3,12 +3,14 @@ import jax.numpy as jnp
 import optax
 
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import replay_metrics
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
     soft_update,
     tree_random_normal_like,
 )
+from jax_baselines.optim import optimizer_metrics
 from jax_baselines.SPR.spr import SPR
 
 
@@ -67,7 +69,7 @@ class BBF(SPR):
         self.reset_hardsoft = filter_like_tree(
             self.params,
             "qnet",
-            (lambda x, filtered: (jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.5)),
+            (lambda x, filtered: jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.5),
         )  # hard_reset for qnet and scaled_by_reset for the rest
         self.soft_reset_freq = 40000
         self.optimizer = self._make_optimizer(self.learning_rate)
@@ -78,6 +80,7 @@ class BBF(SPR):
             axis=0,
         )  # [1, 51]
         self._categorial_bar = jnp.expand_dims(self.categorial_bar, axis=0)  # [1, 1, 51]
+        self.value_support = self.categorial_bar[0]
         self.delta_bar = jax.device_put(
             (self.categorial_max - self.categorial_min) / (self.categorial_bar_n - 1)
         )
@@ -175,7 +178,7 @@ class BBF(SPR):
             parsed_gamma = (
                 jnp.take_along_axis(jnp.expand_dims(_gamma, 0), last_idxs, axis=1) * gamma
             )
-            target_distribution = self._target(
+            target_distribution, target_metrics = self._target(
                 params,
                 target_params,
                 parsed_obses,
@@ -191,7 +194,9 @@ class BBF(SPR):
             )
             transition_actions = actions[:, : self.prediction_depth]
             transition_filled = filled[:, : self.prediction_depth]
-            (_, (centropy, qloss, rprloss)), grad = jax.value_and_grad(self._loss, has_aux=True)(
+            (_, (centropy, qloss, rprloss, metrics)), grad = jax.value_and_grad(
+                self._loss, has_aux=True
+            )(
                 params,
                 target_params,
                 transition_obses,
@@ -204,6 +209,10 @@ class BBF(SPR):
                 key,
             )
             updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+            metrics.update(target_metrics)
+            metrics.update(optimizer_metrics(opt_state, "q"))
+            if self.prioritized_replay:
+                metrics.update(replay_metrics(weights, centropy))
             params = optax.apply_updates(params, updates)
             target_params = soft_update(params, target_params, 0.005)
             params, opt_state = scaled_by_reset_with_filter(
@@ -224,6 +233,7 @@ class BBF(SPR):
                 qloss,
                 rprloss,
                 target_q,
+                metrics,
             )
 
         (params, target_params, opt_state, _), outputs = jax.lax.scan(
@@ -239,7 +249,7 @@ class BBF(SPR):
                 batched_steps,
             ),
         )
-        centropy, qloss, rprloss, target_q = outputs
+        centropy, qloss, rprloss, target_q, metrics = outputs
         qloss = jnp.mean(qloss)
         rprloss = jnp.mean(rprloss)
         target_q = jnp.mean(target_q)
@@ -255,6 +265,7 @@ class BBF(SPR):
             target_q,
             new_priorities,
             rprloss,
+            jax.tree.map(jnp.mean, metrics),
         )
 
     def run_name_update(self, run_name):

--- a/jax_baselines/BBF/hl_gauss_bbf.py
+++ b/jax_baselines/BBF/hl_gauss_bbf.py
@@ -10,12 +10,14 @@ from jax_baselines.math.distributional import (
     distributional_td_target,
 )
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import replay_metrics
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
     soft_update,
     tree_random_normal_like,
 )
+from jax_baselines.optim import optimizer_metrics
 
 
 class HL_GAUSS_BBF(BBF):
@@ -72,7 +74,7 @@ class HL_GAUSS_BBF(BBF):
         self.reset_hardsoft = filter_like_tree(
             self.params,
             "qnet",
-            (lambda x, filtered: (jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.5)),
+            (lambda x, filtered: jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.5),
         )  # hard_reset for qnet and scaled_by_reset for the rest
         self.soft_reset_freq = 40000
         self.optimizer = self._make_optimizer(self.learning_rate)
@@ -81,6 +83,7 @@ class HL_GAUSS_BBF(BBF):
         self.hl_gauss = HLGaussTransform.build(
             self.categorial_min, self.categorial_max, self.categorial_bar_n
         )
+        self.value_support = (self.hl_gauss.support[:-1] + self.hl_gauss.support[1:]) / 2
 
         # Use common JIT compilation
         self._compile_common_functions()
@@ -165,7 +168,7 @@ class HL_GAUSS_BBF(BBF):
             parsed_gamma = (
                 jnp.take_along_axis(jnp.expand_dims(_gamma, 0), last_idxs, axis=1) * gamma
             )
-            target_distribution = self._target(
+            target_distribution, target_metrics = self._target(
                 params,
                 target_params,
                 parsed_obses,
@@ -181,7 +184,9 @@ class HL_GAUSS_BBF(BBF):
             )
             transition_actions = actions[:, : self.prediction_depth]
             transition_filled = filled[:, : self.prediction_depth]
-            (_, (centropy, qloss, rprloss)), grad = jax.value_and_grad(self._loss, has_aux=True)(
+            (_, (centropy, qloss, rprloss, metrics)), grad = jax.value_and_grad(
+                self._loss, has_aux=True
+            )(
                 params,
                 target_params,
                 transition_obses,
@@ -194,6 +199,10 @@ class HL_GAUSS_BBF(BBF):
                 key,
             )
             updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+            metrics.update(target_metrics)
+            metrics.update(optimizer_metrics(opt_state, "q"))
+            if self.prioritized_replay:
+                metrics.update(replay_metrics(weights, centropy))
             params = optax.apply_updates(params, updates)
             target_params = soft_update(params, target_params, 0.005)
             params, opt_state = scaled_by_reset_with_filter(
@@ -211,6 +220,7 @@ class HL_GAUSS_BBF(BBF):
                 qloss,
                 rprloss,
                 target_q,
+                metrics,
             )
 
         (params, target_params, opt_state, _), outputs = jax.lax.scan(
@@ -226,7 +236,7 @@ class HL_GAUSS_BBF(BBF):
                 batched_steps,
             ),
         )
-        centropy, qloss, rprloss, target_q = outputs
+        centropy, qloss, rprloss, target_q, metrics = outputs
         qloss = jnp.mean(qloss)
         rprloss = jnp.mean(rprloss)
         target_q = jnp.mean(target_q)
@@ -242,6 +252,7 @@ class HL_GAUSS_BBF(BBF):
             target_q,
             new_priorities,
             rprloss,
+            jax.tree.map(jnp.mean, metrics),
         )
 
     def _target(
@@ -282,4 +293,5 @@ class HL_GAUSS_BBF(BBF):
             online_next_dists=online_next_dists,
             behavior_dists=behavior_dists,
             munchausen=munchausen,
+            return_diagnostics=True,
         )

--- a/jax_baselines/C51/c51.py
+++ b/jax_baselines/C51/c51.py
@@ -11,7 +11,14 @@ from jax_baselines.math.distributional import (
     distributional_td_target,
 )
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import (
+    array_metrics,
+    categorical_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import hard_update
+from jax_baselines.optim import optimizer_metrics
 
 
 class C51(Q_Network_Family):
@@ -64,7 +71,7 @@ class C51(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def get_q(self, params, obses, key=None) -> jnp.ndarray:
         return self.model(params, key, self.preproc(params, key, obses))
@@ -100,7 +107,7 @@ class C51(Q_Network_Family):
         nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
-        target_distribution = self._target(
+        target_distribution, metrics = self._target(
             params,
             target_params,
             obses,
@@ -110,35 +117,42 @@ class C51(Q_Network_Family):
             not_terminateds,
             key,
         )
-        (loss, centropy), grad = jax.value_and_grad(self._loss, has_aux=True)(
+        (loss, (centropy, distribution)), grad = jax.value_and_grad(self._loss, has_aux=True)(
             params, obses, actions, target_distribution, weights, key
         )
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        q_values = jnp.sum(distribution * self.categorial_bar, axis=1)
+        target_values = jnp.sum(target_distribution * self.categorial_bar, axis=1)
+        metrics.update(
+            {
+                **array_metrics(q_values, "loss/q"),
+                **array_metrics(target_values, "loss/target"),
+                **td_metrics(q_values, target_values),
+                **categorical_metrics(distribution, target_distribution, self.categorial_bar[0]),
+                **optimizer_metrics(opt_state, "q"),
+                "loss/unweighted_loss": jnp.mean(centropy),
+            }
+        )
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = centropy
+            metrics.update(replay_metrics(weights, new_priorities))
         return (
             params,
             target_params,
             opt_state,
             loss,
-            jnp.mean(
-                jnp.sum(
-                    target_distribution * self.categorial_bar,
-                    axis=1,
-                )
-            ),
+            jnp.mean(target_values),
             new_priorities,
+            metrics,
         )
 
     def _loss(self, params, obses, actions, target_distribution, weights, key):
-        distribution = jnp.squeeze(
-            jnp.take_along_axis(self.get_q(params, obses, key), actions, axis=1)
-        )
+        distribution = jnp.take_along_axis(self.get_q(params, obses, key), actions, axis=1)[:, 0]
         cross_entropy = -jnp.sum(target_distribution * jnp.log(distribution + 1e-6), axis=1)
-        return jnp.mean(cross_entropy * weights), cross_entropy
+        return jnp.mean(cross_entropy * weights), (cross_entropy, distribution)
 
     def _target(
         self,
@@ -181,4 +195,5 @@ class C51(Q_Network_Family):
             online_next_dists=online_next_dists,
             behavior_dists=behavior_dists,
             munchausen=munchausen,
+            return_diagnostics=True,
         )

--- a/jax_baselines/C51/hl_gauss_c51.py
+++ b/jax_baselines/C51/hl_gauss_c51.py
@@ -12,7 +12,14 @@ from jax_baselines.math.distributional import (
     distributional_td_target,
 )
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import (
+    array_metrics,
+    categorical_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import hard_update
+from jax_baselines.optim import optimizer_metrics
 
 
 class HL_GAUSS_C51(Q_Network_Family):
@@ -58,7 +65,7 @@ class HL_GAUSS_C51(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def get_q(self, params, obses, key=None) -> jnp.ndarray:
         return self.model(params, key, self.preproc(params, key, obses))
@@ -89,7 +96,7 @@ class HL_GAUSS_C51(Q_Network_Family):
         nxtobses = convert_normalized_obs(nxtobses)
         actions = jnp.expand_dims(actions.astype(jnp.int32), axis=2)
         not_terminateds = 1.0 - terminateds
-        target_distribution = self._target(
+        target_distribution, metrics = self._target(
             params,
             target_params,
             obses,
@@ -99,30 +106,46 @@ class HL_GAUSS_C51(Q_Network_Family):
             not_terminateds,
             key,
         )
-        (loss, centropy), grad = jax.value_and_grad(self._loss, has_aux=True)(
+        (loss, (centropy, distribution)), grad = jax.value_and_grad(self._loss, has_aux=True)(
             params, obses, actions, target_distribution, weights, key
         )
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        q_values = self.hl_gauss.to_scalar(distribution[:, None, :])[:, 0]
+        target_values = self.hl_gauss.to_scalar(target_distribution[:, None, :])[:, 0]
+        metrics.update(
+            {
+                **array_metrics(q_values, "loss/q"),
+                **array_metrics(target_values, "loss/target"),
+                **td_metrics(q_values, target_values),
+                **categorical_metrics(
+                    distribution,
+                    target_distribution,
+                    (self.hl_gauss.support[:-1] + self.hl_gauss.support[1:]) / 2,
+                ),
+                **optimizer_metrics(opt_state, "q"),
+                "loss/unweighted_loss": jnp.mean(centropy),
+            }
+        )
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = centropy
+            metrics.update(replay_metrics(weights, new_priorities))
         return (
             params,
             target_params,
             opt_state,
             loss,
-            self.hl_gauss.to_scalar(jnp.expand_dims(target_distribution, 1)).mean(),
+            jnp.mean(target_values),
             new_priorities,
+            metrics,
         )
 
     def _loss(self, params, obses, actions, target_distribution, weights, key):
-        distribution = jnp.squeeze(
-            jnp.take_along_axis(self.get_q(params, obses, key), actions, axis=1)
-        )
+        distribution = jnp.take_along_axis(self.get_q(params, obses, key), actions, axis=1)[:, 0]
         cross_entropy = -jnp.sum(target_distribution * jnp.log(distribution + 1e-6), axis=1)
-        return jnp.mean(cross_entropy * weights), cross_entropy
+        return jnp.mean(cross_entropy * weights), (cross_entropy, distribution)
 
     def _target(
         self,
@@ -161,4 +184,5 @@ class HL_GAUSS_C51(Q_Network_Family):
             online_next_dists=online_next_dists,
             behavior_dists=behavior_dists,
             munchausen=munchausen,
+            return_diagnostics=True,
         )

--- a/jax_baselines/DQN/base_class.py
+++ b/jax_baselines/DQN/base_class.py
@@ -40,6 +40,7 @@ from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
 class Q_Network_Family:
     _run_name = "Q_network"
     _get_actions: Callable[..., jax.Array]
+    _compiled_bulk_scan: Callable[..., tuple[tuple, tuple]]
 
     supports_bulk_training = False
 
@@ -280,6 +281,7 @@ class Q_Network_Family:
             loss,
             target,
             priorities,
+            metrics,
         ) = self._train_step(
             self.params,
             self.target_params,
@@ -288,7 +290,9 @@ class Q_Network_Family:
             next(self.key_seq) if self.param_noise else None,
             **data,
         )
-        return QNetTrainResult.from_values(loss=loss, target=target, replay_priorities=priorities)
+        return QNetTrainResult.from_values(
+            loss=loss, target=target, replay_priorities=priorities, metrics=metrics
+        )
 
     def _train_on_bulk(self, data, contexts):
         steps = jnp.asarray([context.train_steps_count for context in contexts])
@@ -300,12 +304,14 @@ class Q_Network_Family:
                 losses,
                 targets,
                 priorities,
+                metrics,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = self._compiled_bulk_scan(carry, keys, steps, data)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             replay_priorities=priorities,
+            metrics=jax.tree.map(jnp.mean, metrics),
             update_count=len(contexts),
         )
 
@@ -317,7 +323,7 @@ class Q_Network_Family:
             else:
                 step, batch = xs
                 key = None
-            params, target_params, opt_state, loss, target, priorities = self._train_step(
+            params, target_params, opt_state, loss, target, priorities, metrics = self._train_step(
                 params,
                 target_params,
                 opt_state,
@@ -325,7 +331,7 @@ class Q_Network_Family:
                 key,
                 **batch,
             )
-            return (params, target_params, opt_state), (loss, target, priorities)
+            return (params, target_params, opt_state), (loss, target, priorities, metrics)
 
         xs = (steps, keys, data) if self.param_noise else (steps, data)
         return jax.lax.scan(train_one, carry, xs)
@@ -336,9 +342,13 @@ class Q_Network_Family:
         counts = jnp.array([report.update_count for report in reports])
         total = sum(report.update_count for report in reports)
         metrics = {
-            name: jnp.sum(jnp.array([report.metrics[name] for report in reports]) * counts) / total
-            for name in reports[-1].metrics
-            if all(name in report.metrics for report in reports)
+            name: sum(
+                report.metrics[name] * report.update_count
+                for report in reports
+                if name in report.metrics
+            )
+            / sum(report.update_count for report in reports if name in report.metrics)
+            for name in set().union(*(report.metrics for report in reports))
         }
         histograms = {
             name: jnp.sum(

--- a/jax_baselines/DQN/dqn.py
+++ b/jax_baselines/DQN/dqn.py
@@ -6,8 +6,10 @@ import optax
 
 from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import array_metrics, replay_metrics, td_metrics
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
+from jax_baselines.optim import optimizer_metrics
 
 
 class DQN(Q_Network_Family):
@@ -32,7 +34,7 @@ class DQN(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def get_q(self, params, obses, key=None) -> jnp.ndarray:
         return self.model(params, key, self.preproc(params, key, obses))
@@ -71,24 +73,32 @@ class DQN(Q_Network_Family):
             not_terminateds,
             key,
         )
-        (loss, abs_error), grad = jax.value_and_grad(self._loss, has_aux=True)(
+        (loss, (abs_error, metrics)), grad = jax.value_and_grad(self._loss, has_aux=True)(
             params, obses, actions, targets, weights, key
         )
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        metrics.update(optimizer_metrics(opt_state, "q"))
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = abs_error
-        return params, target_params, opt_state, loss, jnp.mean(targets), new_priorities
+            metrics.update(replay_metrics(weights, new_priorities))
+        return params, target_params, opt_state, loss, jnp.mean(targets), new_priorities, metrics
 
     def _loss(self, params, obses, actions, targets, weights, key):
         vals = jnp.take_along_axis(self.get_q(params, obses, key), actions, axis=1)
         error = jnp.squeeze(vals - targets)
         loss = jnp.square(error)
-        return jnp.mean(loss * weights), jnp.abs(
-            error
-        )  # remove weight multiply cpprb weight is something wrong
+        return jnp.mean(loss * weights), (
+            jnp.abs(error),
+            {
+                **array_metrics(vals, "loss/q"),
+                **array_metrics(targets, "loss/target"),
+                **td_metrics(vals, targets),
+                "loss/unweighted_loss": jnp.mean(loss),
+            },
+        )
 
     def _target(
         self,

--- a/jax_baselines/DQN/training.py
+++ b/jax_baselines/DQN/training.py
@@ -7,7 +7,7 @@ tuple returns and translate them into a lifecycle result on the Python side via
 `jax_baselines.core.rollout`.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import jax
 
@@ -30,6 +30,7 @@ class QNetTrainContext:
     steps: int
     train_steps_count: int
     gradient_steps: int
+    collect_diagnostics: bool = False
 
 
 @dataclass
@@ -95,12 +96,18 @@ class QNetTrainingLifecycle:
         if gradient_steps <= 0:
             raise ValueError("gradient_steps must be greater than 0")
 
+        interval = self.agent.log_interval if log_interval is None else log_interval
+        collect_diagnostics = bool(logger_run and steps - self.agent._last_log_step >= interval)
         if self._uses_bulk_pulse(gradient_steps):
-            report = self._train_one_pulse(steps, gradient_steps)
+            report = self._train_one_pulse(steps, gradient_steps, collect_diagnostics)
         else:
             reports = []
-            for _ in range(gradient_steps):
-                reports.append(self._train_one_batch(steps, gradient_steps))
+            for index in range(gradient_steps):
+                reports.append(
+                    self._train_one_batch(
+                        steps, gradient_steps, collect_diagnostics and index == gradient_steps - 1
+                    )
+                )
 
             report = self.agent._aggregate_train_reports(reports)
 
@@ -110,7 +117,7 @@ class QNetTrainingLifecycle:
     def _uses_bulk_pulse(self, gradient_steps):
         return uses_bulk_pulse(self.agent, gradient_steps)
 
-    def _train_one_batch(self, steps, gradient_steps):
+    def _train_one_batch(self, steps, gradient_steps, collect_diagnostics=False):
         self.agent.train_steps_count += 1
         data = self.agent._sample_batch()
         self._normalize_batch(data)
@@ -118,12 +125,13 @@ class QNetTrainingLifecycle:
             steps=steps,
             train_steps_count=self.agent.train_steps_count,
             gradient_steps=gradient_steps,
+            collect_diagnostics=collect_diagnostics,
         )
         result = self._normalise_train_result(self.agent._train_on_batch(data, context))
         self._update_priorities(data, result)
         return result.report
 
-    def _train_one_pulse(self, steps, gradient_steps):
+    def _train_one_pulse(self, steps, gradient_steps, collect_diagnostics=False):
         """Run chunked bulk updates.
 
         Bulk mode is a throughput path: one replay sample is split into mini-updates,
@@ -141,6 +149,13 @@ class QNetTrainingLifecycle:
                 chunk_size,
                 gradient_steps=chunk_size,
             )
+            contexts = (
+                *contexts[:-1],
+                replace(
+                    contexts[-1],
+                    collect_diagnostics=collect_diagnostics and remaining == chunk_size,
+                ),
+            )
             data = self.agent._sample_batch(chunk_size * self.agent.batch_size)
             data = self._reshape_bulk_batch(data, chunk_size)
             data = normalize_bulk_weights(data)
@@ -151,7 +166,9 @@ class QNetTrainingLifecycle:
             remaining -= chunk_size
 
         while remaining > 0:
-            reports.append(self._train_one_batch(steps, gradient_steps))
+            reports.append(
+                self._train_one_batch(steps, gradient_steps, collect_diagnostics and remaining == 1)
+            )
             remaining -= 1
 
         return self.agent._aggregate_train_reports(reports)

--- a/jax_baselines/FQF/fqf.py
+++ b/jax_baselines/FQF/fqf.py
@@ -8,9 +8,19 @@ from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import FQFQuantileLosses, QuantileHuberLosses
+from jax_baselines.math.metrics import (
+    array_metrics,
+    quantile_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
-from jax_baselines.optim import OptimizerFactory, require_optimizer_factory
+from jax_baselines.optim import (
+    OptimizerFactory,
+    optimizer_metrics,
+    require_optimizer_factory,
+)
 
 
 class FQF(Q_Network_Family):
@@ -59,7 +69,7 @@ class FQF(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def actions(self, obs, epsilon, eval_mode=False):
         params_to_use = self.get_behavior_params()
@@ -104,6 +114,7 @@ class FQF(Q_Network_Family):
             t_std,
             tau,
             new_priorities,
+            metrics,
         ) = self._train_step(
             self.params,
             self.fqf_params,
@@ -119,7 +130,7 @@ class FQF(Q_Network_Family):
             loss=loss,
             target=t_mean,
             replay_priorities=new_priorities,
-            metrics={"loss/fqf_loss": fqf_loss, "loss/target_stds": t_std},
+            metrics={**metrics, "loss/fqf_loss": fqf_loss, "loss/target_stds": t_std},
             histograms={"loss/tau": tau},
         )
 
@@ -148,13 +159,15 @@ class FQF(Q_Network_Family):
                 target_stds,
                 taus,
                 priorities,
+                metrics,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = self._compiled_bulk_scan(carry, keys, steps, data)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             replay_priorities=priorities,
             metrics={
+                **jax.tree.map(jnp.mean, metrics),
                 "loss/fqf_loss": jnp.mean(fqf_losses),
                 "loss/target_stds": jnp.mean(target_stds),
             },
@@ -178,6 +191,7 @@ class FQF(Q_Network_Family):
                 t_std,
                 tau,
                 priorities,
+                metrics,
             ) = self._train_step(
                 params,
                 fqf_params,
@@ -194,7 +208,7 @@ class FQF(Q_Network_Family):
                 target_params,
                 opt_state,
                 fqf_opt_state,
-            ), (loss, fqf_loss, t_mean, t_std, tau, priorities)
+            ), (loss, fqf_loss, t_mean, t_std, tau, priorities, metrics)
 
         return jax.lax.scan(train_one, carry, (steps, keys, data))
 
@@ -229,6 +243,7 @@ class FQF(Q_Network_Family):
                     theta_loss_tile,
                     targets,
                     target_weights,
+                    metrics,
                 ),
             ),
             grad,
@@ -252,11 +267,14 @@ class FQF(Q_Network_Family):
         )
         fqf_params = optax.apply_updates(fqf_params, fqf_update)
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        metrics.update(optimizer_metrics(opt_state, "q"))
+        metrics.update(optimizer_metrics(fqf_opt_state, "fraction"))
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = abs_error
+            metrics.update(replay_metrics(weights, new_priorities))
         return (
             params,
             fqf_params,
@@ -269,6 +287,7 @@ class FQF(Q_Network_Family):
             jnp.mean(jnp.std(targets, axis=1)),
             tau_hats,
             new_priorities,
+            metrics,
         )
 
     def _loss(
@@ -285,7 +304,7 @@ class FQF(Q_Network_Family):
         key,
     ):
         feature = self.preproc(params, key, obses)
-        taus, tau_hats, _ = self.fpf(fqf_params, key, jax.lax.stop_gradient(feature))
+        taus, tau_hats, entropy = self.fpf(fqf_params, key, jax.lax.stop_gradient(feature))
         targets, target_weights = jax.lax.stop_gradient(
             self._target(
                 params,
@@ -316,6 +335,9 @@ class FQF(Q_Network_Family):
             self.delta,
             logit_valid_weight,
         )
+        widths = taus[:, 1:] - taus[:, :-1]
+        q_values = jnp.sum(widths * theta_loss_tile[:, 0], axis=1)
+        target_values = jnp.sum(target_weights * targets, axis=1)
         return jnp.mean(hubber * weights), (
             hubber,
             feature,
@@ -323,6 +345,16 @@ class FQF(Q_Network_Family):
             theta_loss_tile,
             targets,
             target_weights,
+            {
+                **array_metrics(q_values, "loss/q"),
+                **array_metrics(target_values, "loss/target"),
+                **td_metrics(q_values, target_values),
+                **quantile_metrics(theta_loss_tile[:, 0]),
+                "loss/unweighted_loss": jnp.mean(hubber),
+                "loss/fraction_entropy": jnp.mean(entropy),
+                "loss/fraction_width_min": jnp.min(widths),
+                "loss/fraction_width_max": jnp.max(widths),
+            },
         )
 
     def _fqf_loss(self, fqf_params, params, feature, actions, tau_hat_vals, key):

--- a/jax_baselines/IQN/iqn.py
+++ b/jax_baselines/IQN/iqn.py
@@ -8,8 +8,15 @@ from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
+from jax_baselines.math.metrics import (
+    array_metrics,
+    quantile_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
+from jax_baselines.optim import optimizer_metrics
 
 
 class IQN(Q_Network_Family):
@@ -47,7 +54,7 @@ class IQN(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def get_q(self, params, obses, tau, key=None) -> jnp.ndarray:
         return self.model(params, key, self.preproc(params, key, obses), tau)
@@ -82,6 +89,7 @@ class IQN(Q_Network_Family):
             t_mean,
             t_std,
             new_priorities,
+            metrics,
         ) = self._train_step(
             self.params,
             self.target_params,
@@ -94,7 +102,7 @@ class IQN(Q_Network_Family):
             loss=loss,
             target=t_mean,
             replay_priorities=new_priorities,
-            metrics={"loss/target_stds": t_std},
+            metrics={**metrics, "loss/target_stds": t_std},
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -108,13 +116,14 @@ class IQN(Q_Network_Family):
                 targets,
                 target_stds,
                 priorities,
+                metrics,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = self._compiled_bulk_scan(carry, keys, steps, data)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             replay_priorities=priorities,
-            metrics={"loss/target_stds": jnp.mean(target_stds)},
+            metrics={**jax.tree.map(jnp.mean, metrics), "loss/target_stds": jnp.mean(target_stds)},
             update_count=len(contexts),
         )
 
@@ -122,7 +131,16 @@ class IQN(Q_Network_Family):
         def train_one(carry, xs):
             params, target_params, opt_state = carry
             step, key, batch = xs
-            params, target_params, opt_state, loss, t_mean, t_std, priorities = self._train_step(
+            (
+                params,
+                target_params,
+                opt_state,
+                loss,
+                t_mean,
+                t_std,
+                priorities,
+                metrics,
+            ) = self._train_step(
                 params,
                 target_params,
                 opt_state,
@@ -130,7 +148,7 @@ class IQN(Q_Network_Family):
                 key,
                 **batch,
             )
-            return (params, target_params, opt_state), (loss, t_mean, t_std, priorities)
+            return (params, target_params, opt_state), (loss, t_mean, t_std, priorities, metrics)
 
         return jax.lax.scan(train_one, carry, (steps, keys, data))
 
@@ -164,15 +182,26 @@ class IQN(Q_Network_Family):
             not_terminateds,
             key1,
         )
-        (loss, abs_error), grad = jax.value_and_grad(self._loss, has_aux=True)(
+        (loss, (abs_error, quantiles, tau)), grad = jax.value_and_grad(self._loss, has_aux=True)(
             params, obses, actions, targets, weights, key2
         )
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        q_values = jnp.mean(quantiles, axis=1)
+        target_values = jnp.mean(targets, axis=1)
+        metrics = {
+            **array_metrics(q_values, "loss/q"),
+            **array_metrics(target_values, "loss/target"),
+            **td_metrics(q_values, target_values),
+            **quantile_metrics(quantiles, taus=tau),
+            **optimizer_metrics(opt_state, "q"),
+            "loss/unweighted_loss": jnp.mean(abs_error),
+        }
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = abs_error
+            metrics.update(replay_metrics(weights, new_priorities))
         return (
             params,
             target_params,
@@ -181,6 +210,7 @@ class IQN(Q_Network_Family):
             jnp.mean(targets),
             jnp.mean(jnp.std(targets, axis=1)),
             new_priorities,
+            metrics,
         )
 
     def _loss(self, params, obses, actions, targets, weights, key):
@@ -192,7 +222,7 @@ class IQN(Q_Network_Family):
         loss = QuantileHuberLosses(
             logit_valid_tile, theta_loss_tile, jnp.expand_dims(tau, axis=1), self.delta
         )
-        return jnp.mean(loss * weights), loss
+        return jnp.mean(loss * weights), (loss, theta_loss_tile[:, 0], tau)
 
     def _target(
         self,

--- a/jax_baselines/QRDQN/qrdqn.py
+++ b/jax_baselines/QRDQN/qrdqn.py
@@ -8,8 +8,15 @@ from jax_baselines.DQN.base_class import Q_Network_Family
 from jax_baselines.DQN.training import QNetTrainResult
 from jax_baselines.math.jax_utils import convert_normalized_obs
 from jax_baselines.math.losses import QuantileHuberLosses
+from jax_baselines.math.metrics import (
+    array_metrics,
+    quantile_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import hard_update
 from jax_baselines.math.policy_math import q_log_pi
+from jax_baselines.optim import optimizer_metrics
 
 
 class QRDQN(Q_Network_Family):
@@ -55,7 +62,7 @@ class QRDQN(Q_Network_Family):
 
         # Use common JIT compilation
         self._compile_common_functions()
-        self._bulk_scan = jax.jit(self._bulk_scan)
+        self._compiled_bulk_scan = jax.jit(self._bulk_scan)
 
     def get_q(self, params, obses, key=None) -> jnp.ndarray:
         return self.model(params, key, self.preproc(params, key, obses))
@@ -77,6 +84,7 @@ class QRDQN(Q_Network_Family):
             t_mean,
             t_std,
             new_priorities,
+            metrics,
         ) = self._train_step(
             self.params,
             self.target_params,
@@ -89,7 +97,7 @@ class QRDQN(Q_Network_Family):
             loss=loss,
             target=t_mean,
             replay_priorities=new_priorities,
-            metrics={"loss/target_stds": t_std},
+            metrics={**metrics, "loss/target_stds": t_std},
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -103,13 +111,14 @@ class QRDQN(Q_Network_Family):
                 targets,
                 target_stds,
                 priorities,
+                metrics,
             ),
-        ) = self._bulk_scan(carry, keys, steps, data)
+        ) = self._compiled_bulk_scan(carry, keys, steps, data)
         return QNetTrainResult.from_values(
             loss=jnp.mean(losses),
             target=jnp.mean(targets),
             replay_priorities=priorities,
-            metrics={"loss/target_stds": jnp.mean(target_stds)},
+            metrics={**jax.tree.map(jnp.mean, metrics), "loss/target_stds": jnp.mean(target_stds)},
             update_count=len(contexts),
         )
 
@@ -121,7 +130,16 @@ class QRDQN(Q_Network_Family):
             else:
                 step, batch = xs
                 key = None
-            params, target_params, opt_state, loss, t_mean, t_std, priorities = self._train_step(
+            (
+                params,
+                target_params,
+                opt_state,
+                loss,
+                t_mean,
+                t_std,
+                priorities,
+                metrics,
+            ) = self._train_step(
                 params,
                 target_params,
                 opt_state,
@@ -129,7 +147,7 @@ class QRDQN(Q_Network_Family):
                 key,
                 **batch,
             )
-            return (params, target_params, opt_state), (loss, t_mean, t_std, priorities)
+            return (params, target_params, opt_state), (loss, t_mean, t_std, priorities, metrics)
 
         xs = (steps, keys, data) if self.param_noise else (steps, data)
         return jax.lax.scan(train_one, carry, xs)
@@ -163,15 +181,26 @@ class QRDQN(Q_Network_Family):
             not_terminateds,
             key,
         )
-        (loss, abs_error), grad = jax.value_and_grad(self._loss, has_aux=True)(
+        (loss, (abs_error, quantiles)), grad = jax.value_and_grad(self._loss, has_aux=True)(
             params, obses, actions, targets, weights, key
         )
         updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+        q_values = jnp.mean(quantiles, axis=1)
+        target_values = jnp.mean(targets, axis=1)
+        metrics = {
+            **array_metrics(q_values, "loss/q"),
+            **array_metrics(target_values, "loss/target"),
+            **td_metrics(q_values, target_values),
+            **quantile_metrics(quantiles),
+            **optimizer_metrics(opt_state, "q"),
+            "loss/unweighted_loss": jnp.mean(abs_error),
+        }
         params = optax.apply_updates(params, updates)
         target_params = hard_update(params, target_params, steps, self.target_network_update_freq)
         new_priorities = None
         if self.prioritized_replay:
             new_priorities = abs_error
+            metrics.update(replay_metrics(weights, new_priorities))
         return (
             params,
             target_params,
@@ -180,6 +209,7 @@ class QRDQN(Q_Network_Family):
             jnp.mean(targets),
             jnp.mean(jnp.std(targets, axis=1)),
             new_priorities,
+            metrics,
         )
 
     def _loss(self, params, obses, actions, targets, weights, key):
@@ -188,7 +218,7 @@ class QRDQN(Q_Network_Family):
         )  # batch x 1 x support
         logit_valid_tile = jnp.expand_dims(targets, axis=2)  # batch x support x 1
         loss = QuantileHuberLosses(logit_valid_tile, theta_loss_tile, self.quantile, self.delta)
-        return jnp.mean(loss * weights), loss
+        return jnp.mean(loss * weights), (loss, theta_loss_tile[:, 0])
 
     def _target(
         self,

--- a/jax_baselines/SPR/hl_gauss_spr.py
+++ b/jax_baselines/SPR/hl_gauss_spr.py
@@ -11,11 +11,13 @@ from jax_baselines.math.distributional import (
     distributional_td_target,
 )
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import replay_metrics
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
     soft_update,
 )
+from jax_baselines.optim import optimizer_metrics
 from jax_baselines.SPR.spr import SPR
 
 
@@ -90,7 +92,7 @@ class HL_GAUSS_SPR(SPR):
             self.reset_hardsoft = filter_like_tree(
                 self.params,
                 "qnet",
-                (lambda x, filtered: (jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.2)),
+                (lambda x, filtered: jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.2),
             )  # hard_reset for qnet and scaled_by_reset for the rest
             self.soft_reset_freq = 40000
 
@@ -99,6 +101,7 @@ class HL_GAUSS_SPR(SPR):
         self.hl_gauss = HLGaussTransform.build(
             self.categorial_min, self.categorial_max, self.categorial_bar_n
         )
+        self.value_support = (self.hl_gauss.support[:-1] + self.hl_gauss.support[1:]) / 2
 
         # Use common JIT compilation
         self._compile_common_functions()
@@ -204,7 +207,7 @@ class HL_GAUSS_SPR(SPR):
             parsed_gamma = (
                 jnp.take_along_axis(jnp.expand_dims(self._gamma, 0), last_idxs, axis=1) * self.gamma
             )
-            target_distribution = self._target(
+            target_distribution, target_metrics = self._target(
                 params,
                 target_params,
                 parsed_obses,
@@ -220,7 +223,9 @@ class HL_GAUSS_SPR(SPR):
             )
             transition_actions = actions[:, : self.prediction_depth]
             transition_filled = filled[:, : self.prediction_depth]
-            (_, (centropy, qloss, rprloss)), grad = jax.value_and_grad(self._loss, has_aux=True)(
+            (_, (centropy, qloss, rprloss, metrics)), grad = jax.value_and_grad(
+                self._loss, has_aux=True
+            )(
                 params,
                 target_params,
                 transition_obses,
@@ -233,6 +238,10 @@ class HL_GAUSS_SPR(SPR):
                 key,
             )
             updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+            metrics.update(target_metrics)
+            metrics.update(optimizer_metrics(opt_state, "q"))
+            if self.prioritized_replay:
+                metrics.update(replay_metrics(weights, centropy))
             params = optax.apply_updates(params, updates)
             target_params = soft_update(params, target_params, 0.005)
             if self.scaled_by_reset:
@@ -251,6 +260,7 @@ class HL_GAUSS_SPR(SPR):
                 qloss,
                 rprloss,
                 target_q,
+                metrics,
             )
 
         (params, target_params, opt_state, _), outputs = jax.lax.scan(
@@ -266,7 +276,7 @@ class HL_GAUSS_SPR(SPR):
                 batched_steps,
             ),
         )
-        centropy, qloss, rprloss, target_q = outputs
+        centropy, qloss, rprloss, target_q, metrics = outputs
         qloss = jnp.mean(qloss)
         rprloss = jnp.mean(rprloss)
         target_q = jnp.mean(target_q)
@@ -282,6 +292,7 @@ class HL_GAUSS_SPR(SPR):
             target_q,
             new_priorities,
             rprloss,
+            jax.tree.map(jnp.mean, metrics),
         )
 
     def _target(
@@ -322,4 +333,5 @@ class HL_GAUSS_SPR(SPR):
             online_next_dists=online_next_dists,
             behavior_dists=behavior_dists,
             munchausen=munchausen,
+            return_diagnostics=True,
         )

--- a/jax_baselines/SPR/spr.py
+++ b/jax_baselines/SPR/spr.py
@@ -13,23 +13,26 @@ from jax_baselines.core.replay_protocol import (
     require_replay_factory,
 )
 from jax_baselines.DQN.base_class import Q_Network_Family
-from jax_baselines.DQN.training import (
-    QNetTrainContext,
-    QNetTrainReport,
-    QNetTrainResult,
-)
+from jax_baselines.DQN.training import QNetTrainContext, QNetTrainResult
 from jax_baselines.math.distributional import (
     CategoricalBackend,
     MunchausenSpec,
     distributional_td_target,
 )
 from jax_baselines.math.jax_utils import convert_normalized_obs
+from jax_baselines.math.metrics import (
+    array_metrics,
+    categorical_metrics,
+    replay_metrics,
+    td_metrics,
+)
 from jax_baselines.math.param_updates import (
     filter_like_tree,
     scaled_by_reset_with_filter,
     soft_update,
     tree_random_normal_like,
 )
+from jax_baselines.optim import optimizer_metrics
 
 
 class SPR(Q_Network_Family):
@@ -124,7 +127,7 @@ class SPR(Q_Network_Family):
             self.reset_hardsoft = filter_like_tree(
                 self.params,
                 "qnet",
-                (lambda x, filtered: (jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.2)),
+                (lambda x, filtered: jnp.ones_like(x) if filtered else jnp.ones_like(x) * 0.2),
             )  # hard_reset for qnet and scaled_by_reset for the rest
             self.soft_reset_freq = 40000
         self.opt_state = self.optimizer.init(self.params)
@@ -134,6 +137,7 @@ class SPR(Q_Network_Family):
             axis=0,
         )  # [1, 51]
         self._categorial_bar = jnp.expand_dims(self.categorial_bar, axis=0)  # [1, 1, 51]
+        self.value_support = self.categorial_bar[0]
         self.delta_bar = jax.device_put(
             (self.categorial_max - self.categorial_min) / (self.categorial_bar_n - 1)
         )
@@ -161,6 +165,11 @@ class SPR(Q_Network_Family):
         )
 
     def _train_on_batch(self, data, context):
+        if context.collect_diagnostics:
+            diagnostic_obs = jax.tree.map(lambda value: value[:32, 0], data["obses"])
+            diagnostic_key = jax.random.PRNGKey(0)
+            online_before = self._get_actions(self.params, diagnostic_obs, diagnostic_key)
+            target_before = self._get_actions(self.target_params, diagnostic_obs, diagnostic_key)
         (
             self.params,
             self.target_params,
@@ -169,6 +178,7 @@ class SPR(Q_Network_Family):
             t_mean,
             new_priorities,
             rprloss,
+            metrics,
         ) = self._train_step(
             self.params,
             self.target_params,
@@ -178,11 +188,23 @@ class SPR(Q_Network_Family):
             **data,
         )
 
+        if context.collect_diagnostics:
+            online_after = self._get_actions(self.params, diagnostic_obs, diagnostic_key)
+            target_after = self._get_actions(self.target_params, diagnostic_obs, diagnostic_key)
+            metrics.update(
+                {
+                    "loss/online_action_churn": jnp.mean(online_before != online_after),
+                    "loss/target_action_churn": jnp.mean(target_before != target_after),
+                    "loss/online_target_action_agreement": jnp.mean(online_after == target_after),
+                    "loss/action_churn_updates_spanned": data["actions"].shape[0]
+                    // self.batch_size,
+                }
+            )
         return QNetTrainResult.from_values(
             loss=loss,
             target=t_mean,
             replay_priorities=new_priorities,
-            metrics={"loss/rprloss": rprloss},
+            metrics={**metrics, "loss/rprloss": rprloss},
         )
 
     def _train_on_bulk(self, data, contexts):
@@ -192,28 +214,11 @@ class SPR(Q_Network_Family):
                 steps=contexts[0].steps,
                 train_steps_count=contexts[0].train_steps_count,
                 gradient_steps=len(contexts),
+                collect_diagnostics=contexts[-1].collect_diagnostics,
             ),
         )
         result.report.update_count = len(contexts)
         return result
-
-    def _aggregate_train_reports(self, reports):
-        if len(reports) == 1:
-            return reports[0]
-        counts = jnp.array([report.update_count for report in reports])
-        total = sum(report.update_count for report in reports)
-        mean_loss = jnp.sum(jnp.array([report.loss for report in reports]) * counts) / total
-        mean_target = jnp.sum(jnp.array([report.target for report in reports]) * counts) / total
-        mean_rprloss = (
-            jnp.sum(jnp.array([report.metrics["loss/rprloss"] for report in reports]) * counts)
-            / total
-        )
-        return QNetTrainReport(
-            loss=mean_loss,
-            target=mean_target,
-            metrics={"loss/rprloss": mean_rprloss},
-            update_count=total,
-        )
 
     def _image_augmentation(self, obs, key):
         """Random shift + intensity augmentation for B x K x H x W x C images."""
@@ -355,7 +360,7 @@ class SPR(Q_Network_Family):
             parsed_gamma = (
                 jnp.take_along_axis(jnp.expand_dims(self._gamma, 0), last_idxs, axis=1) * self.gamma
             )
-            target_distribution = self._target(
+            target_distribution, target_metrics = self._target(
                 params,
                 target_params,
                 parsed_obses,
@@ -371,7 +376,9 @@ class SPR(Q_Network_Family):
             )
             transition_actions = actions[:, : self.prediction_depth]
             transition_filled = filled[:, : self.prediction_depth]
-            (_, (centropy, qloss, rprloss)), grad = jax.value_and_grad(self._loss, has_aux=True)(
+            (_, (centropy, qloss, rprloss, metrics)), grad = jax.value_and_grad(
+                self._loss, has_aux=True
+            )(
                 params,
                 target_params,
                 transition_obses,
@@ -384,6 +391,10 @@ class SPR(Q_Network_Family):
                 key,
             )
             updates, opt_state = self.optimizer.update(grad, opt_state, params=params)
+            metrics.update(target_metrics)
+            metrics.update(optimizer_metrics(opt_state, "q"))
+            if self.prioritized_replay:
+                metrics.update(replay_metrics(weights, centropy))
             params = optax.apply_updates(params, updates)
             target_params = soft_update(params, target_params, 0.005)
             if self.scaled_by_reset:
@@ -405,6 +416,7 @@ class SPR(Q_Network_Family):
                 qloss,
                 rprloss,
                 target_q,
+                metrics,
             )
 
         (params, target_params, opt_state, _), outputs = jax.lax.scan(
@@ -420,7 +432,7 @@ class SPR(Q_Network_Family):
                 batched_steps,
             ),
         )
-        centropy, qloss, rprloss, target_q = outputs
+        centropy, qloss, rprloss, target_q, metrics = outputs
         qloss = jnp.mean(qloss)
         rprloss = jnp.mean(rprloss)
         target_q = jnp.mean(target_q)
@@ -436,6 +448,7 @@ class SPR(Q_Network_Family):
             target_q,
             new_priorities,
             rprloss,
+            jax.tree.map(jnp.mean, metrics),
         )
 
     def _loss(
@@ -452,16 +465,27 @@ class SPR(Q_Network_Family):
         key,
     ):
         rprloss = self._represetation_loss(params, target_params, obses, actions, filled, key)
-        distribution = jnp.squeeze(
-            jnp.take_along_axis(self.get_q(params, parsed_obses, key), parsed_actions, axis=1)
-        )
+        distribution = jnp.take_along_axis(
+            self.get_q(params, parsed_obses, key), parsed_actions, axis=1
+        )[:, 0]
         centropy = -jnp.sum(target_distribution * jnp.log(distribution + 1e-6), axis=1)
         mean_centropy = jnp.mean(centropy * weights)
         total_loss = mean_centropy + self.spr_weight * rprloss
+        q_values = jnp.sum(distribution * self.value_support, axis=1)
+        target_values = jnp.sum(target_distribution * self.value_support, axis=1)
         return total_loss, (
             centropy,
             mean_centropy,
             rprloss,
+            {
+                **array_metrics(q_values, "loss/q"),
+                **array_metrics(target_values, "loss/target"),
+                **td_metrics(q_values, target_values),
+                **categorical_metrics(distribution, target_distribution, self.value_support),
+                "loss/unweighted_loss": jnp.mean(centropy),
+                "loss/total_loss": total_loss,
+                "loss/weighted_rprloss": self.spr_weight * rprloss,
+            },
         )
 
     def _represetation_loss(self, params, target_params, obses, actions, filled, key):
@@ -545,6 +569,7 @@ class SPR(Q_Network_Family):
             online_next_dists=online_next_dists,
             behavior_dists=behavior_dists,
             munchausen=munchausen,
+            return_diagnostics=True,
         )
 
     def run_name_update(self, run_name):

--- a/tests/test_bbf_ctor_arg_forwarding.py
+++ b/tests/test_bbf_ctor_arg_forwarding.py
@@ -31,6 +31,7 @@ def test_spr_family_forwards_clobbered_ctor_args_to_spr_owner(cls, extra, monkey
         env_builder=lambda *args, **kwargs: None,
         model_builder_maker=lambda *args, **kwargs: None,
         optimizer_factory=lambda learning_rate: None,
+        memory_backend="cpu",
         off_policy_fix=True,
         spr_weight=2.5,
         categorial_bar_n=41,

--- a/tests/test_c51_per_weights.py
+++ b/tests/test_c51_per_weights.py
@@ -16,7 +16,7 @@ def test_c51_loss_applies_per_importance_weights(family):
     agent.get_q = lambda *_args: PREDICTIONS
 
     full, _ = family._loss(agent, None, None, ACTIONS, TARGETS, jnp.ones(2), None)
-    first_only, per_sample = family._loss(
+    first_only, (per_sample, _) = family._loss(
         agent, None, None, ACTIONS, TARGETS, jnp.asarray([1.0, 0.0]), None
     )
 
@@ -29,6 +29,7 @@ def test_spr_loss_applies_per_importance_weights():
     agent.get_q = lambda *_args: PREDICTIONS
     agent._represetation_loss = lambda *_args: jnp.asarray(0.0)
     agent.spr_weight = 5.0
+    agent.value_support = jnp.asarray([-1.0, 1.0])
 
     def loss(weights):
         return SPR._loss(

--- a/tests/test_qnet_training.py
+++ b/tests/test_qnet_training.py
@@ -555,9 +555,11 @@ def test_dqn_train_on_bulk_scans_updates_and_stacks_priorities():
             step.astype(float),
             step.astype(float) + 10.0,
             priorities,
+            {"loss/q_mean": step.astype(float)},
         )
 
     agent._train_step = train_step
+    agent._compiled_bulk_scan = agent._bulk_scan
     data = {
         "obses": np.ones((2, 4, 3)),
         "indexes": np.arange(8).reshape(2, 4),
@@ -575,6 +577,7 @@ def test_dqn_train_on_bulk_scans_updates_and_stacks_priorities():
     assert result.report.loss == pytest.approx(1.5)
     assert result.report.target == pytest.approx(11.5)
     assert result.report.update_count == 2
+    assert result.report.metrics["loss/q_mean"] == pytest.approx(1.5)
     assert np.array_equal(result.replay_priorities, np.array([[1, 1, 1, 1], [2, 2, 2, 2]]))
 
 


### PR DESCRIPTION
QNET의 선택 행동 Q와 scalar TD 잔차를 실제 최적화 loss와 분리해 기록합니다. Categorical·quantile·PER·representation 진단이 단일 update와 bulk 집계를 거쳐 logger까지 전달됩니다.

- DQN·C51·QRDQN·IQN·FQF·SPR·BBF 및 HL-Gauss 변형을 지원합니다. Categorical CE/KL/entropy, 투영 전 support clipping과 투영 후 edge mass, tau 순서에 따른 quantile crossing, FQF fraction 통계를 추가합니다.
- SPR·BBF는 total/weighted representation loss를 기록하고 로그가 필요한 시점에만 최대 32개 관측으로 action churn을 계산합니다. 학습 RNG를 소비하지 않으며 `action_churn_updates_spanned`로 측정한 update/chunk의 길이를 명시합니다.
- 기존 테스트의 변경된 반환 계약을 마이그레이션하고, JIT bulk callable을 별도 속성으로 보관합니다. 전체 지표의 정의·집계·해석은 `docs/loss_metrics.md`에 정리했습니다.

영향받는 기존 테스트를 통과했습니다. 정상 CLI 7개와 실제 image builder/고정 입력을 사용한 BBF·HL-BBF·HL-SPR 직접 업데이트로 10개 변형을 확인했습니다. HL-SPR의 2-update bulk도 확인했습니다. DQN 전체 CLI의 변경 전후 checkpoint는 bitwise 동일하며, 실제 로그의 CE=KL+entropy, TD, PER, FQF, SPR total 관계를 검증했습니다. Ruff와 저장소 커밋 검사를 통과했고, 소스 ty 진단은 기존 31개에서 16개로 줄었으며 신규 진단은 없습니다.
