### PR TITLE
feat(ppo): exact KL 기반 가변 학습률 적용

### DIFF
--- a/docs/loss_metrics.md
+++ b/docs/loss_metrics.md
@@ -8,20 +8,29 @@
 
 A2C·PPO·SPO·TPPO에 적용한다. 표의 키는 `loss/` 접두사를 생략했다.
 
-| 키                                                     | 정의와 측정 시점                                                                                                          |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `critic_loss`, `actor_loss`, `entropy_loss`            | 기존 손실 정의를 유지한다. `entropy_loss`는 음의 entropy다.                                                               |
-| `actor_objective`                                      | 실제 미분한 actor 목적함수. Entropy advantage shaping을 켜면 additive entropy 항을 다시 더하지 않는다.                    |
-| `explained_variance`                                   | 업데이트 전 rollout의 `1 - Var(target - value) / Var(target)`. Target 분산이 0이면 `NaN`이다.                             |
-| `value_mean`, `value_std`, `mean_target`, `target_std` | 업데이트 전 rollout의 value와 return 통계.                                                                                |
-| `advantage_mean`, `advantage_std`                      | 정규화와 entropy advantage shaping 전 advantage 통계.                                                                     |
-| `approx_kl`                                            | PPO·SPO에서 `l = log_pi_new - log_pi_old`일 때 `mean(exp(l) - 1 - l)`. Old policy 표본으로 `KL(old \|\| new)`를 추정한다. |
-| `clip_fraction`                                        | PPO·SPO의 `mean(abs(exp(l) - 1) > ppo_eps)`. 실제 objective가 clipped branch를 선택한 비율과는 다르다.                    |
-| `kl_divergence`                                        | TPPO의 기존 exact KL. PPO의 ratio clipping 통계로 대체하지 않는다.                                                        |
-| `policy_std_mean/min/max`, `log_std_mean/min/max`      | 연속 정책 Gaussian 파라미터의 표준편차와 log 표준편차. Bounded action 표본의 표준편차는 아니다.                           |
+| 키                                                     | 정의와 측정 시점                                                                                                                                                        |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `critic_loss`, `actor_loss`, `entropy_loss`            | 기존 손실 정의를 유지한다. `entropy_loss`는 음의 entropy다.                                                                                                             |
+| `actor_objective`                                      | 실제 미분한 actor 목적함수. Entropy advantage shaping을 켜면 additive entropy 항을 다시 더하지 않는다.                                                                  |
+| `explained_variance`                                   | 업데이트 전 rollout의 `1 - Var(target - value) / Var(target)`. Target 분산이 0이면 `NaN`이다.                                                                           |
+| `value_mean`, `value_std`, `mean_target`, `target_std` | 업데이트 전 rollout의 value와 return 통계.                                                                                                                              |
+| `advantage_mean`, `advantage_std`                      | 정규화와 entropy advantage shaping 전 advantage 통계.                                                                                                                   |
+| `approx_kl`                                            | PPO·SPO에서 `l = log_pi_new - log_pi_old`일 때 `mean(exp(l) - 1 - l)`. Old policy 표본으로 `KL(old \|\| new)`를 추정한다.                                               |
+| `clip_fraction`                                        | PPO·SPO의 `mean(abs(exp(l) - 1) > ppo_eps)`. 실제 objective가 clipped branch를 선택한 비율과는 다르다.                                                                  |
+| `kl_divergence`                                        | PPO·SPO의 exact `KL(old \|\| new)`. 연속 정책은 Gaussian KL의 행동 차원 합을 상태별로 평균하고, 이산 정책은 categorical KL을 사용한다. TPPO의 기존 exact KL도 유지한다. |
+| `policy_std_mean/min/max`, `log_std_mean/min/max`      | 연속 정책 Gaussian 파라미터의 표준편차와 log 표준편차. Bounded action 표본의 표준편차는 아니다.                                                                         |
 
 Rollout 통계는 rollout마다 한 번 측정한다. Surrogate 목적함수, KL, clip fraction,
 정책 scale, optimizer 지표는 각 minibatch의 업데이트 시점에서 계산한 뒤 epoch 전체를 평균한다.
