### PR TITLE
refactor: 모델 빌더 중복과 로거·bulk 래퍼 정리

### DIFF
--- a/experiments/loggers/aim_logger.py
+++ b/experiments/loggers/aim_logger.py
@@ -10,6 +10,7 @@ uninstalled raises a clear, actionable error.
 from __future__ import annotations
 
 import os
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -144,19 +145,10 @@ def make_aim_logger_factory(
     an uninstalled extra fails fast with a clear message before training or
     ``ray.init()`` starts.
     """
-    aim_module = _import_aim()
-    repo = getattr(args, "aim_repo", None)
-
-    def factory(run_name, experiment_name, local_dir, agent):
-        return AimLogger(
-            aim_module,
-            run_name,
-            experiment_name,
-            local_dir,
-            agent,
-            repo=repo,
-            extra_hparams=extra_hparams,
-            run_metadata=run_metadata,
-        )
-
-    return factory
+    return partial(
+        AimLogger,
+        _import_aim(),
+        repo=args.aim_repo,
+        extra_hparams=extra_hparams,
+        run_metadata=run_metadata,
+    )

--- a/experiments/loggers/wandb_logger.py
+++ b/experiments/loggers/wandb_logger.py
@@ -10,6 +10,7 @@ uninstalled raises a clear, actionable error.
 from __future__ import annotations
 
 import os
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -152,21 +153,11 @@ def make_wandb_logger_factory(
     so an uninstalled extra fails fast with a clear message before training or
     ``ray.init()`` starts.
     """
-    wandb_module = _import_wandb()
-    entity = getattr(args, "wandb_entity", None)
-    mode = getattr(args, "wandb_mode", None)
-
-    def factory(run_name, experiment_name, local_dir, agent):
-        return WandbLogger(
-            wandb_module,
-            run_name,
-            experiment_name,
-            local_dir,
-            agent,
-            entity=entity,
-            mode=mode,
-            extra_hparams=extra_hparams,
-            run_metadata=run_metadata,
-        )
-
-    return factory
+    return partial(
+        WandbLogger,
+        _import_wandb(),
+        entity=args.wandb_entity,
+        mode=args.wandb_mode,
+        extra_hparams=extra_hparams,
+        run_metadata=run_metadata,
+    )

--- a/jax_baselines/core/bulk_training.py
+++ b/jax_baselines/core/bulk_training.py
@@ -52,13 +52,10 @@ def bulk_chunk_plan(gradient_steps, buckets):
                 continue
             candidate_calls = calls[steps - bucket] + 1
             candidate_scalars = scalar_counts[steps - bucket]
-            if not _is_better_chunk_plan(
-                candidate_calls,
-                candidate_scalars,
-                bucket,
+            if (candidate_calls, candidate_scalars, -bucket) >= (
                 calls[steps],
                 scalar_counts[steps],
-                first_chunks[steps],
+                -first_chunks[steps],
             ):
                 continue
             calls[steps] = candidate_calls
@@ -75,25 +72,6 @@ def bulk_chunk_plan(gradient_steps, buckets):
         chunks.append(chunk_size)
         remaining -= chunk_size
     return tuple(chunks)
-
-
-def _is_better_chunk_plan(
-    candidate_calls,
-    candidate_scalars,
-    candidate_chunk,
-    current_calls,
-    current_scalars,
-    current_chunk,
-):
-    return (
-        candidate_calls < current_calls
-        or (candidate_calls == current_calls and candidate_scalars < current_scalars)
-        or (
-            candidate_calls == current_calls
-            and candidate_scalars == current_scalars
-            and candidate_chunk > current_chunk
-        )
-    )
 
 
 def bulk_chunk_buckets(max_chunk):

--- a/model_builder/flax/qnet/c51_builder.py
+++ b/model_builder/flax/qnet/c51_builder.py
@@ -4,16 +4,10 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 
-from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, NoisyDense, network_body
-from model_builder.flax.Module import PreProcess
+from model_builder.flax.qnet.dqn_builder import make_qnet_builder
 from model_builder.model_config import MLPConfig
-from model_builder.utils import (
-    dummy_observation,
-    print_flax_model_summary,
-    qnet_model_kwargs,
-)
 
 
 class Model(nn.Module):
@@ -55,40 +49,12 @@ class Model(nn.Module):
 def model_builder_maker(
     observation_space, action_space, dueling_model, param_noise, categorial_bar_n, policy_kwargs
 ):
-    policy_kwargs = qnet_model_kwargs(policy_kwargs)
-
-    def model_builder(key=None, print_model=False):
-        class Merged(nn.Module):
-            def setup(self):
-                self.preproc = PreProcess(
-                    observation_space, embedding_mode=policy_kwargs["network"].embedding_mode
-                )
-                self.qnet = Model(
-                    action_space,
-                    dueling=dueling_model,
-                    noisy=param_noise,
-                    categorial_bar_n=categorial_bar_n,
-                    **policy_kwargs,
-                )
-
-            def __call__(self, x):
-                x = self.preproc(x)
-                return self.qnet(x)
-
-            def preprocess(self, x):
-                return self.preproc(x)
-
-            def q(self, x):
-                return self.qnet(x)
-
-        model = Merged()
-        preproc_fn = get_apply_fn_flax_module(model, model.preprocess)
-        model_fn = get_apply_fn_flax_module(model, model.q)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            params = model.init(key, observation)
-            print_flax_model_summary(print_model, key, (model, observation))
-            return preproc_fn, model_fn, params
-        return preproc_fn, model_fn
-
-    return model_builder
+    return make_qnet_builder(
+        observation_space,
+        Model,
+        action_space,
+        dueling_model,
+        param_noise,
+        policy_kwargs,
+        categorial_bar_n=categorial_bar_n,
+    )

--- a/model_builder/flax/qnet/dqn_builder.py
+++ b/model_builder/flax/qnet/dqn_builder.py
@@ -39,7 +39,15 @@ class Model(nn.Module):
         return v + a - jnp.mean(a, axis=1, keepdims=True)
 
 
-def model_builder_maker(observation_space, action_space, dueling_model, param_noise, policy_kwargs):
+def make_qnet_builder(
+    observation_space,
+    model_cls,
+    action_space,
+    dueling_model,
+    param_noise,
+    policy_kwargs,
+    **head_kwargs
+):
     policy_kwargs = qnet_model_kwargs(policy_kwargs)
 
     def model_builder(key=None, print_model=False):
@@ -48,8 +56,12 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
                 self.preproc = PreProcess(
                     observation_space, embedding_mode=policy_kwargs["network"].embedding_mode
                 )
-                self.qnet = Model(
-                    action_space, dueling=dueling_model, noisy=param_noise, **policy_kwargs
+                self.qnet = model_cls(
+                    action_space,
+                    dueling=dueling_model,
+                    noisy=param_noise,
+                    **head_kwargs,
+                    **policy_kwargs,
                 )
 
             def __call__(self, x):
@@ -73,3 +85,9 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
         return preproc_fn, model_fn
 
     return model_builder
+
+
+def model_builder_maker(observation_space, action_space, dueling_model, param_noise, policy_kwargs):
+    return make_qnet_builder(
+        observation_space, Model, action_space, dueling_model, param_noise, policy_kwargs
+    )

--- a/model_builder/flax/qnet/qrdqn_builder.py
+++ b/model_builder/flax/qnet/qrdqn_builder.py
@@ -3,16 +3,10 @@ from collections.abc import Sequence
 import flax.linen as nn
 import jax.numpy as jnp
 
-from model_builder.flax.apply import get_apply_fn_flax_module
 from model_builder.flax.initializers import clip_factorized_uniform
 from model_builder.flax.layers import Dense, NoisyDense, network_body
-from model_builder.flax.Module import PreProcess
+from model_builder.flax.qnet.dqn_builder import make_qnet_builder
 from model_builder.model_config import MLPConfig
-from model_builder.utils import (
-    dummy_observation,
-    print_flax_model_summary,
-    qnet_model_kwargs,
-)
 
 
 class Model(nn.Module):
@@ -56,40 +50,12 @@ class Model(nn.Module):
 def model_builder_maker(
     observation_space, action_space, dueling_model, param_noise, support_n, policy_kwargs
 ):
-    policy_kwargs = qnet_model_kwargs(policy_kwargs)
-
-    def model_builder(key=None, print_model=False):
-        class Merged(nn.Module):
-            def setup(self):
-                self.preproc = PreProcess(
-                    observation_space, embedding_mode=policy_kwargs["network"].embedding_mode
-                )
-                self.qnet = Model(
-                    action_space,
-                    dueling=dueling_model,
-                    noisy=param_noise,
-                    support_n=support_n,
-                    **policy_kwargs,
-                )
-
-            def __call__(self, x):
-                x = self.preproc(x)
-                return self.qnet(x)
-
-            def preprocess(self, x):
-                return self.preproc(x)
-
-            def q(self, x):
-                return self.qnet(x)
-
-        model = Merged()
-        preproc_fn = get_apply_fn_flax_module(model, model.preprocess)
-        model_fn = get_apply_fn_flax_module(model, model.q)
-        if key is not None:
-            observation = dummy_observation(observation_space)
-            params = model.init(key, observation)
-            print_flax_model_summary(print_model, key, (model, observation))
-            return preproc_fn, model_fn, params
-        return preproc_fn, model_fn
-
-    return model_builder
+    return make_qnet_builder(
+        observation_space,
+        Model,
+        action_space,
+        dueling_model,
+        param_noise,
+        policy_kwargs,
+        support_n=support_n,
+    )

--- a/model_builder/haiku/dpg/ddpg_builder.py
+++ b/model_builder/haiku/dpg/ddpg_builder.py
@@ -12,7 +12,7 @@ from model_builder.utils import (
 )
 
 
-def model_builder_maker(observation_space, action_size, policy_kwargs):
+def _make_model_builder(observation_space, action_size, policy_kwargs, *, twin_critic):
     actor_kwargs, critic_kwargs = split_actor_critic_kwargs(
         policy_kwargs, allowed_embeddings=("normal",)
     )
@@ -39,6 +39,11 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
                 embedding_mode=critic_kwargs["network"].embedding_mode,
                 role="critic",
             )(observation, shared_features)
+            if twin_critic:
+                return (
+                    Critic(**critic_kwargs)(feature, action),
+                    Critic(**critic_kwargs)(feature, action),
+                )
             return Critic(**critic_kwargs)(feature, action)
 
         actor = hk.transform(actor_forward)
@@ -61,3 +66,12 @@ def model_builder_maker(observation_space, action_size, policy_kwargs):
         return actor.apply, critic_fn, policy_params, critic_params
 
     return model_builder
+
+
+def model_builder_maker(observation_space, action_size, policy_kwargs):
+    return _make_model_builder(
+        observation_space,
+        action_size,
+        policy_kwargs,
+        twin_critic=False,
+    )

--- a/model_builder/haiku/dpg/td3_builder.py
+++ b/model_builder/haiku/dpg/td3_builder.py
@@ -1,66 +1,10 @@
-import haiku as hk
-import jax
-import numpy as np
-
-from model_builder.haiku.dpg.ddpg_td3_blocks import Actor, Critic
-from model_builder.haiku.Module import PreProcess
-from model_builder.utils import (
-    dummy_observation,
-    get_critic_apply_fn,
-    print_haiku_model_summary,
-    split_actor_critic_kwargs,
-)
+from model_builder.haiku.dpg.ddpg_builder import _make_model_builder
 
 
 def model_builder_maker(observation_space, action_size, policy_kwargs):
-    actor_kwargs, critic_kwargs = split_actor_critic_kwargs(
-        policy_kwargs, allowed_embeddings=("normal",)
+    return _make_model_builder(
+        observation_space,
+        action_size,
+        policy_kwargs,
+        twin_critic=True,
     )
-
-    def model_builder(key=None, print_model=False):
-        def actor_forward(observation):
-            feature = PreProcess(
-                observation_space,
-                embedding_mode=actor_kwargs["network"].embedding_mode,
-                role="actor",
-            )(observation)
-            return Actor(action_size, **actor_kwargs)(feature)
-
-        def shared_forward(observation):
-            return PreProcess(
-                observation_space,
-                embedding_mode=actor_kwargs["network"].embedding_mode,
-                role="actor",
-            ).shared_features(observation)
-
-        def critic_forward(observation, shared_features, action):
-            feature = PreProcess(
-                observation_space,
-                embedding_mode=critic_kwargs["network"].embedding_mode,
-                role="critic",
-            )(observation, shared_features)
-            return (
-                Critic(**critic_kwargs)(feature, action),
-                Critic(**critic_kwargs)(feature, action),
-            )
-
-        actor = hk.transform(actor_forward)
-        critic = hk.transform(critic_forward)
-        shared_preproc = hk.transform(shared_forward)
-        critic_fn = get_critic_apply_fn(critic.apply, shared_preproc.apply)
-        if key is None:
-            return actor.apply, critic_fn
-        observation = dummy_observation(observation_space)
-        action = np.zeros((1, *action_size), dtype=np.float32)
-        actor_key, critic_key = jax.random.split(key)
-        policy_params = actor.init(actor_key, observation)
-        shared_features = shared_preproc.apply(policy_params, None, observation)
-        critic_params = critic.init(critic_key, observation, shared_features, action)
-        print_haiku_model_summary(
-            print_model,
-            (actor, observation),
-            (critic, observation, shared_features, action),
-        )
-        return actor.apply, critic_fn, policy_params, critic_params
-
-    return model_builder

--- a/model_builder/haiku/qnet/c51_builder.py
+++ b/model_builder/haiku/qnet/c51_builder.py
@@ -3,13 +3,8 @@ import jax
 import jax.numpy as jnp
 
 from model_builder.haiku.layers import NoisyLinear, network_body
-from model_builder.haiku.Module import PreProcess
+from model_builder.haiku.qnet.dqn_builder import make_qnet_builder
 from model_builder.model_config import MLPConfig
-from model_builder.utils import (
-    dummy_observation,
-    print_haiku_model_summary,
-    qnet_model_kwargs,
-)
 
 
 class Model(hk.Module):
@@ -56,34 +51,12 @@ class Model(hk.Module):
 def model_builder_maker(
     observation_space, action_space, dueling_model, param_noise, categorial_bar_n, policy_kwargs
 ):
-    policy_kwargs = qnet_model_kwargs(policy_kwargs, allowed_embeddings=("normal",))
-
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=policy_kwargs["network"].embedding_mode
-            )(x)
-        )
-        model = hk.transform(
-            lambda x: Model(
-                action_space,
-                dueling=dueling_model,
-                noisy=param_noise,
-                categorial_bar_n=categorial_bar_n,
-                **policy_kwargs,
-            )(x)
-        )
-        preproc_fn = preproc.apply
-        model_fn = model.apply
-        if key is not None:
-            key1, key2, key3 = jax.random.split(key, num=3)
-            observation = dummy_observation(observation_space)
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key3, observation)
-            model_param = model.init(key2, feature)
-            params = hk.data_structures.merge(pre_param, model_param)
-            print_haiku_model_summary(print_model, (preproc, observation), (model, feature))
-            return preproc_fn, model_fn, params
-        return preproc_fn, model_fn
-
-    return _model_builder
+    return make_qnet_builder(
+        observation_space,
+        Model,
+        action_space,
+        dueling_model,
+        param_noise,
+        policy_kwargs,
+        categorial_bar_n=categorial_bar_n,
+    )

