### PR TITLE
feat(pg): rollout 행동 정책을 저장하고 학습에서 재사용

### DIFF
--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -48,8 +48,36 @@ def _sample_discrete(prob, key):
     return jax.random.categorical(key, jnp.log(prob), axis=-1)[:, None]
 
 
+def _categorical_policy(logits):
+    prob = jnp.clip(jax.nn.softmax(logits, axis=-1), 1e-8, 1.0)
+    return prob / jnp.sum(prob, axis=-1, keepdims=True)
+
+
+@jax.jit
+def _categorical_log_prob(prob, action):
+    return jnp.log(jnp.take_along_axis(prob, action.astype(jnp.int32), axis=1))
+
+
+def _continuous_log_prob(prob, action):
+    mu, log_std = prob
+    std = jnp.exp(log_std)
+    return -(
+        0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
+        + jnp.sum(log_std, axis=-1, keepdims=True)
+        + 0.5 * jnp.log(2 * np.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
+    )
+
+
+@jax.jit
+def _continuous_old_policy(policy, actions):
+    mu, _, log_std = policy
+    old_policy = (mu, jnp.broadcast_to(log_std, mu.shape))
+    return _continuous_log_prob(old_policy, actions), old_policy
+
+
 class Actor_Critic_Policy_Gradient_Family:
     _run_name = "A2C"
+    _store_old_policy = False
     actor: Callable
     _get_actions: Callable
     logger: AbstractContextManager
@@ -232,20 +260,18 @@ class Actor_Critic_Policy_Gradient_Family:
         raise NotImplementedError
 
     def _get_actions_discrete(self, actor_params, obses, key=None) -> jnp.ndarray:
-        prob = jax.nn.softmax(
-            self.actor(actor_params, key, convert_normalized_obs(obses)),
-            axis=1,
-        )
-        return prob
+        return _categorical_policy(self.actor(actor_params, key, convert_normalized_obs(obses)))
 
     def _get_actions_continuous(
         self, actor_params, obses, key=None
-    ) -> tuple[jnp.ndarray, jnp.ndarray]:
-        mu, std = self.actor(actor_params, key, convert_normalized_obs(obses))
-        return mu, jnp.exp(std)
+    ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+        mu, log_std = self.actor(actor_params, key, convert_normalized_obs(obses))
+        return mu, jnp.exp(log_std), log_std
 
     def action_discrete(self, obs, eval=False):
-        prob = self._get_actions(self.actor_params, obs)
+        return self._action_from_discrete(self._get_actions(self.actor_params, obs), eval)
+
+    def _action_from_discrete(self, prob, eval=False):
         if self.memory_backend == "cpu":
             prob = np.asarray(prob)
             if eval:
@@ -260,7 +286,10 @@ class Actor_Critic_Policy_Gradient_Family:
         return _sample_discrete(prob, next(self.key_seq))
 
     def action_continuous(self, obs, eval=False):
-        mu, std = self._get_actions(self.actor_params, obs)
+        mu, std, _ = self._get_actions(self.actor_params, obs)
+        return self._action_from_continuous(mu, std, eval)
+
+    def _action_from_continuous(self, mu, std, eval=False):
         if self.memory_backend == "cpu":
             if eval:
                 return np.asarray(mu)
@@ -270,22 +299,28 @@ class Actor_Critic_Policy_Gradient_Family:
             return mu
         return _sample_continuous(mu, std, next(self.key_seq))
 
+    def sample_actions(self, obs):
+        if not self._store_old_policy:
+            return self.actions(obs), None
+        policy = self._get_actions(self.actor_params, obs)
+        if self.action_type == "discrete":
+            actions = self._action_from_discrete(policy)
+            old_policy = (_categorical_log_prob(policy, actions), policy)
+        else:
+            mu, std, _ = policy
+            actions = self._action_from_continuous(mu, std)
+            old_policy = _continuous_old_policy(policy, actions)
+        if self.memory_backend == "cpu":
+            old_policy = jax.tree.map(np.asarray, old_policy)
+        return actions, old_policy
+
     def get_logprob_discrete(self, prob, action, key, out_prob=False):
-        prob = jax.nn.softmax(prob)
-        prob = jnp.clip(prob, 1e-8, 1.0)
-        prob = prob / jnp.sum(prob, axis=-1, keepdims=True)
-        action = action.astype(jnp.int32)
-        log_prob = jnp.log(jnp.take_along_axis(prob, action, axis=1))
+        prob = _categorical_policy(prob)
+        log_prob = _categorical_log_prob(prob, action)
         return (prob, log_prob) if out_prob else log_prob
 
     def get_logprob_continuous(self, prob, action, key, out_prob=False):
-        mu, log_std = prob
-        std = jnp.exp(log_std)
-        log_prob = -(
-            0.5 * jnp.sum(jnp.square((action - mu) / (std + 1e-7)), axis=-1, keepdims=True)
-            + jnp.sum(log_std, axis=-1, keepdims=True)
-            + 0.5 * jnp.log(2 * np.pi) * jnp.asarray(action.shape[-1], dtype=jnp.float32)
-        )
+        log_prob = _continuous_log_prob(prob, action)
         return (prob, log_prob) if out_prob else log_prob
 
     def _actor_loss_continuous(self):
@@ -402,7 +437,7 @@ class Actor_Critic_Policy_Gradient_Family:
         steps = 0
         last_log_step = 0
         for steps in ctx.pbar:
-            actions = self.actions(obs)
+            actions, old_policy = self.sample_actions(obs)
             step_action = _normalize_action_for_step(self.conv_action(actions))
             next_obs, reward, terminated, truncated, _ = self.env.step(step_action)
             ctx.progress.env_steps += 1
@@ -430,6 +465,7 @@ class Actor_Critic_Policy_Gradient_Family:
                 next_obs,
                 [terminated],
                 [truncated],
+                old_policy=old_policy,
             )
             score += float(reward)
             eplen += 1