+
+PPO에서 `--desired_kl 0.01`을 지정하면 rsl-rl 방식으로 매 minibatch 업데이트 전에
+`loss/kl_divergence`와 같은 exact KL을 기준으로 actor·critic 학습률을 조절한다.
+KL이 목표의 2배를 넘으면 학습률을 1.5로 나누고(하한 `1e-5`), 0보다 크면서 목표의
+절반보다 작으면 1.5배로 늘린다(상한 `1e-2`). 나머지 구간에서는 유지한다.
+`loss/approx_kl`은 표본 기반 비교 지표로 계속 기록하며 학습률 조절에는 사용하지 않는다.
+`--desired_kl`을 생략하면 이 조절은 꺼지고, `--lr_annealing`과는 함께 사용할 수 없다.
+Mjlab Go1·G1 설정의 PPO variant에는 `desired_kl: 0.01`이 적용되어 있다.
+실제 업데이트의 학습률 평균은 `optim/actor_learning_rate`, `optim/critic_learning_rate`에서 확인한다.
 
 ## DPG
 

--- a/experiments/cli/_validation.py
+++ b/experiments/cli/_validation.py
@@ -79,9 +79,14 @@ def parse_runner_args(
         value = values[name]
         if value < 0 or int(value) != value:
             parser.error(f"--{name} must be a nonnegative integer")
-    for name in {"learning_rate", "optimizer_eps", "max_grad_norm"} & values.keys():
+    for name in {"learning_rate", "optimizer_eps", "max_grad_norm", "desired_kl"} & values.keys():
         if values[name] is not None and values[name] <= 0:
             parser.error(f"--{name} must be positive")
+    if "desired_kl" in values and args.desired_kl is not None:
+        if args.algo != "PPO":
+            parser.error("--desired_kl is only supported for PPO")
+        if args.lr_annealing:
+            parser.error("--desired_kl cannot be combined with --lr_annealing")
     for name in {
         "gamma",
         "lamda",

--- a/experiments/cli/pg.py
+++ b/experiments/cli/pg.py
@@ -69,6 +69,12 @@ def add_args(parser):
     parser.add_argument("--epoch_num", type=int, default=4, help="epoch number")
     parser.add_argument("--ppo_eps", type=float, default=0.2, help="PPO policy clip range")
     parser.add_argument(
+        "--desired_kl",
+        type=float,
+        default=None,
+        help="PPO exact KL target for adaptive learning rate; omitted disables adaptation",
+    )
+    parser.add_argument(
         "--value_clip",
         type=float,
         default=2.0,
@@ -139,6 +145,7 @@ def _ppo_build(a):
         **_ppo_like(a),
         "ppo_eps": a.ppo_eps,
         "value_clip": a.value_clip,
+        **({"desired_kl": a.desired_kl} if a.algo == "PPO" else {}),
     }
 
 

--- a/experiments/configs/mjlab/pg_mjlab_g1.yaml
+++ b/experiments/configs/mjlab/pg_mjlab_g1.yaml
@@ -29,5 +29,5 @@ base:
   optimizer: adam
   optimizer_eps: 1.0e-8
 variants:
-  - {algo: PPO, enabled: true}
+  - {algo: PPO, desired_kl: 0.01, enabled: true}
   - {algo: SPO, enabled: true}

--- a/experiments/configs/mjlab/pg_mjlab_go1.yaml
+++ b/experiments/configs/mjlab/pg_mjlab_go1.yaml
@@ -29,5 +29,5 @@ base:
   optimizer: adam
   optimizer_eps: 1.0e-8
 variants:
-  - {algo: PPO, enabled: true}
+  - {algo: PPO, desired_kl: 0.01, enabled: true}
   - {algo: SPO, enabled: true}

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -34,8 +34,20 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         epoch_num=4,
         ppo_eps=0.2,
         value_clip=2.0,
+        batch_size=256,
+        learning_rate=3e-4,
+        lr_annealing=False,
+        desired_kl: float | None = None,
         **kwargs,
     ):
+        if desired_kl is not None:
+            if not np.isfinite(desired_kl) or desired_kl <= 0:
+                raise ValueError("desired_kl must be finite and positive")
+            if lr_annealing or callable(learning_rate):
+                raise ValueError("desired_kl requires a scalar learning rate without lr_annealing")
+            if not np.isfinite(learning_rate) or learning_rate <= 0:
+                raise ValueError("desired_kl requires a finite positive learning rate")
+        self.desired_kl = desired_kl
         self.lamda = lamda
         self.gae_normalize = gae_normalize
         self.gae_normalize_scope = validate_advantage_normalize_scope(gae_normalize_scope)
@@ -44,14 +56,26 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         self.minibatch_size = minibatch_size
         self.epoch_num = epoch_num
 
-        super().__init__(env_builder, model_builder_maker, **kwargs)
+        super().__init__(
+            env_builder,
+            model_builder_maker,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            lr_annealing=lr_annealing,
+            **kwargs,
+        )
 
         self.batch_size = int(
-            np.ceil(kwargs.get("batch_size", 256) * self.worker_size / minibatch_size)
+            np.ceil(batch_size * self.worker_size / minibatch_size)
             * minibatch_size
             / self.worker_size
         )
         self.get_memory_setup()
+
+    def _make_optimizer(self, learning_rate):
+        if self.desired_kl is not None:
+            return optax.inject_hyperparams(super()._make_optimizer)(learning_rate=learning_rate)
+        return super()._make_optimizer(learning_rate)
 
     def setup_model(self):
         self.model_builder = self.model_builder_maker(
@@ -112,24 +136,28 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
             critic_params, actor_params, key, nxtobses
         )
-        pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None))(
+        old_distribution, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
             jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
             actions,
             key,
+            True,
         )