--- a/model_builder/haiku/qnet/dqn_builder.py
+++ b/model_builder/haiku/qnet/dqn_builder.py
@@ -36,7 +36,15 @@ class Model(hk.Module):
         return v + a - jnp.mean(a, axis=1, keepdims=True)
 
 
-def model_builder_maker(observation_space, action_space, dueling_model, param_noise, policy_kwargs):
+def make_qnet_builder(
+    observation_space,
+    model_cls,
+    action_space,
+    dueling_model,
+    param_noise,
+    policy_kwargs,
+    **head_kwargs
+):
     policy_kwargs = qnet_model_kwargs(policy_kwargs, allowed_embeddings=("normal",))
 
     def _model_builder(key=None, print_model=False):
@@ -46,8 +54,12 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
             )(x)
         )
         model = hk.transform(
-            lambda x: Model(
-                action_space, dueling=dueling_model, noisy=param_noise, **policy_kwargs
+            lambda x: model_cls(
+                action_space,
+                dueling=dueling_model,
+                noisy=param_noise,
+                **head_kwargs,
+                **policy_kwargs,
             )(x)
         )
         preproc_fn = preproc.apply
@@ -64,3 +76,9 @@ def model_builder_maker(observation_space, action_space, dueling_model, param_no
         return preproc_fn, model_fn
 
     return _model_builder
+
+
+def model_builder_maker(observation_space, action_space, dueling_model, param_noise, policy_kwargs):
+    return make_qnet_builder(
+        observation_space, Model, action_space, dueling_model, param_noise, policy_kwargs
+    )

--- a/model_builder/haiku/qnet/qrdqn_builder.py
+++ b/model_builder/haiku/qnet/qrdqn_builder.py
@@ -1,15 +1,9 @@
 import haiku as hk
-import jax
 import jax.numpy as jnp
 
 from model_builder.haiku.layers import NoisyLinear, network_body
-from model_builder.haiku.Module import PreProcess
+from model_builder.haiku.qnet.dqn_builder import make_qnet_builder
 from model_builder.model_config import MLPConfig
-from model_builder.utils import (
-    dummy_observation,
-    print_haiku_model_summary,
-    qnet_model_kwargs,
-)
 
 
 class Model(hk.Module):
@@ -47,34 +41,12 @@ class Model(hk.Module):
 def model_builder_maker(
     observation_space, action_space, dueling_model, param_noise, support_n, policy_kwargs
 ):
-    policy_kwargs = qnet_model_kwargs(policy_kwargs, allowed_embeddings=("normal",))
-
-    def _model_builder(key=None, print_model=False):
-        preproc = hk.transform(
-            lambda x: PreProcess(
-                observation_space, embedding_mode=policy_kwargs["network"].embedding_mode
-            )(x)
-        )
-        model = hk.transform(
-            lambda x: Model(
-                action_space,
-                dueling=dueling_model,
-                noisy=param_noise,
-                support_n=support_n,
-                **policy_kwargs,
-            )(x)
-        )
-        preproc_fn = preproc.apply
-        model_fn = model.apply
-        if key is not None:
-            key1, key2, key3 = jax.random.split(key, num=3)
-            observation = dummy_observation(observation_space)
-            pre_param = preproc.init(key1, observation)
-            feature = preproc.apply(pre_param, key3, observation)
-            model_param = model.init(key2, feature)
-            params = hk.data_structures.merge(pre_param, model_param)
-            print_haiku_model_summary(print_model, (preproc, observation), (model, feature))
-            return preproc_fn, model_fn, params
-        return preproc_fn, model_fn
-
-    return _model_builder
+    return make_qnet_builder(
+        observation_space,
+        Model,
+        action_space,
+        dueling_model,
+        param_noise,
+        policy_kwargs,
+        support_n=support_n,
+    )


### PR DESCRIPTION
Flax·Haiku의 DQN/C51/QRDQN 초기화 중복을 기존 DQN 빌더의 공통 경로로 모으고, Haiku DDPG/TD3도 기존 DDPG 빌더를 공유하도록 정리합니다. 파라미터 구조와 빌더 호출 계약을 유지합니다.

생성자에 인자를 전달하기만 하는 Aim/W&B closure는 `functools.partial`로 바꾸고, bulk chunk 계획의 별도 비교 헬퍼는 tuple 비교로 대체합니다. 이 PR은 PPO 스택과 독립적입니다.

분리된 브랜치에서 관련 테스트 97개와 타입 검사가 통과했습니다. 기존 Ruff 진단 5건은 유지됩니다. W&B의 프로세스 종료 정체는 변경 전후 모두 관측되어 정상 종료까지 검증한 것으로 처리하지 않았습니다.