@@ -500,7 +536,7 @@ class Actor_Critic_Policy_Gradient_Family:
         obs = normalize_empirical_observation(
             raw_obs, self.obs_rms, on_device=self.memory_backend == "gpu"
         )
-        actions = self.actions(obs)
+        actions, old_policy = self.sample_actions(obs)
         end = object()
         first = True
         steps = 0
@@ -539,7 +575,7 @@ class Actor_Critic_Policy_Gradient_Family:
             train_due = (steps + self.worker_size) % (self.batch_size * self.worker_size) == 0
             if not train_due and next_step is not end:
                 # Keep the async overlap except when train_step changes the policy.
-                next_actions = self.actions(action_observation)
+                next_actions, next_old_policy = self.sample_actions(action_observation)
                 send(next_actions)
 
             if device_rollout:
@@ -551,7 +587,15 @@ class Actor_Critic_Policy_Gradient_Family:
                     truncateds,
                     vector_autoreset_mask(self.env, terminateds, truncateds, infos),
                 )
-                self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
+                self.buffer.add(
+                    obs,
+                    actions,
+                    rewards,
+                    next_obses,
+                    terminateds,
+                    truncateds,
+                    old_policy=old_policy,
+                )
                 completed_steps.append(steps)
                 completed_rows.append(completed)
                 if train_due or log_due or next_step is end:
@@ -586,7 +630,15 @@ class Actor_Critic_Policy_Gradient_Family:
                     # whatever the env reports on the discarded autoreset step.
                     terminateds = np.where(prev_done, True, terminateds)
                     rewards = np.where(prev_done, np.float32(0.0), rewards)