+        if self.action_type == "continuous":
+            old_mu, old_log_std = jax.vmap(jnp.broadcast_arrays)(*old_distribution)
+            old_distribution = (old_mu, jnp.exp(old_log_std))
         adv = jax.vmap(get_gaes, in_axes=(0, 0, 0, 0, 0, None, None))(
             rewards, terminateds, truncateds, value, next_value, self.gamma, self.lamda
         )
         obses = {key: jnp.vstack(value) for key, value in obses.items()}
         actions = jnp.vstack(actions)
         value = jnp.vstack(value)
-        pi_prob = jnp.vstack(pi_prob)
+        old_policy = (jnp.vstack(pi_prob), jax.tree.map(jnp.vstack, old_distribution))
         adv = jnp.vstack(adv)
         targets = value + adv
         metrics = rollout_metrics(value, targets, adv)
         if self.gae_normalize and self.gae_normalize_scope == "batch":
             adv = normalize_advantage(adv)
-        return obses, actions, value, targets, pi_prob, adv, metrics
+        return obses, actions, value, targets, old_policy, adv, metrics
 
     def _train_step(
         self,
@@ -145,7 +173,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         terminateds,
         truncateds,
     ):
-        obses, actions, old_values, targets, act_prob, adv, metrics = self._preprocess(
+        obses, actions, old_values, targets, old_policy, adv, metrics = self._preprocess(
             actor_params,
             critic_params,
             key,
@@ -167,21 +195,39 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             actions_batch = actions[batch_idxes]
             old_values_batch = old_values[batch_idxes]
             targets_batch = targets[batch_idxes]
-            act_prob_batch = act_prob[batch_idxes]
+            old_policy_batch = jax.tree.map(lambda value: value[batch_idxes], old_policy)
             adv_batch = adv[batch_idxes]
 
             def f(updates, input):
                 actor_params, critic_params, actor_opt_state, critic_opt_state, key = updates
-                obs, act, oldv, target, act_prob, adv = input
+                obs, act, oldv, target, old_policy, adv = input
                 if self.gae_normalize and self.gae_normalize_scope == "minibatch":
                     adv = normalize_advantage(adv)
                 use_key, key = jax.random.split(key)
                 (actor_objective, batch_metrics), actor_grad = jax.value_and_grad(
                     self._actor_loss, has_aux=True
-                )(actor_params, obs, act, act_prob, adv, use_key)
+                )(actor_params, obs, act, old_policy, adv, use_key)
                 c_loss, critic_grad = jax.value_and_grad(self._critic_loss)(
                     critic_params, actor_params, obs, oldv, target, use_key
                 )
+                if self.desired_kl is not None:
+                    kl = batch_metrics["loss/kl_divergence"]
+                    learning_rate = actor_opt_state.hyperparams["learning_rate"]
+                    learning_rate = jnp.where(
+                        kl > 2.0 * self.desired_kl,
+                        jnp.maximum(1e-5, learning_rate / 1.5),
+                        jnp.where(
+                            (kl > 0.0) & (kl < self.desired_kl / 2.0),
+                            jnp.minimum(1e-2, learning_rate * 1.5),
+                            learning_rate,
+                        ),
+                    )
+                    actor_opt_state = actor_opt_state._replace(
+                        hyperparams={**actor_opt_state.hyperparams, "learning_rate": learning_rate}
+                    )
+                    critic_opt_state = critic_opt_state._replace(
+                        hyperparams={**critic_opt_state.hyperparams, "learning_rate": learning_rate}
+                    )
                 actor_updates, actor_opt_state = self.optimizer.update(
                     actor_grad, actor_opt_state, params=actor_params
                 )
@@ -210,7 +256,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
                     actions_batch,
                     old_values_batch,
                     targets_batch,
-                    act_prob_batch,
+                    old_policy_batch,
                     adv_batch,
                 ),
             )

