### PR TITLE
perf(pg): GPU 행동·정책 캐시 계산을 한 JIT로 통합

### DIFF
--- a/jax_baselines/A2C/base_class.py
+++ b/jax_baselines/A2C/base_class.py
@@ -302,6 +302,8 @@ class Actor_Critic_Policy_Gradient_Family:
     def sample_actions(self, obs):
         if not self._store_old_policy:
             return self.actions(obs), None
+        if self.memory_backend == "gpu":
+            return self._sample_actions_gpu(self.actor_params, obs, next(self.key_seq))
         policy = self._get_actions(self.actor_params, obs)
         if self.action_type == "discrete":
             actions = self._action_from_discrete(policy)
@@ -310,9 +312,17 @@ class Actor_Critic_Policy_Gradient_Family:
             mu, std, _ = policy
             actions = self._action_from_continuous(mu, std)
             old_policy = _continuous_old_policy(policy, actions)
-        if self.memory_backend == "cpu":
-            old_policy = jax.tree.map(np.asarray, old_policy)
-        return actions, old_policy
+        return actions, jax.tree.map(np.asarray, old_policy)
+
+    @jax.jit(static_argnums=0)
+    def _sample_actions_gpu(self, actor_params, obs, key):
+        policy = self._get_actions(actor_params, obs)
+        if self.action_type == "discrete":
+            actions = _sample_discrete(policy, key)
+            return actions, (_categorical_log_prob(policy, actions), policy)
+        mu, std, _ = policy
+        actions = _sample_continuous(mu, std, key)
+        return actions, _continuous_old_policy(policy, actions)
 
     def get_logprob_discrete(self, prob, action, key, out_prob=False):
         prob = _categorical_policy(prob)


### PR DESCRIPTION
행동 정책 캐시를 만들 때 따로 실행하던 GPU actor 추론·행동 샘플링·log-prob 계산을 한 JIT 호출로 묶습니다. 파라미터·관측·RNG 키를 명시적인 입력으로 전달하여 업데이트된 정책과 매번 새 키를 사용합니다.

샘플링 호환성 검사와 Ruff·타입 검사가 통과했습니다. 같은 구현의 Go1 GPU 학습도 정상 완료했습니다. 각 100표본 비교에서 샘플링·저장 중앙값은 약 3.4% 줄었고 전체 계산 시간은 거의 같았으므로, 전체 학습 가속을 보장하는 변경은 아닙니다.