-                self.buffer.add(obs, actions, rewards, next_obses, terminateds, truncateds)
+                self.buffer.add(
+                    obs,
+                    actions,
+                    rewards,
+                    next_obses,
+                    terminateds,
+                    truncateds,
+                    old_policy=old_policy,
+                )
 
                 for idx in np.where(done & active)[0]:
                     self.rollout_tracker.record(
@@ -605,7 +657,7 @@ class Actor_Critic_Policy_Gradient_Family:
                 ctx.progress.update_steps += self._optimizer_updates_per_train_step()
                 self.lossque.append(loss)
                 if next_step is not end:
-                    next_actions = self.actions(action_observation)
+                    next_actions, next_old_policy = self.sample_actions(action_observation)
                     send(next_actions)
 
             if next_step is not end:
@@ -613,6 +665,7 @@ class Actor_Critic_Policy_Gradient_Family:
                 # the action just sent belongs to the env's current observation.
                 obs = action_observation
                 actions = next_actions
+                old_policy = next_old_policy
 
             if steps % ctx.eval_freq == 0:
                 eval_result = self.eval(ctx, steps)

--- a/jax_baselines/A2C/surrogate_base.py
+++ b/jax_baselines/A2C/surrogate_base.py
@@ -23,6 +23,8 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
     (wired to ``self._actor_loss`` by ``Actor_Critic_Policy_Gradient_Family``).
     """
 
+    _store_old_policy = True
+
     def __init__(
         self,
         env_builder,
@@ -127,6 +129,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         nxtobses,
         terminateds,
         truncateds,
+        old_policy,
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
@@ -136,14 +139,9 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
             critic_params, actor_params, key, nxtobses
         )
-        old_distribution, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
-            actions,
-            key,
-            True,
-        )
+        pi_prob, old_distribution = old_policy
         if self.action_type == "continuous":
-            old_mu, old_log_std = jax.vmap(jnp.broadcast_arrays)(*old_distribution)
+            old_mu, old_log_std = old_distribution
             old_distribution = (old_mu, jnp.exp(old_log_std))
         adv = jax.vmap(get_gaes, in_axes=(0, 0, 0, 0, 0, None, None))(
             rewards, terminateds, truncateds, value, next_value, self.gamma, self.lamda
@@ -172,6 +170,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
         nxtobses,
         terminateds,
         truncateds,
+        old_policy,
     ):
         obses, actions, old_values, targets, old_policy, adv, metrics = self._preprocess(
             actor_params,
@@ -183,6 +182,7 @@ class SurrogatePolicyGradient(Actor_Critic_Policy_Gradient_Family):
             nxtobses,
             terminateds,
             truncateds,
+            old_policy,
         )
 
         def i_f(vals, _):

--- a/jax_baselines/TPPO/tppo.py
+++ b/jax_baselines/TPPO/tppo.py
@@ -20,6 +20,7 @@ from jax_baselines.optim import optimizer_metrics
 
 class TPPO(Actor_Critic_Policy_Gradient_Family):
     _run_name = "TPPO"
+    _store_old_policy = True
 
     def __init__(
         self,
@@ -103,6 +104,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         nxtobses,
         terminateds,
         truncateds,
+        old_policy,
     ):
         obses = convert_normalized_obs(obses)
         nxtobses = convert_normalized_obs(nxtobses)
@@ -112,21 +114,13 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         next_value = jax.vmap(self.critic, in_axes=(None, None, None, 0))(
             critic_params, actor_params, key, nxtobses
         )
-        prob, pi_prob = jax.vmap(self.get_logprob, in_axes=(0, 0, None, None))(
-            jax.vmap(self.actor, in_axes=(None, None, 0))(actor_params, key, obses),
-            actions,
-            key,
-            True,
-        )
+        pi_prob, prob = old_policy
         adv = jax.vmap(get_gaes, in_axes=(0, 0, 0, 0, 0, None, None))(
             rewards, terminateds, truncateds, value, next_value, self.gamma, self.lamda
         )
         obses = {key: jnp.vstack(value) for key, value in obses.items()}
         actions = jnp.vstack(actions)
         value = jnp.vstack(value)
-        if self.action_type == "continuous":
-            mu, log_std = prob
-            prob = (mu, jnp.broadcast_to(log_std, mu.shape))
         prob = jax.tree.map(jnp.vstack, prob)
         pi_prob = jnp.vstack(pi_prob)
         adv = jnp.vstack(adv)
@@ -149,6 +143,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
         nxtobses,
         terminateds,
         truncateds,
+        old_policy,
     ):
         obses, actions, old_value, targets, old_prob, old_act_prob, adv, metrics = self._preprocess(
             actor_params,
@@ -160,6 +155,7 @@ class TPPO(Actor_Critic_Policy_Gradient_Family):
             nxtobses,
             terminateds,
             truncateds,
+            old_policy,
         )
 
         def i_f(vals, _):

--- a/jax_baselines/core/epoch_buffer.py
+++ b/jax_baselines/core/epoch_buffer.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+
+_Array = np.ndarray | jax.Array
+OldPolicy = tuple[_Array, _Array | tuple[_Array, _Array]]
 
 
 class EpochBatch(TypedDict):
@@ -16,6 +19,7 @@ class EpochBatch(TypedDict):
     nxtobses: dict[str, np.ndarray | jax.Array]
     terminateds: np.ndarray | jax.Array
     truncateds: np.ndarray | jax.Array
+    old_policy: NotRequired[OldPolicy]
 
 
 @jax.jit
@@ -61,7 +65,17 @@ class EpochBuffer:
         )
         self._transitions: list[EpochBatch] = []
 
-    def add(self, obs_t, action, reward, nxtobs_t, terminated, truncated):
+    def add(
+        self,
+        obs_t,
+        action,
+        reward,
+        nxtobs_t,
+        terminated,
+        truncated,
+        *,
+        old_policy: OldPolicy | None = None,
+    ):
         if len(self._transitions) >= self.epoch_size:
             raise ValueError("EpochBuffer is full; consume the rollout before adding transitions")
         if (
@@ -96,6 +110,35 @@ class EpochBuffer:
                 },
                 is_leaf=lambda value: isinstance(value, (list, tuple)),
             )
+        if old_policy is not None:
+            log_prob, distribution = old_policy
+            if log_prob.shape != (self.worker_size, 1):
+                raise ValueError(
+                    f"Expected old-policy log probabilities with shape {(self.worker_size, 1)}"
+                )
+            if isinstance(distribution, tuple):
+                if len(distribution) != 2 or any(
+                    value.shape != (self.worker_size, *self.action_shape) for value in distribution
+                ):
+                    raise ValueError("Expected old-policy mean and log std with the action shape")
+            elif (
+                distribution.ndim != 2
+                or distribution.shape[0] != self.worker_size
+                or distribution.shape[1] < 1
+            ):
+                raise ValueError("Expected old-policy probabilities with shape (workers, actions)")
+            transition["old_policy"] = (
+                jax.tree.map(lambda value: np.array(value, copy=True), old_policy)
+                if self.memory_backend == "cpu"
+                else jax.tree.map(
+                    lambda value: jnp.array(
+                        value,
+                        copy=not isinstance(value, jax.Array),
+                        device=self._device,
+                    ),
+                    old_policy,
+                )
+            )
         transition["rewards"] = transition["rewards"].reshape(self.worker_size)
         transition["terminateds"] = (
             transition["terminateds"].astype(bool, copy=False).reshape(self.worker_size)
@@ -114,26 +157,23 @@ class EpochBuffer:
             raise ValueError(
                 f"Expected actions with shape {(self.worker_size, *self.action_shape)}"
             )
+        if self._transitions and (
+            jax.tree.structure(transition) != jax.tree.structure(self._transitions[0])
+            or [value.shape for value in jax.tree.leaves(transition)]
+            != [value.shape for value in jax.tree.leaves(self._transitions[0])]
+        ):
+            raise ValueError(
+                "Transition structure and shapes must remain constant within a rollout"
+            )
         self._transitions.append(transition)
 
     def get_buffer(self) -> EpochBatch:
         if not self._transitions:
             raise ValueError("Cannot consume an empty EpochBuffer")
         if self.memory_backend == "cpu":
-            transitions: EpochBatch = {
-                "obses": {
-                    key: np.stack([row["obses"][key] for row in self._transitions], axis=1)
-                    for key in self.observation_space
-                },
-                "actions": np.stack([row["actions"] for row in self._transitions], axis=1),
-                "rewards": np.stack([row["rewards"] for row in self._transitions], axis=1),
-                "nxtobses": {
-                    key: np.stack([row["nxtobses"][key] for row in self._transitions], axis=1)
-                    for key in self.observation_space
-                },
-                "terminateds": np.stack([row["terminateds"] for row in self._transitions], axis=1),
-                "truncateds": np.stack([row["truncateds"] for row in self._transitions], axis=1),
-            }
+            transitions: EpochBatch = jax.tree.map(
+                lambda *values: np.stack(values, axis=1), *self._transitions
+            )
         else:
             transitions = _stack_transitions(self._transitions)
         self._transitions.clear()

--- a/tests/test_ac_memory_backend.py
+++ b/tests/test_ac_memory_backend.py
@@ -78,7 +78,11 @@ def test_host_environment_keeps_rollout_arrays_on_cpu(backend, jax_observation):
         on_device=agent.memory_backend == "gpu",
     )
     assert isinstance(normalized["unified_obs"], np.ndarray)
-    agent._get_actions = lambda params, obs: (jnp.zeros((1, 1)), jnp.ones((1, 1)))
+    agent._get_actions = lambda params, obs: (
+        jnp.zeros((1, 1)),
+        jnp.ones((1, 1)),
+        jnp.zeros((1, 1)),
+    )
     assert isinstance(agent.action_continuous(normalized), np.ndarray)
     agent._get_actions = lambda params, obs: jnp.array([[0.25, 0.75]])
     assert isinstance(agent.action_discrete(normalized), np.ndarray)

--- a/tests/test_ac_observation_normalization.py
+++ b/tests/test_ac_observation_normalization.py
@@ -31,6 +31,7 @@ def _agent(enabled=True):
     agent._get_actions = lambda params, obs: (
         params * obs["unified_obs"],
         np.ones_like(obs["unified_obs"]),
+        np.zeros_like(obs["unified_obs"]),
     )
     agent.actions = agent.action_continuous
     return agent
@@ -174,7 +175,9 @@ def test_rollout_normalizes_successors_before_reset_statistics(
     agent.conv_action = lambda action: action
     transitions = []
     train_counts = []
-    agent.buffer = SimpleNamespace(add=lambda *transition: transitions.append(transition))
+    agent.buffer = SimpleNamespace(
+        add=lambda *transition, old_policy=None: transitions.append(transition)
+    )
     agent.train_step = lambda steps, logger_run: train_counts.append(agent.obs_rms.count) or 0.0
     agent.eval = lambda ctx, steps: None
     ctx = RunContext(

--- a/tests/test_returns_episode_boundary.py
+++ b/tests/test_returns_episode_boundary.py
@@ -27,6 +27,7 @@ from jax_baselines.A2C.base_class import Actor_Critic_Policy_Gradient_Family
 from jax_baselines.APE_X.dpg_worker import Ape_X_Worker as ApeXDPGWorker
 from jax_baselines.APE_X.worker import Ape_X_Worker as ApeXQWorker
 from jax_baselines.core.env_info import infer_action_meta
+from jax_baselines.core.rollout_stats import TrainingProgress
 from jax_baselines.IMPALA.base_class import IMPALA_Family
 from jax_baselines.IMPALA.worker import Impala_Worker
 from jax_baselines.math.returns import discount_with_terminated, get_gaes, get_vtrace
@@ -317,7 +318,7 @@ class _RecordingBuffer:
         self.obses = []
         self.nxtobses = []
 
-    def add(self, obs, action, reward, nxtobs, terminated, truncated):
+    def add(self, obs, action, reward, nxtobs, terminated, truncated, *, old_policy=None):
         self.terminateds.append(np.asarray(terminated).copy())
         self.rewards.append(np.asarray(reward).copy())
         self.truncateds.append(np.asarray(truncated).copy())
@@ -342,6 +343,7 @@ class _Ctx:
         self.eval_freq = 10_000
         self.log_interval = 10_000
         self.logger_run = _NullLogger()
+        self.progress = TrainingProgress()
 
 
 def test_a2c_vectorized_flags_autoreset_dummy_step_as_terminal():

--- a/tests/test_tppo_continuous.py
+++ b/tests/test_tppo_continuous.py
@@ -78,6 +78,10 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
         agent.gae_normalize = False
         agent.gae_normalize_scope = "batch"
         agent.value_clip = 0.3
+        distribution, log_prob = agent.get_logprob(
+            agent.actor(agent.actor_params, None, obses), actions, None, out_prob=True
+        )
+        old_mu, old_log_std = distribution
         result = TPPO._train_step(
             agent,
             agent.actor_params,
@@ -91,6 +95,7 @@ def test_continuous_tppo_full_train_step_handles_gaussian_minibatches(cls, famil
             obses,
             scalars,
             scalars,
+            old_policy=(log_prob, (old_mu, jnp.broadcast_to(old_log_std, old_mu.shape))),
         )
     else:
         agent.mu_ratio = 0.0


### PR DESCRIPTION
PPO·SPO·TPPO가 학습 전처리에서 이전 actor를 다시 실행하던 경로를 제거합니다. 환경에서 행동을 선택할 때 해당 행동의 log-prob와 정책 분포를 함께 저장하고, 이후 minibatch·epoch에서 재사용합니다.

CPU·GPU EpochBuffer가 categorical 확률 또는 Gaussian mean/log-std를 보존합니다. 동기·비동기 rollout 모두 행동과 정책 정보를 함께 전달하며, A2C에는 불필요한 정책 데이터를 저장하지 않습니다. 바뀐 샘플링·버퍼 계약을 사용하는 기존 테스트도 같은 변경에 갱신했습니다.

분리된 레이어에서 관련 테스트 59개가 통과했고 GPU 전용 5개는 생략했습니다. 동일 구현의 실제 GPU 캐시 검증도 통과했습니다. 기존 Ruff 2건·타입 진단 13건은 유지됩니다.