--- a/jax_baselines/PPO/ppo.py
+++ b/jax_baselines/PPO/ppo.py
@@ -3,12 +3,17 @@ import jax.numpy as jnp
 
 from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
 from jax_baselines.math.metrics import gaussian_metrics, policy_ratio_metrics
+from jax_baselines.math.policy_math import (
+    kl_divergence_continuous,
+    kl_divergence_discrete,
+)
 
 
 class PPO(SurrogatePolicyGradient):
     _run_name = "PPO"
 
-    def _actor_loss_discrete(self, actor_params, obses, actions, old_prob, adv, key):
+    def _actor_loss_discrete(self, actor_params, obses, actions, old_policy, adv, key):
+        old_prob, old_distribution = old_policy
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -34,10 +39,14 @@ class PPO(SurrogatePolicyGradient):
         return actor_objective, {
             "loss/actor_loss": actor_loss,
             "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(
+                jax.vmap(kl_divergence_discrete, in_axes=(0, 0, None))(old_distribution, prob, 0.0)
+            ),
             **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
         }
 
-    def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
+    def _actor_loss_continuous(self, actor_params, obses, actions, old_policy, adv, key):
+        old_prob, old_distribution = old_policy
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -68,6 +77,9 @@ class PPO(SurrogatePolicyGradient):
         return actor_objective, {
             "loss/actor_loss": actor_loss,
             "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(
+                kl_divergence_continuous(old_distribution, (mu, jnp.exp(log_std)))
+            ),
             **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
             **gaussian_metrics(log_std),
         }

--- a/jax_baselines/SPO/spo.py
+++ b/jax_baselines/SPO/spo.py
@@ -3,6 +3,10 @@ import jax.numpy as jnp
 
 from jax_baselines.A2C.surrogate_base import SurrogatePolicyGradient
 from jax_baselines.math.metrics import gaussian_metrics, policy_ratio_metrics
+from jax_baselines.math.policy_math import (
+    kl_divergence_continuous,
+    kl_divergence_discrete,
+)
 
 
 class SPO(SurrogatePolicyGradient):
@@ -34,7 +38,8 @@ class SPO(SurrogatePolicyGradient):
             **kwargs,
         )
 
-    def _actor_loss_discrete(self, actor_params, obses, actions, old_prob, adv, key):
+    def _actor_loss_discrete(self, actor_params, obses, actions, old_policy, adv, key):
+        old_prob, old_distribution = old_policy
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -61,10 +66,14 @@ class SPO(SurrogatePolicyGradient):
         return actor_objective, {
             "loss/actor_loss": actor_loss,
             "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(
+                jax.vmap(kl_divergence_discrete, in_axes=(0, 0, None))(old_distribution, prob, 0.0)
+            ),
             **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
         }
 
-    def _actor_loss_continuous(self, actor_params, obses, actions, old_prob, adv, key):
+    def _actor_loss_continuous(self, actor_params, obses, actions, old_policy, adv, key):
+        old_prob, old_distribution = old_policy
         prob, log_prob = self.get_logprob(
             self.actor(actor_params, key, obses), actions, key, out_prob=True
         )
@@ -96,6 +105,9 @@ class SPO(SurrogatePolicyGradient):
         return actor_objective, {
             "loss/actor_loss": actor_loss,
             "loss/entropy_loss": entropy_loss,
+            "loss/kl_divergence": jnp.mean(
+                kl_divergence_continuous(old_distribution, (mu, jnp.exp(log_std)))
+            ),
             **policy_ratio_metrics(log_prob, old_prob, self.ppo_eps),
             **gaussian_metrics(log_std),
         }

--- a/jax_baselines/math/policy_math.py
+++ b/jax_baselines/math/policy_math.py
@@ -47,6 +47,8 @@ def kl_divergence_discrete(p, q, eps: float = 1e-8):
 def kl_divergence_continuous(p, q):
     p_mu, p_std = p
     q_mu, q_std = q
-    term1 = jnp.log(q_std / p_std)
-    term2 = (p_std**2 + (p_mu - q_mu) ** 2) / (2 * q_std**2)
-    return jnp.sum(term1 + term2 - 0.5, axis=-1, keepdims=True)
+    variance_ratio = jnp.square(p_std / q_std)
+    mean_difference = jnp.square((p_mu - q_mu) / q_std)
+    return 0.5 * jnp.sum(
+        variance_ratio + mean_difference - 1.0 - jnp.log(variance_ratio), axis=-1, keepdims=True
+    )

--- a/jax_baselines/optim/__init__.py
+++ b/jax_baselines/optim/__init__.py
@@ -94,6 +94,8 @@ def track_optimizer(
 
 def optimizer_metrics(opt_state: optax.OptState, prefix: str) -> dict[str, jax.Array]:
     """Read the last update; arbitrary injected Optax optimizers may opt out."""
+    if isinstance(opt_state, optax.InjectStatefulHyperparamsState):
+        opt_state = opt_state.inner_state
     if not isinstance(opt_state, OptimizerMetricsState):
         return {}
     return {

--- a/tests/test_experiment_env_configs.py
+++ b/tests/test_experiment_env_configs.py
@@ -29,7 +29,8 @@ def test_adapter_configs_preserve_actor_and_critic_observations(filename, runner
     }
     assert config["category"] == "mjlab"
     assert config["runner"] == runner
-    assert config["variants"] == [{"algo": algo, "enabled": True} for algo in algorithms]
+    assert [variant["algo"] for variant in config["variants"]] == algorithms
+    assert all(variant["enabled"] for variant in config["variants"])
     assert config["base"] | expected == config["base"]
     assert config["base"]["obs_rms_norm"] is True
     assert "env_episode_length" not in config["base"]


### PR DESCRIPTION
PPO에서 `--desired_kl`을 지정하면 minibatch별 exact KL에 따라 actor·critic 학습률을 함께 조절합니다. 목표의 2배를 넘으면 LR을 1.5로 나누고, 0보다 크면서 목표의 절반보다 작으면 1.5배로 늘립니다. 조절 상태는 다음 rollout까지 유지됩니다.

PPO·SPO에 Gaussian/categorical `loss/kl_divergence`를 기록하고, 기존 sampled `loss/approx_kl`도 유지합니다. Go1·G1의 PPO 설정은 `desired_kl: 0.01`을 사용하며, CLI에서 다른 알고리즘이나 LR annealing과의 조합을 거부합니다. 정책 데이터 이름을 `old_policy`로 통일했습니다.

분리된 레이어에서 관련 테스트 30개와 Ruff가 통과했습니다. 기존 타입 진단 11건은 유지됩니다. 실제 Go1 GPU에서 LR·KL 동작도 확인했으며, 장시간 KL 폭주와 보행 안정성 개선은 아직 검증하지 않았습니다.
